### PR TITLE
Add reusable PageHeader component and fix Fluent UI anti-patterns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ Add it to `Fleans.Api/Controllers/WorkflowController.cs`. DTOs go in `Fleans.Ser
 - Tests use MSTest + Orleans.TestingHost, AAA pattern. Activity tests must verify both post-completion and post-failure state. Query state via `workflowInstance.GetState()` after completion/failure — never hold grain references from before completion to assert on.
 - **Admin UI (Fleans.Web) communicates with Orleans grains directly via `WorkflowEngine` service** — not through HTTP API endpoints. The Web app runs as Blazor Server (InteractiveServer), so Razor components execute server-side and can call grains directly. Do not add API endpoints for admin UI functionality.
 - **Logging: always use `[LoggerMessage]` source generators** instead of `ILogger.Log*()` extension methods. Define log methods as `private partial void` on `partial` classes. See `WorkflowInstance.cs` for the pattern. EventId ranges are documented in `docs/plans/2026-02-08-structured-workflow-logging.md`.
+- **Fluent UI Blazor (Fleans.Web)**: Only use components that exist in the library (https://www.fluentui-blazor.net/). Use `IconStart`/`IconEnd` parameters on `FluentButton` — never place `<FluentIcon>` as child content. Use the `Loading` parameter for buttons with loading states.
 
 ## Things to Know
 

--- a/src/Fleans/Fleans.Web/Components/Layout/MainLayout.razor
+++ b/src/Fleans/Fleans.Web/Components/Layout/MainLayout.razor
@@ -11,7 +11,7 @@
             <NavMenu/>
         </FluentNavMenu>
 
-        <FluentBodyContent>
+        <FluentBodyContent Style="padding: calc(var(--design-unit) * 1px) 0">
             @Body
         </FluentBodyContent>
     </FluentStack>

--- a/src/Fleans/Fleans.Web/Components/Pages/Editor.razor
+++ b/src/Fleans/Fleans.Web/Components/Pages/Editor.razor
@@ -15,8 +15,9 @@
 
 <div class="editor-page">
     <div class="editor-toolbar">
-        <FluentButton Appearance="Appearance.Stealth" @onclick="GoBack">
-            <FluentIcon Value="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size20.ArrowLeft())" />
+        <FluentButton Appearance="Appearance.Stealth"
+                      IconStart="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size20.ArrowLeft())"
+                      @onclick="GoBack">
             Back
         </FluentButton>
 
@@ -36,27 +37,23 @@
                          Accept=".bpmn,.xml"
                          OnCompleted="@OnImportFileSelected" />
 
-        <FluentButton Id="ImportBpmnButton" Appearance="Appearance.Neutral">
-            <FluentIcon Value="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size20.ArrowUpload())" />
+        <FluentButton Id="ImportBpmnButton"
+                      Appearance="Appearance.Neutral"
+                      IconStart="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size20.ArrowUpload())">
             Import BPMN
         </FluentButton>
 
-        <FluentButton Appearance="Appearance.Neutral" @onclick="DownloadXml">
-            <FluentIcon Value="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size20.ArrowDownload())" />
+        <FluentButton Appearance="Appearance.Neutral"
+                      IconStart="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size20.ArrowDownload())"
+                      @onclick="DownloadXml">
             Download XML
         </FluentButton>
 
-        <FluentButton Appearance="Appearance.Accent" @onclick="ShowDeployDialog" Disabled="@isDeploying">
-            @if (isDeploying)
-            {
-                <FluentProgressRing Size="Size.Small" />
-                <span style="margin-left: 4px;">Deploying...</span>
-            }
-            else
-            {
-                <FluentIcon Value="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size20.Rocket())" />
-                <span style="margin-left: 4px;">Deploy</span>
-            }
+        <FluentButton Appearance="Appearance.Accent"
+                      IconStart="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size20.Rocket())"
+                      Loading="@isDeploying"
+                      @onclick="ShowDeployDialog">
+            Deploy
         </FluentButton>
     </div>
 

--- a/src/Fleans/Fleans.Web/Components/Pages/Error.razor
+++ b/src/Fleans/Fleans.Web/Components/Pages/Error.razor
@@ -4,26 +4,27 @@
 <PageTitle>Error</PageTitle>
 
 <FluentStack Orientation="Orientation.Vertical" Gap="20px">
-    <FluentHeading HSize="HeadingSize.H1" ForegroundColor="Color.Error">Error.</FluentHeading>
-    <FluentHeading HSize="HeadingSize.H2" ForegroundColor="Color.Error">An error occurred while processing your request.</FluentHeading>
+    <FluentLabel Typo="Typography.EmailHeader" Color="Color.Error">Error.</FluentLabel>
+    <FluentDivider Style="width: 100%;" Role="DividerRole.Presentation"></FluentDivider>
+    <FluentLabel Typo="Typography.Header" Color="Color.Error">An error occurred while processing your request.</FluentLabel>
 
     @if (ShowRequestId)
     {
-        <FluentBodyText>
+        <p>
             <strong>Request ID:</strong> <code>@RequestId</code>
-        </FluentBodyText>
+        </p>
     }
 
-    <FluentHeading HSize="HeadingSize.H3">Development Mode</FluentHeading>
-    <FluentBodyText>
+    <FluentLabel Typo="Typography.Subject">Development Mode</FluentLabel>
+    <p>
         Swapping to <strong>Development</strong> environment will display more detailed information about the error that occurred.
-    </FluentBodyText>
-    <FluentBodyText>
+    </p>
+    <p>
         <strong>The Development environment shouldn't be enabled for deployed applications.</strong>
         It can result in displaying sensitive information from exceptions to end users.
         For local debugging, enable the <strong>Development</strong> environment by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>
         and restarting the app.
-    </FluentBodyText>
+    </p>
 </FluentStack>
 
 @code{

--- a/src/Fleans/Fleans.Web/Components/Pages/NotFound.razor
+++ b/src/Fleans/Fleans.Web/Components/Pages/NotFound.razor
@@ -2,6 +2,6 @@
 @layout MainLayout
 
 <FluentStack Orientation="Orientation.Vertical" Gap="20px">
-    <FluentHeading HSize="HeadingSize.H3">Not Found</FluentHeading>
-    <FluentBodyText>Sorry, the content you are looking for does not exist.</FluentBodyText>
+    <PageHeader Title="Not Found" />
+    <p>Sorry, the content you are looking for does not exist.</p>
 </FluentStack>

--- a/src/Fleans/Fleans.Web/Components/Pages/ProcessInstance.razor
+++ b/src/Fleans/Fleans.Web/Components/Pages/ProcessInstance.razor
@@ -12,32 +12,29 @@
 <PageTitle>Instance @InstanceId</PageTitle>
 
 <FluentStack Orientation="Orientation.Vertical" Gap="16px">
-    <FluentStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="12px">
-        <FluentButton Appearance="Appearance.Stealth" @onclick="GoBack">
-            <FluentIcon Value="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size20.ArrowLeft())" />
-            Back
-        </FluentButton>
-        <FluentHeader HSize="HeadingSize.H2">Process Instance</FluentHeader>
-        @if (snapshot != null)
-        {
-            @if (snapshot.IsCompleted)
+    <PageHeader Title="Process Instance" OnGoBack="GoBack">
+        <Actions>
+            @if (snapshot != null)
             {
-                <FluentBadge Color="Color.Success">Completed</FluentBadge>
+                @if (snapshot.IsCompleted)
+                {
+                    <FluentBadge Color="Color.Success">Completed</FluentBadge>
+                }
+                else if (snapshot.IsStarted)
+                {
+                    <FluentBadge Color="Color.Accent">Running</FluentBadge>
+                }
             }
-            else if (snapshot.IsStarted)
-            {
-                <FluentBadge Color="Color.Accent">Running</FluentBadge>
-            }
-        }
-    </FluentStack>
+        </Actions>
+    </PageHeader>
 
-    <FluentBodyText><strong>Instance ID:</strong> @InstanceId</FluentBodyText>
+    <p><strong>Instance ID:</strong> @InstanceId</p>
 
     @if (isLoading)
     {
         <FluentStack Orientation="Orientation.Vertical" AlignItems="AlignItems.Center" Gap="10px">
             <FluentProgressRing />
-            <FluentBodyText>Loading instance...</FluentBodyText>
+            <p>Loading instance...</p>
         </FluentStack>
     }
     else if (errorMessage != null)
@@ -52,10 +49,10 @@
 
         <FluentStack Orientation="Orientation.Horizontal" Gap="24px" Style="align-items: flex-start;">
             <FluentStack Orientation="Orientation.Vertical" Gap="8px" Style="flex: 1;">
-                <FluentHeading HSize="HeadingSize.H4">Completed Activities</FluentHeading>
+                <FluentLabel Typo="Typography.Subject">Completed Activities</FluentLabel>
                 @if (snapshot!.CompletedActivityIds.Count == 0)
                 {
-                    <FluentBodyText>None</FluentBodyText>
+                    <span>None</span>
                 }
                 else
                 {
@@ -63,17 +60,17 @@
                     {
                         <FluentStack Orientation="Orientation.Horizontal" Gap="8px" AlignItems="AlignItems.Center">
                             <FluentIcon Value="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size16.CheckmarkCircle())" Color="Color.Success" />
-                            <FluentBodyText>@id</FluentBodyText>
+                            <span>@id</span>
                         </FluentStack>
                     }
                 }
             </FluentStack>
 
             <FluentStack Orientation="Orientation.Vertical" Gap="8px" Style="flex: 1;">
-                <FluentHeading HSize="HeadingSize.H4">Active Activities</FluentHeading>
+                <FluentLabel Typo="Typography.Subject">Active Activities</FluentLabel>
                 @if (snapshot!.ActiveActivityIds.Count == 0)
                 {
-                    <FluentBodyText>None</FluentBodyText>
+                    <span>None</span>
                 }
                 else
                 {
@@ -81,15 +78,16 @@
                     {
                         <FluentStack Orientation="Orientation.Horizontal" Gap="8px" AlignItems="AlignItems.Center">
                             <FluentIcon Value="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size16.Circle())" Color="Color.Accent" />
-                            <FluentBodyText>@id</FluentBodyText>
+                            <span>@id</span>
                         </FluentStack>
                     }
                 }
             </FluentStack>
         </FluentStack>
 
-        <FluentButton Appearance="Appearance.Neutral" @onclick="Refresh">
-            <FluentIcon Value="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size20.ArrowSync())" />
+        <FluentButton Appearance="Appearance.Neutral"
+                      IconStart="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size20.ArrowSync())"
+                      @onclick="Refresh">
             Refresh
         </FluentButton>
     }

--- a/src/Fleans/Fleans.Web/Components/Pages/ProcessInstances.razor
+++ b/src/Fleans/Fleans.Web/Components/Pages/ProcessInstances.razor
@@ -10,19 +10,13 @@
 <PageTitle>Instances - @ProcessDefinitionKey</PageTitle>
 
 <FluentStack Orientation="Orientation.Vertical" Gap="16px">
-    <FluentStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="12px">
-        <FluentButton Appearance="Appearance.Stealth" @onclick="GoBack">
-            <FluentIcon Value="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size20.ArrowLeft())" />
-            Back to Workflows
-        </FluentButton>
-        <FluentHeader HSize="HeadingSize.H2">Instances for @ProcessDefinitionKey</FluentHeader>
-    </FluentStack>
+    <PageHeader Title="@($"Instances for {ProcessDefinitionKey}")" GoBackUrl="/workflows" />
 
     @if (isLoading)
     {
         <FluentStack Orientation="Orientation.Vertical" AlignItems="AlignItems.Center" Gap="10px">
             <FluentProgressRing />
-            <FluentBodyText>Loading instances...</FluentBodyText>
+            <p>Loading instances...</p>
         </FluentStack>
     }
     else if (errorMessage != null)
@@ -58,8 +52,9 @@
                 }
             </TemplateColumn>
             <TemplateColumn Title="Actions">
-                <FluentButton Appearance="Appearance.Stealth" @onclick="() => ViewInstance(context.InstanceId)">
-                    <FluentIcon Value="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size20.Eye())" />
+                <FluentButton Appearance="Appearance.Stealth"
+                              IconStart="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size20.Eye())"
+                              @onclick="() => ViewInstance(context.InstanceId)">
                     View
                 </FluentButton>
             </TemplateColumn>
@@ -104,10 +99,5 @@
     private void ViewInstance(Guid instanceId)
     {
         Navigation.NavigateTo($"/process-instance/{instanceId}");
-    }
-
-    private void GoBack()
-    {
-        Navigation.NavigateTo("/workflows");
     }
 }

--- a/src/Fleans/Fleans.Web/Components/Pages/Workflows.razor
+++ b/src/Fleans/Fleans.Web/Components/Pages/Workflows.razor
@@ -9,26 +9,28 @@
 
 <PageTitle>Workflows</PageTitle>
 
-<FluentStack Orientation="Orientation.Vertical" Gap="20px">
-    <FluentStack Orientation="Orientation.Horizontal" Justify="JustifyContent.SpaceBetween" AlignItems="AlignItems.Center">
-        <FluentLabel Typo="Typography.PageTitle">Registered Workflows</FluentLabel>
-        <FluentStack Orientation="Orientation.Horizontal" Gap="8px" AlignItems="AlignItems.Center">
-            <FluentButton Appearance="Appearance.Accent" @onclick="NewWorkflow">
-                <FluentIcon Value="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size20.Add())" />
+<FluentStack Orientation="Orientation.Vertical" Gap="20px" >
+    <PageHeader Title="Registered Workflows">
+        <Actions>
+            <FluentButton Appearance="Appearance.Accent"
+                          IconStart="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size20.Add())"
+                          @onclick="NewWorkflow">
                 New Workflow
             </FluentButton>
-            <FluentButton Appearance="Appearance.Neutral" @onclick="RefreshWorkflows" Disabled="@isLoading">
-                <FluentIcon Value="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size20.ArrowSync())" />
+            <FluentButton Appearance="Appearance.Neutral"
+                          IconStart="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size20.ArrowSync())"
+                          @onclick="RefreshWorkflows"
+                          Disabled="@isLoading">
                 Refresh
             </FluentButton>
-        </FluentStack>
-    </FluentStack>
+        </Actions>
+    </PageHeader>
 
     @if (isLoading && allDefinitions.Count == 0)
     {
         <FluentStack Orientation="Orientation.Vertical" AlignItems="AlignItems.Center" Gap="10px">
             <FluentProgressRing />
-            <FluentBodyText>Loading workflows...</FluentBodyText>
+            <p>Loading workflows...</p>
         </FluentStack>
     }
     else
@@ -92,27 +94,20 @@
                     <TemplateColumn Title="Actions">
                         <FluentStack Orientation="Orientation.Horizontal" Gap="4px">
                             <FluentButton Appearance="Appearance.Stealth"
+                                          IconStart="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size20.Edit())"
                                           @onclick="() => EditWorkflow(context)">
-                                <FluentIcon Value="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size20.Edit())" />
                                 Edit
                             </FluentButton>
                             <FluentButton Appearance="Appearance.Stealth"
-                                          @onclick="() => StartVersion(context)"
-                                          Disabled="@isStarting">
-                                @if (isStarting && startingProcessDefinitionId == context.ProcessDefinitionId)
-                                {
-                                    <FluentProgressRing Size="Size.Small" />
-                                    <span style="margin-left: 8px;">Starting...</span>
-                                }
-                                else
-                                {
-                                    <FluentIcon Value="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size20.Play())" />
-                                    <span style="margin-left: 8px;">Start</span>
-                                }
+                                          IconStart="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size20.Play())"
+                                          Loading="@(isStarting && startingProcessDefinitionId == context.ProcessDefinitionId)"
+                                          Disabled="@isStarting"
+                                          @onclick="() => StartVersion(context)">
+                                Start
                             </FluentButton>
                             <FluentButton Appearance="Appearance.Stealth"
+                                          IconStart="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size20.List())"
                                           @onclick="() => ViewInstances(context)">
-                                <FluentIcon Value="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size20.List())" />
                                 Instances
                             </FluentButton>
                         </FluentStack>

--- a/src/Fleans/Fleans.Web/Components/Shared/PageHeader.razor
+++ b/src/Fleans/Fleans.Web/Components/Shared/PageHeader.razor
@@ -1,0 +1,50 @@
+@using Microsoft.FluentUI.AspNetCore.Components
+
+<FluentStack Orientation="Orientation.Horizontal" HorizontalAlignment="HorizontalAlignment.SpaceBetween" VerticalAlignment="VerticalAlignment.Center">
+
+    <FluentStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="8px">
+        @if (ShowBackButton)
+        {
+            <FluentButton Appearance="Appearance.Stealth"
+                          IconStart="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size20.ArrowLeft())"
+                          Title="Go back"
+                          @onclick="HandleGoBack" />
+        }
+        <FluentLabel Typo="Typography.EmailHeader">@Title</FluentLabel>
+    </FluentStack>
+
+    @if (Actions is not null)
+    {
+        <FluentStack Orientation="Orientation.Horizontal" HorizontalAlignment="HorizontalAlignment.End" Gap="8px" Style="padding-right: 10px">
+            @Actions
+        </FluentStack>
+    }
+
+</FluentStack>
+<FluentDivider Style="width: 100%;" Role="DividerRole.Presentation"></FluentDivider>
+
+@inject NavigationManager Navigation
+
+@code {
+    [Parameter, EditorRequired]
+    public string Title { get; set; } = string.Empty;
+
+    [Parameter]
+    public string? GoBackUrl { get; set; }
+
+    [Parameter]
+    public EventCallback OnGoBack { get; set; }
+
+    [Parameter]
+    public RenderFragment? Actions { get; set; }
+
+    private bool ShowBackButton => GoBackUrl is not null || OnGoBack.HasDelegate;
+
+    private async Task HandleGoBack()
+    {
+        if (OnGoBack.HasDelegate)
+            await OnGoBack.InvokeAsync();
+        else if (GoBackUrl is not null)
+            Navigation.NavigateTo(GoBackUrl);
+    }
+}

--- a/src/Fleans/Fleans.Web/Components/_Imports.razor
+++ b/src/Fleans/Fleans.Web/Components/_Imports.razor
@@ -11,3 +11,4 @@
 @using Fleans.Web
 @using Fleans.Web.Components
 @using Fleans.Web.Components.Layout
+@using Fleans.Web.Components.Shared


### PR DESCRIPTION
## Summary
- Add shared `PageHeader` component (`Title`, `Actions` RenderFragment, `GoBackUrl`/`OnGoBack` back button)
- Replace nonexistent Fluent UI components (`FluentBodyText`, `FluentHeading`) with valid alternatives (`<p>`, `<span>`, `FluentLabel`)
- Use `IconStart`/`IconEnd` parameters on `FluentButton` instead of child `<FluentIcon>` content
- Use `Loading` parameter for button loading states instead of manual `FluentProgressRing`
- Add global body content padding in `MainLayout`
- Document Fluent UI Blazor conventions in `CLAUDE.md`

## Test plan
- [ ] Verify all pages render correctly (Workflows, ProcessInstances, ProcessInstance, Editor, Error, NotFound)
- [ ] Verify back buttons navigate correctly on ProcessInstances and ProcessInstance pages
- [ ] Verify deploy button shows loading state in Editor
- [ ] Verify start button shows loading state in Workflows
- [ ] Build passes with zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)