### PR TITLE
feat: structured workflow logging with LoggerMessage source generators

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ Add it to `Fleans.Api/Controllers/WorkflowController.cs`. DTOs go in `Fleans.Ser
 - ExpandoObject + Newtonsoft.Json for dynamic workflow variable state
 - Tests use MSTest + Orleans.TestingHost, AAA pattern. Activity tests must verify both post-completion and post-failure state. Query state via `workflowInstance.GetState()` after completion/failure — never hold grain references from before completion to assert on.
 - **Admin UI (Fleans.Web) communicates with Orleans grains directly via `WorkflowEngine` service** — not through HTTP API endpoints. The Web app runs as Blazor Server (InteractiveServer), so Razor components execute server-side and can call grains directly. Do not add API endpoints for admin UI functionality.
+- **Logging: always use `[LoggerMessage]` source generators** instead of `ILogger.Log*()` extension methods. Define log methods as `private partial void` on `partial` classes. See `WorkflowInstance.cs` for the pattern. EventId ranges are documented in `docs/plans/2026-02-08-structured-workflow-logging.md`.
 
 ## Things to Know
 

--- a/docs/plans/2026-02-08-structured-workflow-logging.md
+++ b/docs/plans/2026-02-08-structured-workflow-logging.md
@@ -1,0 +1,82 @@
+# Structured Workflow Logging
+
+## Date: 2026-02-08
+
+## Problem
+
+Workflow grains had zero logging. Event handlers had some logging but lacked consistent workflow context. No way to correlate log entries across grain boundaries for a single workflow execution.
+
+## Key Insight
+
+Orleans `ILogger.BeginScope` does NOT propagate across grain calls (AsyncLocal-based). The Orleans-recommended approach:
+1. **`RequestContext`** — serialized into grain messages, propagates automatically
+2. **Incoming grain call filter** — reads `RequestContext` and creates `BeginScope` at each grain
+
+## Solution
+
+### RequestContext Keys
+
+| Key | Type | Set By |
+|-----|------|--------|
+| `WorkflowId` | string | WorkflowInstance |
+| `ProcessDefinitionId` | string | WorkflowInstance |
+| `WorkflowInstanceId` | string | WorkflowInstance |
+| `ActivityId` | string | WorkflowInstance / ActivityInstance |
+| `ActivityInstanceId` | string | WorkflowInstance / ActivityInstance |
+| `VariablesId` | string | ActivityInstance |
+
+### Architecture
+
+- **`WorkflowLoggingScopeFilter`** (`IIncomingGrainCallFilter`) — reads `RequestContext` and wraps grain invocations in `BeginScope`. Skips `IWorkflowInstance` (which manages its own scope) to avoid duplication.
+- **`WorkflowLoggingContext`** — static helper for event handlers (stream delivery doesn't carry `RequestContext`) that sets both `RequestContext` AND `BeginScope`.
+- **`ProcessDefinitionId`** added to `IWorkflowDefinition` / `WorkflowDefinition` — stamped by `WorkflowInstanceFactoryGrain.DeployWorkflow` and carried through domain events.
+- **`[LoggerMessage]` source generators** used for all log statements — zero-allocation, compile-time validated.
+
+### BeginScope Format
+
+Uses the string template overload (`logger.BeginScope(string, params)`) which creates `FormattedLogValues`:
+- Simple formatter renders: `=> [wf-order, proc:1:..., guid, -, -, -]`
+- JSON formatter emits structured key-value pairs
+- `"-"` used as placeholder for null/absent values
+
+### EventId Ranges
+
+| Range | Class |
+|-------|-------|
+| 1000-1099 | WorkflowInstance |
+| 2000-2099 | ActivityInstance |
+| 3000-3099 | WorkflowInstanceState |
+| 4000-4099 | Event handlers |
+| 5000-5099 | WorkflowEventsPublisher |
+| 6000-6099 | WorkflowInstanceFactoryGrain |
+| 7000-7099 | WorkflowEngine |
+
+### Filter Skip Logic
+
+The filter skips `IWorkflowInstance` via `context.TargetContext.GrainInstance is IWorkflowInstance` because:
+- WorkflowInstance creates its own `BeginWorkflowScope()` in every public method
+- Without the skip, scopes would nest/duplicate
+- A `RequestContext` flag approach doesn't work: the flag would propagate to downstream grains (causing them to be skipped too), and the filter runs before the grain method body (so the flag isn't set yet)
+
+## Files
+
+| File | Change |
+|------|--------|
+| `Fleans.Domain/Workflow.cs` | `ProcessDefinitionId` on interface + record |
+| `Fleans.Application/Logging/WorkflowLoggingScopeFilter.cs` | NEW — grain call filter |
+| `Fleans.Application/Logging/WorkflowLoggingContext.cs` | NEW — event handler helper |
+| `Fleans.Api/Program.cs` | Register filter |
+| `Fleans.Api/appsettings.Development.json` | Enable `IncludeScopes` |
+| `Fleans.Domain/WorkflowInstance.cs` | ILogger + RequestContext + LoggerMessage |
+| `Fleans.Domain/ActivityInstance.cs` | ILogger + LoggerMessage |
+| `Fleans.Domain/States/WorkflowInstanceState.cs` | ILogger + LoggerMessage |
+| `Fleans.Domain/Events/EvaluateConditionEvent.cs` | Added `ProcessDefinitionId` |
+| `Fleans.Domain/Events/ExecuteScriptEvent.cs` | Added `ProcessDefinitionId` |
+| `Fleans.Domain/Activities/ExclusiveGateway.cs` | Pass `ProcessDefinitionId` |
+| `Fleans.Domain/Activities/ScriptTask.cs` | Pass `ProcessDefinitionId` |
+| `Fleans.Application/Events/Handlers/*.cs` | WorkflowLoggingContext + LoggerMessage |
+| `Fleans.Application/Events/WorkflowEventsPublisher.cs` | ILogger + LoggerMessage |
+| `Fleans.Application/WorkflowFactory/WorkflowInstanceFactoryGrain.cs` | ILogger + ProcessDefinitionId + RequestContext + LoggerMessage |
+| `Fleans.Application/WorkflowEngine.cs` | ILogger + LoggerMessage |
+| `Fleans.Application.Tests/WorkflowEngineTests.cs` | NullLogger |
+| `Fleans.Domain/Fleans.Domain.csproj` | Explicit logging dependency |

--- a/src/Fleans/Fleans.Api/Program.cs
+++ b/src/Fleans/Fleans.Api/Program.cs
@@ -1,4 +1,5 @@
 using Fleans.Application;
+using Fleans.Application.Logging;
 using Fleans.Infrastructure;
 using Fleans.Domain;
 using StackExchange.Redis;
@@ -56,6 +57,9 @@ builder.UseOrleans(siloBuilder =>
 
     // Configure Redis streaming (optional, for pub/sub)
     siloBuilder.AddMemoryStreams("StreamProvider");
+
+    // Structured workflow logging via RequestContext
+    siloBuilder.AddIncomingGrainCallFilter<WorkflowLoggingScopeFilter>();
 });
 
 // Add services to the container.

--- a/src/Fleans/Fleans.Api/appsettings.Development.json
+++ b/src/Fleans/Fleans.Api/appsettings.Development.json
@@ -2,7 +2,16 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "Fleans": "Debug"
+    },
+    "Console": {
+      "FormatterName": "simple",
+      "FormatterOptions": {
+        "IncludeScopes": true,
+        "TimestampFormat": "HH:mm:ss.SSS ",
+        "SingleLine": true
+      }
     }
   }
 }

--- a/src/Fleans/Fleans.Application.Tests/WorkflowEngineTests.cs
+++ b/src/Fleans/Fleans.Application.Tests/WorkflowEngineTests.cs
@@ -3,6 +3,7 @@ using Fleans.Application.WorkflowFactory;
 using Fleans.Domain;
 using Fleans.Domain.Activities;
 using Fleans.Domain.Sequences;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 using Orleans;
@@ -22,7 +23,7 @@ namespace Fleans.Application.Tests
         {
             _grainFactory = Substitute.For<IGrainFactory>();
             _factoryGrain = Substitute.For<IWorkflowInstanceFactoryGrain>();
-            _workflowEngine = new WorkflowEngine(_grainFactory);
+            _workflowEngine = new WorkflowEngine(_grainFactory, NullLogger<WorkflowEngine>.Instance);
         }
 
         [TestMethod]

--- a/src/Fleans/Fleans.Application/Events/WorkflowEventsPublisher.cs
+++ b/src/Fleans/Fleans.Application/Events/WorkflowEventsPublisher.cs
@@ -1,4 +1,4 @@
-﻿using Fleans.Application.Events.Handlers;
+using Fleans.Application.Events.Handlers;
 using Fleans.Domain.Events;
 using Microsoft.Extensions.Logging;
 using Orleans.Concurrency;
@@ -10,12 +10,18 @@ using System.IO;
 namespace Fleans.Application.Events;
 
 [StatelessWorker]
-public class WorkflowEventsPublisher : Grain, IEventPublisher
+public partial class WorkflowEventsPublisher : Grain, IEventPublisher
 {
     private IStreamProvider _streamProvider = null!;
+    private readonly ILogger<WorkflowEventsPublisher> _logger;
 
     public const string StreamProvider = "StreamProvider";
     public const string StreamNameSpace = "events";
+
+    public WorkflowEventsPublisher(ILogger<WorkflowEventsPublisher> logger)
+    {
+        _logger = logger;
+    }
 
     public override Task OnActivateAsync(CancellationToken cancellationToken)
     {
@@ -25,7 +31,9 @@ public class WorkflowEventsPublisher : Grain, IEventPublisher
     }
 
     public async Task Publish(IDomainEvent domainEvent)
-    {                                        
+    {
+        LogPublishing(domainEvent.GetType().Name);
+
         switch (domainEvent)
         {
             case EvaluateConditionEvent evaluateConditionEvent:
@@ -47,7 +55,8 @@ public class WorkflowEventsPublisher : Grain, IEventPublisher
                 break;
         }
 
-    }    
+    }
+
+    [LoggerMessage(EventId = 5000, Level = LogLevel.Debug, Message = "Publishing {EventType}")]
+    private partial void LogPublishing(string eventType);
 }
-
-

--- a/src/Fleans/Fleans.Application/Logging/WorkflowLoggingContext.cs
+++ b/src/Fleans/Fleans.Application/Logging/WorkflowLoggingContext.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.Logging;
+using Orleans.Runtime;
+
+namespace Fleans.Application.Logging;
+
+internal static class WorkflowLoggingContext
+{
+    public static IDisposable? BeginWorkflowScope(
+        ILogger logger, string workflowId, string? processDefinitionId,
+        Guid workflowInstanceId, string? activityId = null)
+    {
+        RequestContext.Set("WorkflowId", workflowId);
+        RequestContext.Set("WorkflowInstanceId", workflowInstanceId.ToString());
+        if (processDefinitionId is not null)
+            RequestContext.Set("ProcessDefinitionId", processDefinitionId);
+        if (activityId is not null)
+            RequestContext.Set("ActivityId", activityId);
+
+        return logger.BeginScope(
+            "[{WorkflowId}, {ProcessDefinitionId}, {WorkflowInstanceId}, {ActivityId}]",
+            workflowId, processDefinitionId ?? "-", workflowInstanceId, activityId ?? "-");
+    }
+}

--- a/src/Fleans/Fleans.Application/Logging/WorkflowLoggingScopeFilter.cs
+++ b/src/Fleans/Fleans.Application/Logging/WorkflowLoggingScopeFilter.cs
@@ -1,0 +1,45 @@
+using Fleans.Domain;
+using Microsoft.Extensions.Logging;
+using Orleans;
+using Orleans.Runtime;
+
+namespace Fleans.Application.Logging;
+
+public class WorkflowLoggingScopeFilter : IIncomingGrainCallFilter
+{
+    private readonly ILogger<WorkflowLoggingScopeFilter> _logger;
+
+    public WorkflowLoggingScopeFilter(ILogger<WorkflowLoggingScopeFilter> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task Invoke(IIncomingGrainCallContext context)
+    {
+        // WorkflowInstance manages its own scope via BeginWorkflowScope() — skip to avoid duplicates
+        if (context.TargetContext.GrainInstance is IWorkflowInstance)
+        {
+            await context.Invoke();
+            return;
+        }
+
+        var wid = RequestContext.Get("WorkflowId") as string;
+        var pdid = RequestContext.Get("ProcessDefinitionId") as string;
+        var wiid = RequestContext.Get("WorkflowInstanceId") as string;
+        var aid = RequestContext.Get("ActivityId") as string;
+        var aiid = RequestContext.Get("ActivityInstanceId") as string;
+        var vid = RequestContext.Get("VariablesId") as string;
+
+        if (wid is not null || wiid is not null)
+        {
+            using (_logger.BeginScope(
+                "[{WorkflowId}, {ProcessDefinitionId}, {WorkflowInstanceId}, {ActivityId}, {ActivityInstanceId}, {VariablesId}]",
+                wid ?? "-", pdid ?? "-", wiid ?? "-", aid ?? "-", aiid ?? "-", vid ?? "-"))
+                await context.Invoke();
+        }
+        else
+        {
+            await context.Invoke();
+        }
+    }
+}

--- a/src/Fleans/Fleans.Domain/Activities/ExclusiveGateway.cs
+++ b/src/Fleans/Fleans.Domain/Activities/ExclusiveGateway.cs
@@ -45,6 +45,7 @@ public record ExclusiveGateway : Gateway
             
             await activityInstance.PublishEvent(new EvaluateConditionEvent(workflowInstance.GetGrainId().GetGuidKey(),
                                                                definition.WorkflowId,
+                                                                definition.ProcessDefinitionId,
                                                                 await activityInstance.GetActivityInstanceId(),
                                                                 ActivityId,
                                                                 sequence.SequenceFlowId,

--- a/src/Fleans/Fleans.Domain/Activities/ScriptTask.cs
+++ b/src/Fleans/Fleans.Domain/Activities/ScriptTask.cs
@@ -26,6 +26,7 @@ public record ScriptTask : TaskActivity
         await activityInstance.PublishEvent(new ExecuteScriptEvent(
             workflowInstance.GetGrainId().GetGuidKey(),
             definition.WorkflowId,
+            definition.ProcessDefinitionId,
             await activityInstance.GetActivityInstanceId(),
             ActivityId,
             Script,

--- a/src/Fleans/Fleans.Domain/Events/EvaluateConditionEvent.cs
+++ b/src/Fleans/Fleans.Domain/Events/EvaluateConditionEvent.cs
@@ -3,6 +3,7 @@
 [GenerateSerializer]
 public record EvaluateConditionEvent(Guid WorkflowInstanceId,
                                      string WorkflowId,
+                                     string? ProcessDefinitionId,
                                      Guid ActivityInstanceId,
                                      string ActivityId,
                                      string SequenceFlowId,

--- a/src/Fleans/Fleans.Domain/Events/ExecuteScriptEvent.cs
+++ b/src/Fleans/Fleans.Domain/Events/ExecuteScriptEvent.cs
@@ -3,6 +3,7 @@ namespace Fleans.Domain.Events;
 [GenerateSerializer]
 public record ExecuteScriptEvent(Guid WorkflowInstanceId,
                                  string WorkflowId,
+                                 string? ProcessDefinitionId,
                                  Guid ActivityInstanceId,
                                  string ActivityId,
                                  string Script,

--- a/src/Fleans/Fleans.Domain/Fleans.Domain.csproj
+++ b/src/Fleans/Fleans.Domain/Fleans.Domain.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
     <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="9.2.1" />
     <PackageReference Include="Microsoft.Orleans.Sdk" Version="9.2.1" />
     <PackageReference Include="Microsoft.Orleans.Serialization.NewtonsoftJson" Version="9.2.1" />

--- a/src/Fleans/Fleans.Domain/Workflow.cs
+++ b/src/Fleans/Fleans.Domain/Workflow.cs
@@ -13,6 +13,7 @@ namespace Fleans.Domain
     public interface IWorkflowDefinition
     {
         string WorkflowId { get; }
+        string? ProcessDefinitionId { get; }
         List<Activity> Activities { get; }
         List<SequenceFlow> SequenceFlows { get; }
     }
@@ -33,5 +34,8 @@ namespace Fleans.Domain
 
         [Id(2)]
         public required List<SequenceFlow> SequenceFlows { get; init; }
+
+        [Id(3)]
+        public string? ProcessDefinitionId { get; init; }
     }
 }

--- a/src/Fleans/Fleans.Domain/WorkflowInstance.cs
+++ b/src/Fleans/Fleans.Domain/WorkflowInstance.cs
@@ -2,31 +2,33 @@ using Fleans.Domain.Activities;
 using Fleans.Domain.Errors;
 using Fleans.Domain.Events;
 using Fleans.Domain.States;
+using Microsoft.Extensions.Logging;
 using Orleans;
 using Orleans.Runtime;
 using System.Dynamic;
-using System.Security.Cryptography;
 
 namespace Fleans.Domain;
 
-public class WorkflowInstance : Grain, IWorkflowInstance
+public partial class WorkflowInstance : Grain, IWorkflowInstance
 {
     public ValueTask<Guid> GetWorkflowInstanceId() => ValueTask.FromResult(this.GetPrimaryKey());
     public IWorkflowDefinition WorkflowDefinition { get; private set; } = null!;
-    public IWorkflowInstanceState State { get; private set; } = null!; 
-    
-    private readonly IGrainFactory _grainFactory;    
+    public IWorkflowInstanceState State { get; private set; } = null!;
 
-    public WorkflowInstance(IGrainFactory grainFactory)
+    private readonly IGrainFactory _grainFactory;
+    private readonly ILogger<WorkflowInstance> _logger;
+
+    public WorkflowInstance(IGrainFactory grainFactory, ILogger<WorkflowInstance> logger)
     {
         _grainFactory = grainFactory;
+        _logger = logger;
     }
 
     private readonly Queue<IDomainEvent> _events = new();
 
     public override Task OnActivateAsync(CancellationToken cancellationToken)
     {
-        
+
         State = _grainFactory.GetGrain<IWorkflowInstanceState>(this.GetPrimaryKey());
 
         return base.OnActivateAsync(cancellationToken);
@@ -34,6 +36,9 @@ public class WorkflowInstance : Grain, IWorkflowInstance
 
     public async Task StartWorkflow()
     {
+        SetWorkflowRequestContext();
+        using var scope = BeginWorkflowScope();
+        LogWorkflowStarted();
         await ExecuteWorkflow();
     }
 
@@ -44,21 +49,29 @@ public class WorkflowInstance : Grain, IWorkflowInstance
             foreach (var activityState in await State.GetNotExecutingNotCompletedActivities())
             {
                 var currentActivity = await activityState.GetCurrentActivity();
+                SetActivityRequestContext(currentActivity.ActivityId, activityState);
+                LogExecutingActivity(currentActivity.ActivityId, currentActivity.GetType().Name);
                 await currentActivity.ExecuteAsync(this, activityState);
             }
 
-            await TransitionToNextActivity();            
+            await TransitionToNextActivity();
         }
     }
-    
+
     public async Task CompleteActivity(string activityId, ExpandoObject variables)
     {
+        SetWorkflowRequestContext();
+        using var scope = BeginWorkflowScope();
+        LogCompletingActivity(activityId);
         await CompleteActivityState(activityId, variables);
         await ExecuteWorkflow();
     }
 
     public async Task FailActivity(string activityId, Exception exception)
     {
+        SetWorkflowRequestContext();
+        using var scope = BeginWorkflowScope();
+        LogFailingActivity(activityId);
         await FailActivityState(activityId, exception);
         await ExecuteWorkflow();
     }
@@ -70,16 +83,17 @@ public class WorkflowInstance : Grain, IWorkflowInstance
 
         foreach (var activityState in await State.GetActiveActivities())
         {
-           
+
             if (await activityState.IsCompleted())
             {
                 var currentActivity = await activityState.GetCurrentActivity();
-                
+
                 var nextActivities = await currentActivity.GetNextActivities(this, activityState);
 
                 foreach(var nextActivity in nextActivities)
                 {
                     var variablesId = await activityState.GetVariablesStateId();
+                    RequestContext.Set("VariablesId", variablesId.ToString());
                     var activityInstance = _grainFactory.GetGrain<IActivityInstance>(Guid.NewGuid());
                     await activityInstance.SetVariablesId(variablesId);
 
@@ -87,11 +101,12 @@ public class WorkflowInstance : Grain, IWorkflowInstance
 
                     newActiveActivities.Add(activityInstance);
                 }
-                
+
                 completedActivities.Add(activityState);
             }
         }
 
+        LogTransition(completedActivities.Count, newActiveActivities.Count);
         await State.RemoveActiveActivities(completedActivities);
         await State.AddActiveActivities(newActiveActivities);
         await State.AddCompletedActivities(completedActivities);
@@ -102,10 +117,12 @@ public class WorkflowInstance : Grain, IWorkflowInstance
         var activityInstance = await State.GetFirstActive(activityId)
             ?? throw new InvalidOperationException("Active activity not found");
 
+        SetActivityRequestContext(activityId, activityInstance);
         await activityInstance.Complete();
         var variablesId = await activityInstance.GetVariablesStateId();
+        RequestContext.Set("VariablesId", variablesId.ToString());
 
-        await State.MergeState(variablesId, variables);        
+        await State.MergeState(variablesId, variables);
     }
 
     private async Task FailActivityState(string activityId, Exception exception)
@@ -113,17 +130,22 @@ public class WorkflowInstance : Grain, IWorkflowInstance
         var activityInstance = await State.GetFirstActive(activityId)
             ?? throw new InvalidOperationException("Active activity not found");
 
+        SetActivityRequestContext(activityId, activityInstance);
         await activityInstance.Fail(exception);
     }
 
-    public ValueTask Start() 
+    public ValueTask Start()
         => State.Start();
 
-    public ValueTask Complete() 
+    public ValueTask Complete()
         => State.Complete();
 
     public async Task CompleteConditionSequence(string activityId, string conditionSequenceId, bool result)
     {
+        SetWorkflowRequestContext();
+        using var scope = BeginWorkflowScope();
+        LogConditionResult(conditionSequenceId, result);
+
         var activityInstance = await State.GetFirstActive(activityId)
             ?? throw new InvalidOperationException("Active activity not found");
 
@@ -143,12 +165,16 @@ public class WorkflowInstance : Grain, IWorkflowInstance
         WorkflowDefinition = workflow ?? throw new ArgumentNullException(nameof(workflow));
         State = _grainFactory.GetGrain<IWorkflowInstanceState>(this.GetPrimaryKey());
 
+        SetWorkflowRequestContext();
+        using var scope = BeginWorkflowScope();
+        LogWorkflowDefinitionSet();
+
         var startActivity = workflow.Activities.OfType<StartEvent>().First();
         await State.StartWith(startActivity);
     }
 
     public ValueTask<IWorkflowInstanceState> GetState() => ValueTask.FromResult(State);
-    
+
     public ValueTask<IWorkflowDefinition> GetWorkflowDefinition() => ValueTask.FromResult(WorkflowDefinition);
 
     public async ValueTask<ExpandoObject> GetVariables(Guid variablesStateId)
@@ -158,4 +184,50 @@ public class WorkflowInstance : Grain, IWorkflowInstance
 
         return variables;
     }
+
+    private void SetWorkflowRequestContext()
+    {
+        if (WorkflowDefinition is null) return;
+
+        RequestContext.Set("WorkflowId", WorkflowDefinition.WorkflowId);
+        RequestContext.Set("WorkflowInstanceId", this.GetPrimaryKey().ToString());
+        if (WorkflowDefinition.ProcessDefinitionId is not null)
+            RequestContext.Set("ProcessDefinitionId", WorkflowDefinition.ProcessDefinitionId);
+    }
+
+    private void SetActivityRequestContext(string activityId, IActivityInstance activityInstance)
+    {
+        RequestContext.Set("ActivityId", activityId);
+        RequestContext.Set("ActivityInstanceId", activityInstance.GetPrimaryKey().ToString());
+    }
+
+    private IDisposable? BeginWorkflowScope()
+    {
+        if (WorkflowDefinition is null) return null;
+
+        return _logger.BeginScope(
+            "[{WorkflowId}, {ProcessDefinitionId}, {WorkflowInstanceId}]",
+            WorkflowDefinition.WorkflowId, WorkflowDefinition.ProcessDefinitionId ?? "-", this.GetPrimaryKey().ToString());
+    }
+
+    [LoggerMessage(EventId = 1000, Level = LogLevel.Information, Message = "Workflow definition set")]
+    private partial void LogWorkflowDefinitionSet();
+
+    [LoggerMessage(EventId = 1001, Level = LogLevel.Information, Message = "Workflow execution started")]
+    private partial void LogWorkflowStarted();
+
+    [LoggerMessage(EventId = 1002, Level = LogLevel.Debug, Message = "Executing activity {ActivityId} ({ActivityType})")]
+    private partial void LogExecutingActivity(string activityId, string activityType);
+
+    [LoggerMessage(EventId = 1003, Level = LogLevel.Information, Message = "Completing activity {ActivityId}")]
+    private partial void LogCompletingActivity(string activityId);
+
+    [LoggerMessage(EventId = 1004, Level = LogLevel.Warning, Message = "Failing activity {ActivityId}")]
+    private partial void LogFailingActivity(string activityId);
+
+    [LoggerMessage(EventId = 1005, Level = LogLevel.Debug, Message = "Condition sequence result: {SequenceFlowId}={Result}")]
+    private partial void LogConditionResult(string sequenceFlowId, bool result);
+
+    [LoggerMessage(EventId = 1006, Level = LogLevel.Debug, Message = "Transitioning: {CompletedCount} completed, {NewCount} new")]
+    private partial void LogTransition(int completedCount, int newCount);
 }


### PR DESCRIPTION
## Summary

- Add **structured logging** across all workflow grains using `[LoggerMessage]` source generators for zero-allocation, compile-time validated logging
- Propagate workflow context (`WorkflowId`, `ProcessDefinitionId`, `WorkflowInstanceId`, `ActivityId`) across grain boundaries via Orleans `RequestContext`
- Add `IIncomingGrainCallFilter` that reads `RequestContext` and wraps downstream grain calls in `ILogger.BeginScope` — skips `IWorkflowInstance` which manages its own scope
- Add `ProcessDefinitionId` to `IWorkflowDefinition` / `WorkflowDefinition`, stamped at deploy time
- Add `ProcessDefinitionId` to domain events (`EvaluateConditionEvent`, `ExecuteScriptEvent`) for full correlation in event handlers
- Add `[LoggerMessage]` convention to `CLAUDE.md`

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 111/111 tests pass (62 domain + 12 application + 37 infrastructure)
- [ ] Run via Aspire, deploy a BPMN, start & complete a workflow — verify console logs include structured scope values

🤖 Generated with [Claude Code](https://claude.com/claude-code)