### PR TITLE
Enrich process instance viewer with detailed snapshots and bidirectional selection

### DIFF
--- a/docs/plans/2026-02-07-process-instance-viewer-plan.md
+++ b/docs/plans/2026-02-07-process-instance-viewer-plan.md
@@ -1,8 +1,8 @@
 # Process Instance Viewer Implementation Plan
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+> **Status:** Implemented (2026-02-09)
 
-**Goal:** Add a Camunda Cockpit-like process instance detail page that renders the full BPMN diagram with highlighted active/completed steps.
+**Goal:** Add a Camunda Cockpit-like process instance detail page that renders the full BPMN diagram with highlighted active/completed steps, plus detailed activity/variable/condition information.
 
 **Architecture:** Blazor Server pages call `WorkflowEngine` which wraps Orleans grain calls. bpmn-js renders BPMN XML in the browser via JS interop. Original BPMN XML stored alongside `ProcessDefinition`. Factory grain tracks created instances per process key.
 
@@ -15,45 +15,7 @@
 **Files:**
 - Modify: `src/Fleans/Fleans.Domain/ProcessDefinitions.cs`
 
-**Step 1: Add BpmnXml property to ProcessDefinition**
-
-In `src/Fleans/Fleans.Domain/ProcessDefinitions.cs`, add after the `Workflow` property (line 33):
-
-```csharp
-[Id(5)]
-public required string BpmnXml { get; init; }
-```
-
-**Step 2: Add InstanceStateSnapshot record**
-
-In the same file, after the `ProcessDefinitionSummary` record (after line 43), add:
-
-```csharp
-[GenerateSerializer]
-public sealed record InstanceStateSnapshot(
-    [property: Id(0)] List<string> ActiveActivityIds,
-    [property: Id(1)] List<string> CompletedActivityIds,
-    [property: Id(2)] bool IsStarted,
-    [property: Id(3)] bool IsCompleted);
-```
-
-**Step 3: Add WorkflowInstanceInfo record**
-
-In the same file, add:
-
-```csharp
-[GenerateSerializer]
-public sealed record WorkflowInstanceInfo(
-    [property: Id(0)] Guid InstanceId,
-    [property: Id(1)] string ProcessDefinitionId,
-    [property: Id(2)] bool IsStarted,
-    [property: Id(3)] bool IsCompleted);
-```
-
-**Step 4: Build to verify**
-
-Run: `dotnet build src/Fleans/`
-Expected: Build errors in `WorkflowInstanceFactoryGrain` because `ProcessDefinition` now requires `BpmnXml`. This is expected — we fix it in Task 3.
+Add `BpmnXml` property to `ProcessDefinition` (Id 5). Add `InstanceStateSnapshot`, `WorkflowInstanceInfo` records.
 
 ---
 
@@ -63,40 +25,7 @@ Expected: Build errors in `WorkflowInstanceFactoryGrain` because `ProcessDefinit
 - Modify: `src/Fleans/Fleans.Domain/States/IWorkflowInstanceState.cs`
 - Modify: `src/Fleans/Fleans.Domain/States/WorkflowInstanceState.cs`
 
-**Step 1: Add interface method**
-
-In `IWorkflowInstanceState.cs`, add inside the interface:
-
-```csharp
-ValueTask<InstanceStateSnapshot> GetStateSnapshot();
-```
-
-Also add the using at top if not present: `using Fleans.Domain;` (it's already there via `Fleans.Domain.Activities`).
-
-**Step 2: Implement in WorkflowInstanceState**
-
-In `WorkflowInstanceState.cs`, add this method:
-
-```csharp
-public async ValueTask<InstanceStateSnapshot> GetStateSnapshot()
-{
-    var activeIds = new List<string>();
-    foreach (var activity in _activeActivities)
-    {
-        var current = await activity.GetCurrentActivity();
-        activeIds.Add(current.ActivityId);
-    }
-
-    var completedIds = new List<string>();
-    foreach (var activity in _completedActivities)
-    {
-        var current = await activity.GetCurrentActivity();
-        completedIds.Add(current.ActivityId);
-    }
-
-    return new InstanceStateSnapshot(activeIds, completedIds, _isStarted, _isCompleted);
-}
-```
+Add `GetStateSnapshot()` method returning `InstanceStateSnapshot`.
 
 ---
 
@@ -106,100 +35,7 @@ public async ValueTask<InstanceStateSnapshot> GetStateSnapshot()
 - Modify: `src/Fleans/Fleans.Application/WorkflowFactory/IWorkflowInstanceFactoryGrain.cs`
 - Modify: `src/Fleans/Fleans.Application/WorkflowFactory/WorkflowInstanceFactoryGrain.cs`
 
-**Step 1: Update grain interface**
-
-In `IWorkflowInstanceFactoryGrain.cs`, change the `DeployWorkflow` signature and add new methods:
-
-```csharp
-Task<ProcessDefinitionSummary> DeployWorkflow(WorkflowDefinition workflow, string bpmnXml);
-Task<IReadOnlyList<WorkflowInstanceInfo>> GetInstancesByKey(string processDefinitionKey);
-Task<string> GetBpmnXml(string processDefinitionId);
-```
-
-**Step 2: Update grain implementation**
-
-In `WorkflowInstanceFactoryGrain.cs`:
-
-Add new fields after `_byKey`:
-
-```csharp
-private readonly Dictionary<string, List<Guid>> _instancesByKey = new(StringComparer.Ordinal);
-private readonly Dictionary<Guid, string> _instanceToDefinitionId = new();
-```
-
-Update `DeployWorkflow` to accept and store `bpmnXml`:
-
-```csharp
-public Task<ProcessDefinitionSummary> DeployWorkflow(WorkflowDefinition workflow, string bpmnXml)
-```
-
-In the method body, change the `ProcessDefinition` creation to include `BpmnXml = bpmnXml`.
-
-Update `CreateWorkflowInstanceGrain` — after creating the grain and before returning, track the instance:
-
-```csharp
-var guid = Guid.NewGuid();
-// ... existing code ...
-TrackInstance(definition.ProcessDefinitionKey, guid, definition.ProcessDefinitionId);
-return workflowInstanceGrain;
-```
-
-Same for `CreateWorkflowInstanceGrainByProcessDefinitionId`.
-
-Add helper method:
-
-```csharp
-private void TrackInstance(string processDefinitionKey, Guid instanceId, string processDefinitionId)
-{
-    if (!_instancesByKey.TryGetValue(processDefinitionKey, out var instances))
-    {
-        instances = new List<Guid>();
-        _instancesByKey[processDefinitionKey] = instances;
-    }
-    instances.Add(instanceId);
-    _instanceToDefinitionId[instanceId] = processDefinitionId;
-}
-```
-
-Implement new methods:
-
-```csharp
-public async Task<IReadOnlyList<WorkflowInstanceInfo>> GetInstancesByKey(string processDefinitionKey)
-{
-    if (!_instancesByKey.TryGetValue(processDefinitionKey, out var instanceIds))
-        return Array.Empty<WorkflowInstanceInfo>();
-
-    var result = new List<WorkflowInstanceInfo>();
-    foreach (var id in instanceIds)
-    {
-        var instance = _grainFactory.GetGrain<IWorkflowInstance>(id);
-        var state = await instance.GetState();
-        var isStarted = await state.IsStarted();
-        var isCompleted = await state.IsCompleted();
-        var defId = _instanceToDefinitionId[id];
-        result.Add(new WorkflowInstanceInfo(id, defId, isStarted, isCompleted));
-    }
-    return result;
-}
-
-public Task<string> GetBpmnXml(string processDefinitionId)
-{
-    if (!_byId.TryGetValue(processDefinitionId, out var definition))
-        throw new KeyNotFoundException($"Process definition '{processDefinitionId}' not found.");
-    return Task.FromResult(definition.BpmnXml);
-}
-```
-
-Update the `RegisterWorkflow` method — it calls `DeployWorkflow` so it needs to pass an empty bpmnXml:
-
-```csharp
-await DeployWorkflow(def, string.Empty);
-```
-
-**Step 3: Build to verify**
-
-Run: `dotnet build src/Fleans/`
-Expected: Build errors in `WorkflowEngine.cs` because `DeployWorkflow` signature changed. Fixed in next task.
+Update `DeployWorkflow` to accept `bpmnXml`. Add `_instancesByKey` and `_instanceToDefinitionId` tracking. Implement `GetInstancesByKey`, `GetBpmnXml`, `GetBpmnXmlByInstanceId`.
 
 ---
 
@@ -208,82 +44,7 @@ Expected: Build errors in `WorkflowEngine.cs` because `DeployWorkflow` signature
 **Files:**
 - Modify: `src/Fleans/Fleans.Application/WorkflowEngine.cs`
 
-**Step 1: Update DeployWorkflow**
-
-Change signature to:
-
-```csharp
-public async Task<ProcessDefinitionSummary> DeployWorkflow(WorkflowDefinition workflow, string bpmnXml)
-{
-    var factoryGrain = _grainFactory.GetGrain<IWorkflowInstanceFactoryGrain>(WorkflowInstanceFactorySingletonId);
-    return await factoryGrain.DeployWorkflow(workflow, bpmnXml);
-}
-```
-
-**Step 2: Add new methods**
-
-```csharp
-public async Task<IReadOnlyList<WorkflowInstanceInfo>> GetInstancesByKey(string processDefinitionKey)
-{
-    var factoryGrain = _grainFactory.GetGrain<IWorkflowInstanceFactoryGrain>(WorkflowInstanceFactorySingletonId);
-    return await factoryGrain.GetInstancesByKey(processDefinitionKey);
-}
-
-public async Task<InstanceStateSnapshot> GetInstanceDetail(Guid instanceId)
-{
-    var instance = _grainFactory.GetGrain<IWorkflowInstance>(instanceId);
-    var state = await instance.GetState();
-    return await state.GetStateSnapshot();
-}
-
-public async Task<string> GetBpmnXml(Guid instanceId)
-{
-    var factoryGrain = _grainFactory.GetGrain<IWorkflowInstanceFactoryGrain>(WorkflowInstanceFactorySingletonId);
-    // Look up which process definition this instance belongs to
-    var instance = _grainFactory.GetGrain<IWorkflowInstance>(instanceId);
-    var def = await instance.GetWorkflowDefinition();
-    // We need the processDefinitionId — go through factory
-    // Simpler: store it on the instance. For now, get bpmn from factory by key (latest).
-    // Actually, the factory tracks instanceId → definitionId, so we add a method for that.
-    return await factoryGrain.GetBpmnXmlByInstanceId(instanceId);
-}
-```
-
-Wait — we need `GetBpmnXmlByInstanceId` on the factory grain. Let me revise.
-
-**Step 2 (revised): Add GetBpmnXmlByInstanceId to grain interface and implementation**
-
-In `IWorkflowInstanceFactoryGrain.cs`, add:
-
-```csharp
-Task<string> GetBpmnXmlByInstanceId(Guid instanceId);
-```
-
-In `WorkflowInstanceFactoryGrain.cs`, implement:
-
-```csharp
-public Task<string> GetBpmnXmlByInstanceId(Guid instanceId)
-{
-    if (!_instanceToDefinitionId.TryGetValue(instanceId, out var definitionId))
-        throw new KeyNotFoundException($"Instance '{instanceId}' not found.");
-    return GetBpmnXml(definitionId);
-}
-```
-
-Then in `WorkflowEngine.cs`:
-
-```csharp
-public async Task<string> GetBpmnXml(Guid instanceId)
-{
-    var factoryGrain = _grainFactory.GetGrain<IWorkflowInstanceFactoryGrain>(WorkflowInstanceFactorySingletonId);
-    return await factoryGrain.GetBpmnXmlByInstanceId(instanceId);
-}
-```
-
-**Step 3: Build to verify**
-
-Run: `dotnet build src/Fleans/`
-Expected: Build errors in Web upload panel (calls `DeployWorkflow` with old signature). Fixed in next task.
+Add `GetInstancesByKey`, `GetInstanceDetail`, `GetBpmnXml`. Update `DeployWorkflow` signature.
 
 ---
 
@@ -292,64 +53,13 @@ Expected: Build errors in Web upload panel (calls `DeployWorkflow` with old sign
 **Files:**
 - Modify: `src/Fleans/Fleans.Web/Components/Pages/WorkflowUploadPanel.razor`
 
-**Step 1: Read the XML as string and pass it**
-
-In `HandleFileUpload()`, around line 141-144, change from:
-
-```csharp
-using var fileStream = file.LocalFile.OpenRead();
-var workflow = await BpmnConverter.ConvertFromXmlAsync(fileStream);
-
-var deployed = await WorkflowEngine.DeployWorkflow(workflow);
-```
-
-To:
-
-```csharp
-var bpmnXml = await File.ReadAllTextAsync(file.LocalFile.FullName);
-using var fileStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(bpmnXml));
-var workflow = await BpmnConverter.ConvertFromXmlAsync(fileStream);
-
-var deployed = await WorkflowEngine.DeployWorkflow(workflow, bpmnXml);
-```
-
-**Step 2: Build to verify**
-
-Run: `dotnet build src/Fleans/`
-Expected: SUCCESS. All compile errors resolved.
-
-**Step 3: Run tests**
-
-Run: `dotnet test src/Fleans/`
-Expected: Some tests may fail if they call `DeployWorkflow` with old signature. Check and fix if needed.
+Read XML as string and pass to `DeployWorkflow`.
 
 ---
 
 ### Task 6: Fix existing tests for new DeployWorkflow signature
 
-**Step 1: Search for test usages of DeployWorkflow**
-
-Check if any tests call `DeployWorkflow` — they may use `RegisterWorkflow` instead (which we already updated to call the new signature internally).
-
-Run: search for `DeployWorkflow` in test files.
-
-If tests call it directly, add `string.Empty` as second arg. If tests only use `RegisterWorkflow`, no changes needed.
-
-**Step 2: Run all tests**
-
-Run: `dotnet test src/Fleans/`
-Expected: PASS
-
-**Step 3: Commit**
-
-```bash
-git add -A && git commit -m "feat: add BpmnXml storage, instance tracking, and state snapshot
-
-Thread BPMN XML through deploy flow and store on ProcessDefinition.
-Track created instances per process key in factory grain.
-Add InstanceStateSnapshot for querying active/completed activity IDs.
-Add WorkflowEngine query methods for instance list, detail, and BPMN XML."
-```
+Update any tests calling `DeployWorkflow` directly. `RegisterWorkflow` internal calls already updated.
 
 ---
 
@@ -359,136 +69,16 @@ Add WorkflowEngine query methods for instance list, detail, and BPMN XML."
 - Modify: `src/Fleans/Fleans.Web/Components/App.razor`
 - Create: `src/Fleans/Fleans.Web/wwwroot/js/bpmnViewer.js`
 
-**Step 1: Add bpmn-js script to App.razor**
-
-In `App.razor`, before the closing `</body>` tag, add after the blazor script:
-
-```html
-<script src="https://unpkg.com/bpmn-js@17.11.1/dist/bpmn-navigated-viewer.production.min.js"></script>
-<script src="js/bpmnViewer.js"></script>
-```
-
-**Step 2: Create bpmnViewer.js**
-
-Create `src/Fleans/Fleans.Web/wwwroot/js/bpmnViewer.js`:
-
-```javascript
-window.bpmnViewer = {
-    _viewer: null,
-
-    init: async function (containerId, bpmnXml) {
-        const container = document.getElementById(containerId);
-        if (!container) return;
-
-        if (this._viewer) {
-            this._viewer.destroy();
-        }
-
-        this._viewer = new BpmnJS({ container: container });
-
-        try {
-            await this._viewer.importXML(bpmnXml);
-            const canvas = this._viewer.get('canvas');
-            canvas.zoom('fit-viewport');
-        } catch (err) {
-            console.error('Failed to render BPMN diagram', err);
-        }
-    },
-
-    highlight: function (completedIds, activeIds) {
-        if (!this._viewer) return;
-
-        const canvas = this._viewer.get('canvas');
-        const elementRegistry = this._viewer.get('elementRegistry');
-
-        // Clear previous markers
-        elementRegistry.forEach(function (element) {
-            canvas.removeMarker(element.id, 'bpmn-completed');
-            canvas.removeMarker(element.id, 'bpmn-active');
-        });
-
-        // Mark completed elements
-        if (completedIds) {
-            completedIds.forEach(function (id) {
-                if (elementRegistry.get(id)) {
-                    canvas.addMarker(id, 'bpmn-completed');
-                }
-            });
-        }
-
-        // Mark active elements
-        if (activeIds) {
-            activeIds.forEach(function (id) {
-                if (elementRegistry.get(id)) {
-                    canvas.addMarker(id, 'bpmn-active');
-                }
-            });
-        }
-    },
-
-    destroy: function () {
-        if (this._viewer) {
-            this._viewer.destroy();
-            this._viewer = null;
-        }
-    }
-};
-```
-
-**Step 3: Build to verify**
-
-Run: `dotnet build src/Fleans/`
-Expected: PASS (JS files are just static assets)
+Add bpmn-js CDN script. Create interop module with `init`, `highlight`, `destroy` methods.
 
 ---
 
 ### Task 8: Add bpmn-js CSS styles
 
 **Files:**
-- Modify or create CSS in `src/Fleans/Fleans.Web/wwwroot/app.css` (or wherever the global CSS lives)
+- Modify: `src/Fleans/Fleans.Web/wwwroot/app.css`
 
-**Step 1: Find the CSS file**
-
-Look for `app.css` in `wwwroot/`.
-
-**Step 2: Add BPMN overlay styles**
-
-Append to the CSS file:
-
-```css
-/* BPMN Viewer Styles */
-.bpmn-container {
-    width: 100%;
-    height: 600px;
-    border: 1px solid var(--neutral-stroke-rest);
-    border-radius: 4px;
-    overflow: hidden;
-}
-
-.bpmn-completed :deep(.djs-visual > :nth-child(1)) {
-    stroke: #22c55e !important;
-    fill: rgba(34, 197, 94, 0.15) !important;
-}
-
-.bpmn-active :deep(.djs-visual > :nth-child(1)) {
-    stroke: #3b82f6 !important;
-    fill: rgba(59, 130, 246, 0.15) !important;
-    stroke-width: 3px !important;
-}
-
-:deep(.bpmn-completed .djs-visual > :nth-child(1)) {
-    stroke: #22c55e !important;
-    fill: rgba(34, 197, 94, 0.15) !important;
-}
-
-:deep(.bpmn-active .djs-visual > :nth-child(1)) {
-    stroke: #3b82f6 !important;
-    fill: rgba(59, 130, 246, 0.15) !important;
-    stroke-width: 3px !important;
-}
-```
-
-Note: bpmn-js uses CSS classes on SVG elements. The marker classes `bpmn-completed` and `bpmn-active` are added by our `highlight()` JS function. The `.djs-visual > :nth-child(1)` selector targets the main shape SVG element.
+Add `.bpmn-container`, `.bpmn-completed`, `.bpmn-active` CSS classes for diagram rendering.
 
 ---
 
@@ -497,140 +87,7 @@ Note: bpmn-js uses CSS classes on SVG elements. The marker classes `bpmn-complet
 **Files:**
 - Create: `src/Fleans/Fleans.Web/Components/Pages/ProcessInstances.razor`
 
-**Step 1: Create the page**
-
-```razor
-@page "/process-instances/{ProcessDefinitionKey}"
-@rendermode InteractiveServer
-@using Fleans.Application
-@using Fleans.Domain
-@using Microsoft.FluentUI.AspNetCore.Components
-@inject WorkflowEngine WorkflowEngine
-@inject NavigationManager Navigation
-@inject ILogger<ProcessInstances> Logger
-
-<PageTitle>Instances - @ProcessDefinitionKey</PageTitle>
-
-<FluentStack Orientation="Orientation.Vertical" Gap="16px">
-    <FluentStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="12px">
-        <FluentButton Appearance="Appearance.Stealth" @onclick="GoBack">
-            <FluentIcon Value="@(new Icons.Regular.Size20.ArrowLeft())" />
-            Back to Workflows
-        </FluentButton>
-        <FluentHeader HSize="HeadingSize.H2">Instances for @ProcessDefinitionKey</FluentHeader>
-    </FluentStack>
-
-    @if (isLoading)
-    {
-        <FluentStack Orientation="Orientation.Vertical" AlignItems="AlignItems.Center" Gap="10px">
-            <FluentProgressRing />
-            <FluentBodyText>Loading instances...</FluentBodyText>
-        </FluentStack>
-    }
-    else if (errorMessage != null)
-    {
-        <FluentMessageBar Intent="MessageIntent.Error" Dismissible="true" OnDismissed="@(() => errorMessage = null)">
-            @errorMessage
-        </FluentMessageBar>
-    }
-    else if (instances.Count == 0)
-    {
-        <FluentMessageBar Intent="MessageIntent.Info">
-            No instances found for this process. Start a workflow to create one.
-        </FluentMessageBar>
-    }
-    else
-    {
-        <FluentTable Items="@instances">
-            <FluentTableHeader>
-                <FluentTableRow>
-                    <FluentTableHeaderCell>Instance ID</FluentTableHeaderCell>
-                    <FluentTableHeaderCell>Status</FluentTableHeaderCell>
-                    <FluentTableHeaderCell>Actions</FluentTableHeaderCell>
-                </FluentTableRow>
-            </FluentTableHeader>
-            <FluentTableBody>
-                @foreach (var instance in instances)
-                {
-                    <FluentTableRow>
-                        <FluentTableCell>
-                            <FluentBodyText>@instance.InstanceId.ToString()[..8]...</FluentBodyText>
-                        </FluentTableCell>
-                        <FluentTableCell>
-                            @if (instance.IsCompleted)
-                            {
-                                <FluentBadge Color="Color.Success">Completed</FluentBadge>
-                            }
-                            else if (instance.IsStarted)
-                            {
-                                <FluentBadge Color="Color.Accent">Running</FluentBadge>
-                            }
-                            else
-                            {
-                                <FluentBadge Color="Color.Neutral">Pending</FluentBadge>
-                            }
-                        </FluentTableCell>
-                        <FluentTableCell>
-                            <FluentButton Appearance="Appearance.Stealth" @onclick="() => ViewInstance(instance.InstanceId)">
-                                <FluentIcon Value="@(new Icons.Regular.Size20.Eye())" />
-                                View
-                            </FluentButton>
-                        </FluentTableCell>
-                    </FluentTableRow>
-                }
-            </FluentTableBody>
-        </FluentTable>
-    }
-</FluentStack>
-
-@code {
-    [Parameter] public string ProcessDefinitionKey { get; set; } = string.Empty;
-
-    private List<WorkflowInstanceInfo> instances = new();
-    private bool isLoading = true;
-    private string? errorMessage;
-
-    protected override async Task OnInitializedAsync()
-    {
-        await LoadInstances();
-    }
-
-    private async Task LoadInstances()
-    {
-        try
-        {
-            isLoading = true;
-            errorMessage = null;
-            var result = await WorkflowEngine.GetInstancesByKey(ProcessDefinitionKey);
-            instances = result.ToList();
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Error loading instances for {Key}", ProcessDefinitionKey);
-            errorMessage = $"Failed to load instances: {ex.Message}";
-        }
-        finally
-        {
-            isLoading = false;
-        }
-    }
-
-    private void ViewInstance(Guid instanceId)
-    {
-        Navigation.NavigateTo($"/process-instance/{instanceId}");
-    }
-
-    private void GoBack()
-    {
-        Navigation.NavigateTo("/workflows");
-    }
-}
-```
-
-**Step 2: Build to verify**
-
-Run: `dotnet build src/Fleans/`
-Expected: PASS
+`FluentDataGrid` listing instances with ID, status badges, and view link.
 
 ---
 
@@ -639,191 +96,7 @@ Expected: PASS
 **Files:**
 - Create: `src/Fleans/Fleans.Web/Components/Pages/ProcessInstance.razor`
 
-**Step 1: Create the page**
-
-```razor
-@page "/process-instance/{InstanceId:guid}"
-@rendermode InteractiveServer
-@using Fleans.Application
-@using Fleans.Domain
-@using Microsoft.FluentUI.AspNetCore.Components
-@inject WorkflowEngine WorkflowEngine
-@inject NavigationManager Navigation
-@inject IJSRuntime JS
-@inject ILogger<ProcessInstance> Logger
-@implements IAsyncDisposable
-
-<PageTitle>Instance @InstanceId</PageTitle>
-
-<FluentStack Orientation="Orientation.Vertical" Gap="16px">
-    <FluentStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="12px">
-        <FluentButton Appearance="Appearance.Stealth" @onclick="GoBack">
-            <FluentIcon Value="@(new Icons.Regular.Size20.ArrowLeft())" />
-            Back
-        </FluentButton>
-        <FluentHeader HSize="HeadingSize.H2">Process Instance</FluentHeader>
-        @if (snapshot != null)
-        {
-            @if (snapshot.IsCompleted)
-            {
-                <FluentBadge Color="Color.Success">Completed</FluentBadge>
-            }
-            else if (snapshot.IsStarted)
-            {
-                <FluentBadge Color="Color.Accent">Running</FluentBadge>
-            }
-        }
-    </FluentStack>
-
-    <FluentBodyText><strong>Instance ID:</strong> @InstanceId</FluentBodyText>
-
-    @if (isLoading)
-    {
-        <FluentStack Orientation="Orientation.Vertical" AlignItems="AlignItems.Center" Gap="10px">
-            <FluentProgressRing />
-            <FluentBodyText>Loading instance...</FluentBodyText>
-        </FluentStack>
-    }
-    else if (errorMessage != null)
-    {
-        <FluentMessageBar Intent="MessageIntent.Error">
-            @errorMessage
-        </FluentMessageBar>
-    }
-    else
-    {
-        <div id="bpmn-canvas" class="bpmn-container"></div>
-
-        <FluentStack Orientation="Orientation.Horizontal" Gap="24px" Style="align-items: flex-start;">
-            <FluentStack Orientation="Orientation.Vertical" Gap="8px" Style="flex: 1;">
-                <FluentHeading HSize="HeadingSize.H4">Completed Activities</FluentHeading>
-                @if (snapshot!.CompletedActivityIds.Count == 0)
-                {
-                    <FluentBodyText>None</FluentBodyText>
-                }
-                else
-                {
-                    @foreach (var id in snapshot.CompletedActivityIds)
-                    {
-                        <FluentStack Orientation="Orientation.Horizontal" Gap="8px" AlignItems="AlignItems.Center">
-                            <FluentIcon Value="@(new Icons.Regular.Size16.CheckmarkCircle())" Color="Color.Success" />
-                            <FluentBodyText>@id</FluentBodyText>
-                        </FluentStack>
-                    }
-                }
-            </FluentStack>
-
-            <FluentStack Orientation="Orientation.Vertical" Gap="8px" Style="flex: 1;">
-                <FluentHeading HSize="HeadingSize.H4">Active Activities</FluentHeading>
-                @if (snapshot!.ActiveActivityIds.Count == 0)
-                {
-                    <FluentBodyText>None</FluentBodyText>
-                }
-                else
-                {
-                    @foreach (var id in snapshot.ActiveActivityIds)
-                    {
-                        <FluentStack Orientation="Orientation.Horizontal" Gap="8px" AlignItems="AlignItems.Center">
-                            <FluentIcon Value="@(new Icons.Regular.Size16.Circle())" Color="Color.Accent" />
-                            <FluentBodyText>@id</FluentBodyText>
-                        </FluentStack>
-                    }
-                }
-            </FluentStack>
-        </FluentStack>
-
-        <FluentButton Appearance="Appearance.Neutral" @onclick="Refresh">
-            <FluentIcon Value="@(new Icons.Regular.Size20.ArrowSync())" />
-            Refresh
-        </FluentButton>
-    }
-</FluentStack>
-
-@code {
-    [Parameter] public Guid InstanceId { get; set; }
-
-    private InstanceStateSnapshot? snapshot;
-    private string? bpmnXml;
-    private bool isLoading = true;
-    private string? errorMessage;
-
-    protected override async Task OnInitializedAsync()
-    {
-        await LoadInstance();
-    }
-
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        if (firstRender && bpmnXml != null)
-        {
-            await RenderDiagram();
-        }
-    }
-
-    private async Task LoadInstance()
-    {
-        try
-        {
-            isLoading = true;
-            errorMessage = null;
-
-            snapshot = await WorkflowEngine.GetInstanceDetail(InstanceId);
-            bpmnXml = await WorkflowEngine.GetBpmnXml(InstanceId);
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Error loading instance {InstanceId}", InstanceId);
-            errorMessage = $"Failed to load instance: {ex.Message}";
-        }
-        finally
-        {
-            isLoading = false;
-        }
-    }
-
-    private async Task RenderDiagram()
-    {
-        if (bpmnXml == null || snapshot == null) return;
-
-        await JS.InvokeVoidAsync("bpmnViewer.init", "bpmn-canvas", bpmnXml);
-        await JS.InvokeVoidAsync("bpmnViewer.highlight", snapshot.CompletedActivityIds, snapshot.ActiveActivityIds);
-    }
-
-    private async Task Refresh()
-    {
-        await LoadInstance();
-        StateHasChanged();
-        // Wait for render, then update diagram highlights
-        await Task.Yield();
-        if (snapshot != null)
-        {
-            await JS.InvokeVoidAsync("bpmnViewer.highlight", snapshot.CompletedActivityIds, snapshot.ActiveActivityIds);
-        }
-    }
-
-    private void GoBack()
-    {
-        Navigation.NavigateTo("javascript:history.back()");
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        try
-        {
-            await JS.InvokeVoidAsync("bpmnViewer.destroy");
-        }
-        catch
-        {
-            // JS interop may fail during disposal
-        }
-    }
-}
-```
-
-**Step 2: Build to verify**
-
-Run: `dotnet build src/Fleans/`
-Expected: PASS
+BPMN diagram with highlighting. Status badges. Refresh button.
 
 ---
 
@@ -831,66 +104,88 @@ Expected: PASS
 
 **Files:**
 - Modify: `src/Fleans/Fleans.Web/Components/Pages/WorkflowVersionsPanel.razor`
-- Modify: `src/Fleans/Fleans.Web/Components/Pages/Workflows.razor`
-
-**Step 1: Add NavigationManager and Instances button to WorkflowVersionsPanel**
-
-Add `@inject NavigationManager Navigation` at top.
-
-In the header area (after the "Start selected version" button area, around line 29), add an "Instances" button:
-
-```razor
-<FluentButton Appearance="Appearance.Neutral"
-              @onclick="ViewInstances"
-              Disabled="@(SelectedGroup == null)">
-    <FluentIcon Value="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size20.List())" />
-    <span style="margin-left: 8px;">View Instances</span>
-</FluentButton>
-```
-
-In the `@code` block, add:
-
-```csharp
-private void ViewInstances()
-{
-    if (SelectedGroup != null)
-    {
-        Navigation.NavigateTo($"/process-instances/{SelectedGroup.ProcessDefinitionKey}");
-    }
-}
-```
-
-**Step 2: Build to verify**
-
-Run: `dotnet build src/Fleans/`
-Expected: PASS
 
 ---
 
-### Task 12: Run full build and tests, commit
+### Task 12: Enrich InstanceStateSnapshot with detailed activity/variable/condition data
 
-**Step 1: Build**
+**Files:**
+- Modify: `src/Fleans/Fleans.Domain/ProcessDefinitions.cs`
+- Modify: `src/Fleans/Fleans.Domain/States/WorkflowInstanceState.cs`
 
-Run: `dotnet build src/Fleans/`
-Expected: PASS
+Add 3 new snapshot DTOs: `ActivityInstanceSnapshot`, `VariableStateSnapshot`, `ConditionSequenceSnapshot`. Extend `InstanceStateSnapshot` with properties at Id 4-7 (ActiveActivities, CompletedActivities, VariableStates, ConditionSequences).
 
-**Step 2: Run tests**
+Rewrite `GetStateSnapshot()` to populate enriched data: fetch activity details in parallel, convert `ExpandoObject` variables to `Dictionary<string, string>`, flatten condition sequence states.
 
-Run: `dotnet test src/Fleans/`
-Expected: PASS
+---
 
-**Step 3: Commit all changes**
+### Task 13: Add CompletedAt tracking to ActivityInstance
 
-```bash
-git add -A
-git commit -m "feat: add process instance viewer with BPMN diagram visualization
+**Files:**
+- Modify: `src/Fleans/Fleans.Domain/IActivityInstance.cs`
+- Modify: `src/Fleans/Fleans.Domain/ActivityInstance.cs`
 
-- Store BPMN XML in ProcessDefinition for diagram rendering
-- Track workflow instances per process key in factory grain
-- Add InstanceStateSnapshot for querying active/completed activities
-- Add ProcessInstances page listing instances per process key
-- Add ProcessInstance detail page with bpmn-js diagram rendering
-- Highlight completed (green) and active (blue) activities on diagram
-- Add View Instances button to WorkflowVersionsPanel
-- Add bpmn-js CDN dependency and JS interop module"
-```
+Add `DateTimeOffset? _completedAt` field, set in `Complete()`. Add `GetCompletedAt()` to interface. Add `CompletedAt` property to `ActivityInstanceSnapshot` (Id 7).
+
+---
+
+### Task 14: Add GetSnapshot() batching to IActivityInstance
+
+**Files:**
+- Modify: `src/Fleans/Fleans.Domain/IActivityInstance.cs`
+- Modify: `src/Fleans/Fleans.Domain/ActivityInstance.cs`
+- Modify: `src/Fleans/Fleans.Domain/States/WorkflowInstanceState.cs`
+
+Add `[ReadOnly] ValueTask<ActivityInstanceSnapshot> GetSnapshot()` to `IActivityInstance`. Implement in `ActivityInstance` returning all fields from local state in a single synchronous call. Update `GetStateSnapshot()` to use `GetSnapshot()` instead of 7 individual grain calls per activity. This reduces grain calls from 7N to N.
+
+---
+
+### Task 15: Update ProcessInstance.razor with tabbed UI, sorting, and filtering
+
+**Files:**
+- Modify: `src/Fleans/Fleans.Web/Components/Pages/ProcessInstance.razor`
+
+Replace simple activity lists with `FluentTabs` containing 3 tabs (Activities, Variables, Conditions). Add `FluentDataGrid` with `Sortable="true"` on `PropertyColumn`s and `SortBy` with `GridSort` on `TemplateColumn`s. Add `ColumnOptions` with `FluentSearch`/`FluentSelect` for filtering. Add `Loading` parameter to refresh button. Add error banners for failed activities. Add CompletedAt column.
+
+---
+
+### Task 16: Add [ReadOnly] to IWorkflowInstanceState read methods
+
+**Files:**
+- Modify: `src/Fleans/Fleans.Domain/States/IWorkflowInstanceState.cs`
+
+Annotate all 10 read-only methods with `[ReadOnly]` from `Orleans.Concurrency`. Reorganize interface to group read-only methods above mutating methods.
+
+---
+
+### Task 17: Add error handling to Refresh()
+
+**Files:**
+- Modify: `src/Fleans/Fleans.Web/Components/Pages/ProcessInstance.razor`
+
+Add try/catch to `Refresh()` matching the `LoadInstance()` pattern. Log error and set `errorMessage` for display in `FluentMessageBar`.
+
+---
+
+### Task 18: Add tests for GetCompletedAt and GetStateSnapshot
+
+**Files:**
+- Modify: `src/Fleans/Fleans.Domain.Tests/TaskActivityTests.cs` (5 new tests)
+- Modify: `src/Fleans/Fleans.Domain.Tests/WorkflowInstanceStateTests.cs` (4 new tests)
+
+**TaskActivityTests:**
+- `GetCompletedAt` null before completion, timestamp after completion, timestamp after failure
+- `GetSnapshot` returns all fields in one call, includes error state after failure
+
+**WorkflowInstanceStateTests:**
+- `GetStateSnapshot` active/completed splitting with correct activity types and timestamps
+- `GetStateSnapshot` variable serialization to `Dictionary<string, string>`
+- `GetStateSnapshot` condition sequences with correct paths and results
+- `GetStateSnapshot` empty state returns empty lists
+
+---
+
+### Verification
+
+- `dotnet build src/Fleans/` — 0 errors
+- `dotnet test src/Fleans/` — 120/120 tests pass (71 Domain + 12 Application + 37 Infrastructure)

--- a/src/Fleans/Fleans.Domain/ActivityInstance.cs
+++ b/src/Fleans/Fleans.Domain/ActivityInstance.cs
@@ -15,6 +15,7 @@ namespace Fleans.Domain
 
         private bool _isCompleted;
         private bool _isExecuting;
+        private DateTimeOffset? _completedAt;
         private ActivityErrorState? _errorState;
         private Guid _variablesId;
 
@@ -29,6 +30,7 @@ namespace Fleans.Domain
         {
             _isExecuting = false;
             _isCompleted = true;
+            _completedAt = DateTimeOffset.UtcNow;
             LogCompleted();
             return ValueTask.CompletedTask;
         }
@@ -64,6 +66,19 @@ namespace Fleans.Domain
         public ValueTask<Activity> GetCurrentActivity() => ValueTask.FromResult(_currentActivity);
 
         public ValueTask<ActivityErrorState?> GetErrorState() => ValueTask.FromResult(_errorState);
+
+        public ValueTask<DateTimeOffset?> GetCompletedAt() => ValueTask.FromResult(_completedAt);
+
+        public ValueTask<ActivityInstanceSnapshot> GetSnapshot() => ValueTask.FromResult(
+            new ActivityInstanceSnapshot(
+                this.GetPrimaryKey(),
+                _currentActivity.ActivityId,
+                _currentActivity.GetType().Name,
+                _isCompleted,
+                _isExecuting,
+                _variablesId,
+                _errorState,
+                _completedAt));
 
         ValueTask<bool> IActivityInstance.IsCompleted()
             => ValueTask.FromResult(_isCompleted);

--- a/src/Fleans/Fleans.Domain/IActivityInstance.cs
+++ b/src/Fleans/Fleans.Domain/IActivityInstance.cs
@@ -16,6 +16,9 @@ namespace Fleans.Domain
         ValueTask<ActivityErrorState?> GetErrorState();
 
         [ReadOnly]
+        ValueTask<DateTimeOffset?> GetCompletedAt();
+
+        [ReadOnly]
         ValueTask<bool> IsCompleted();
 
         [ReadOnly]
@@ -23,6 +26,9 @@ namespace Fleans.Domain
 
         [ReadOnly]
         ValueTask<Guid> GetVariablesStateId();
+
+        [ReadOnly]
+        ValueTask<ActivityInstanceSnapshot> GetSnapshot();
 
         ValueTask Complete();
         ValueTask Fail(Exception exception);

--- a/src/Fleans/Fleans.Domain/IWorkflowInstance.cs
+++ b/src/Fleans/Fleans.Domain/IWorkflowInstance.cs
@@ -8,8 +8,11 @@ namespace Fleans.Domain;
 
 public interface IWorkflowInstance : IGrainWithGuidKey
 {
+    [ReadOnly]
     ValueTask<Guid> GetWorkflowInstanceId();
+    [ReadOnly]
     ValueTask<IWorkflowInstanceState> GetState();
+    [ReadOnly]
     ValueTask<IWorkflowDefinition> GetWorkflowDefinition();
 
     Task CompleteActivity(string activityId, ExpandoObject variables);

--- a/src/Fleans/Fleans.Domain/ProcessDefinitions.cs
+++ b/src/Fleans/Fleans.Domain/ProcessDefinitions.cs
@@ -50,7 +50,35 @@ public sealed record InstanceStateSnapshot(
     [property: Id(0)] List<string> ActiveActivityIds,
     [property: Id(1)] List<string> CompletedActivityIds,
     [property: Id(2)] bool IsStarted,
-    [property: Id(3)] bool IsCompleted);
+    [property: Id(3)] bool IsCompleted,
+    [property: Id(4)] List<ActivityInstanceSnapshot> ActiveActivities,
+    [property: Id(5)] List<ActivityInstanceSnapshot> CompletedActivities,
+    [property: Id(6)] List<VariableStateSnapshot> VariableStates,
+    [property: Id(7)] List<ConditionSequenceSnapshot> ConditionSequences);
+
+[GenerateSerializer]
+public sealed record ActivityInstanceSnapshot(
+    [property: Id(0)] Guid ActivityInstanceId,
+    [property: Id(1)] string ActivityId,
+    [property: Id(2)] string ActivityType,
+    [property: Id(3)] bool IsCompleted,
+    [property: Id(4)] bool IsExecuting,
+    [property: Id(5)] Guid VariablesStateId,
+    [property: Id(6)] ActivityErrorState? ErrorState,
+    [property: Id(7)] DateTimeOffset? CompletedAt);
+
+[GenerateSerializer]
+public sealed record VariableStateSnapshot(
+    [property: Id(0)] Guid VariablesId,
+    [property: Id(1)] Dictionary<string, string> Variables);
+
+[GenerateSerializer]
+public sealed record ConditionSequenceSnapshot(
+    [property: Id(0)] string SequenceFlowId,
+    [property: Id(1)] string Condition,
+    [property: Id(2)] string SourceActivityId,
+    [property: Id(3)] string TargetActivityId,
+    [property: Id(4)] bool Result);
 
 [GenerateSerializer]
 public sealed record WorkflowInstanceInfo(

--- a/src/Fleans/Fleans.Domain/States/IWorkflowInstanceState.cs
+++ b/src/Fleans/Fleans.Domain/States/IWorkflowInstanceState.cs
@@ -2,32 +2,43 @@
 using Fleans.Domain.Activities;
 using Fleans.Domain.Sequences;
 using Orleans;
+using Orleans.Concurrency;
 using System.Dynamic;
 
 namespace Fleans.Domain.States
 {
     public interface IWorkflowInstanceState : IGrainWithGuidKey
-    {        
+    {
+        [ReadOnly]
         ValueTask<IReadOnlyList<IActivityInstance>> GetActiveActivities();
+        [ReadOnly]
         ValueTask<IReadOnlyList<IActivityInstance>> GetCompletedActivities();
+        [ReadOnly]
         ValueTask<IReadOnlyDictionary<Guid, ConditionSequenceState[]>> GetConditionSequenceStates();
+        [ReadOnly]
         ValueTask<bool> IsCompleted();
+        [ReadOnly]
         ValueTask<bool> IsStarted();
+        [ReadOnly]
         ValueTask<IReadOnlyDictionary<Guid, WorklfowVariablesState>> GetVariableStates();
+        [ReadOnly]
+        ValueTask<IActivityInstance?> GetFirstActive(string activityId);
+        [ReadOnly]
+        ValueTask<bool> AnyNotExecuting();
+        [ReadOnly]
+        ValueTask<IActivityInstance[]> GetNotExecutingNotCompletedActivities();
+        [ReadOnly]
+        ValueTask<InstanceStateSnapshot> GetStateSnapshot();
 
         ValueTask<Guid> AddCloneOfVariableState(Guid variableStateId);
-        ValueTask AddActiveActivities(IEnumerable<IActivityInstance> activities);        
+        ValueTask AddActiveActivities(IEnumerable<IActivityInstance> activities);
         ValueTask AddCompletedActivities(IEnumerable<IActivityInstance> activities);
         ValueTask AddConditionSequenceStates(Guid activityInstanceId, ConditionalSequenceFlow[] sequences);
         ValueTask Complete();
         ValueTask RemoveActiveActivities(List<IActivityInstance> removeInstances);
         ValueTask Start();
         ValueTask StartWith(Activity startActivity);
-        ValueTask<IActivityInstance?> GetFirstActive(string activityId);
-        ValueTask<bool> AnyNotExecuting();
-        ValueTask<IActivityInstance[]> GetNotExecutingNotCompletedActivities();
         ValueTask SetCondigitionSequencesResult(Guid activityInstanceId, string sequenceId, bool result);
         ValueTask MergeState(Guid variablesId, ExpandoObject variables);
-        ValueTask<InstanceStateSnapshot> GetStateSnapshot();
     }
 }

--- a/src/Fleans/Fleans.Web/Components/Pages/ProcessInstance.razor
+++ b/src/Fleans/Fleans.Web/Components/Pages/ProcessInstance.razor
@@ -3,6 +3,7 @@
 @using Fleans.Application
 @using Fleans.Domain
 @using Microsoft.FluentUI.AspNetCore.Components
+@using Microsoft.JSInterop
 @inject WorkflowEngine WorkflowEngine
 @inject NavigationManager Navigation
 @inject IJSRuntime JS
@@ -47,49 +48,170 @@
     {
         <div id="bpmn-canvas" class="bpmn-container"></div>
 
-        <FluentStack Orientation="Orientation.Horizontal" Gap="24px" Style="align-items: flex-start;">
-            <FluentStack Orientation="Orientation.Vertical" Gap="8px" Style="flex: 1;">
-                <FluentLabel Typo="Typography.Subject">Completed Activities</FluentLabel>
-                @if (snapshot!.CompletedActivityIds.Count == 0)
-                {
-                    <span>None</span>
-                }
-                else
-                {
-                    @foreach (var id in snapshot.CompletedActivityIds)
-                    {
-                        <FluentStack Orientation="Orientation.Horizontal" Gap="8px" AlignItems="AlignItems.Center">
-                            <FluentIcon Value="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size16.CheckmarkCircle())" Color="Color.Success" />
-                            <span>@id</span>
-                        </FluentStack>
-                    }
-                }
-            </FluentStack>
-
-            <FluentStack Orientation="Orientation.Vertical" Gap="8px" Style="flex: 1;">
-                <FluentLabel Typo="Typography.Subject">Active Activities</FluentLabel>
-                @if (snapshot!.ActiveActivityIds.Count == 0)
-                {
-                    <span>None</span>
-                }
-                else
-                {
-                    @foreach (var id in snapshot.ActiveActivityIds)
-                    {
-                        <FluentStack Orientation="Orientation.Horizontal" Gap="8px" AlignItems="AlignItems.Center">
-                            <FluentIcon Value="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size16.Circle())" Color="Color.Accent" />
-                            <span>@id</span>
-                        </FluentStack>
-                    }
-                }
-            </FluentStack>
-        </FluentStack>
-
         <FluentButton Appearance="Appearance.Neutral"
                       IconStart="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size20.ArrowSync())"
+                      Loading="@isRefreshing"
                       @onclick="Refresh">
             Refresh
         </FluentButton>
+
+        @if (failedActivities.Count > 0)
+        {
+            @foreach (var failed in failedActivities)
+            {
+                <FluentMessageBar Intent="MessageIntent.Error">
+                    Activity <strong>@failed.ActivityId</strong> failed: [@failed.ErrorState!.Code] @failed.ErrorState.Message
+                </FluentMessageBar>
+            }
+        }
+
+        <FluentTabs>
+            <FluentTab Label="Activities">
+                <FluentDataGrid Items="@filteredActivities" GridTemplateColumns="1fr 1fr 1fr 1fr 2fr"
+                                TGridItem="ActivityInstanceSnapshot"
+                                OnRowClick="@OnActivityRowClick"
+                                RowClass="@GetActivityRowClass">
+                    <PropertyColumn Property="@(a => a.ActivityId)" Title="Activity ID" Sortable="true">
+                        <ColumnOptions>
+                            <FluentSearch @bind-Value="activityIdFilter"
+                                          @bind-Value:after="ApplyActivityFilters"
+                                          Placeholder="Filter..." />
+                        </ColumnOptions>
+                    </PropertyColumn>
+                    <PropertyColumn Property="@(a => a.ActivityType)" Title="Type" Sortable="true">
+                        <ColumnOptions>
+                            <FluentSearch @bind-Value="activityTypeFilter"
+                                          @bind-Value:after="ApplyActivityFilters"
+                                          Placeholder="Filter..." />
+                        </ColumnOptions>
+                    </PropertyColumn>
+                    <TemplateColumn Title="Status" SortBy="@statusSort">
+                        <ColumnOptions>
+                            <FluentSearch @bind-Value="activityStatusFilter"
+                                          @bind-Value:after="ApplyActivityFilters"
+                                          Placeholder="Filter..." />
+                        </ColumnOptions>
+                        <ChildContent>
+                            @if (context.ErrorState != null)
+                            {
+                                <FluentBadge Color="Color.Error">Failed</FluentBadge>
+                            }
+                            else if (context.IsCompleted)
+                            {
+                                <FluentBadge Color="Color.Success">Completed</FluentBadge>
+                            }
+                            else if (context.IsExecuting)
+                            {
+                                <FluentBadge Color="Color.Accent">Running</FluentBadge>
+                            }
+                            else
+                            {
+                                <FluentBadge Color="Color.Lightweight">Pending</FluentBadge>
+                            }
+                        </ChildContent>
+                    </TemplateColumn>
+                    <PropertyColumn Property="@(a => a.CompletedAt)" Title="Completed At" Sortable="true" Format="yyyy-MM-dd HH:mm:ss" />
+                    <TemplateColumn Title="Error" SortBy="@errorSort">
+                        <ColumnOptions>
+                            <FluentSearch @bind-Value="activityErrorFilter"
+                                          @bind-Value:after="ApplyActivityFilters"
+                                          Placeholder="Filter..." />
+                        </ColumnOptions>
+                        <ChildContent>
+                            @if (context.ErrorState != null)
+                            {
+                                <span>[@context.ErrorState.Code] @context.ErrorState.Message</span>
+                            }
+                            else
+                            {
+                                <span>-</span>
+                            }
+                        </ChildContent>
+                    </TemplateColumn>
+                </FluentDataGrid>
+            </FluentTab>
+
+            <FluentTab Label="Variables">
+                @if (snapshot!.VariableStates.Count == 0)
+                {
+                    <FluentMessageBar Intent="MessageIntent.Info">
+                        No variable states recorded.
+                    </FluentMessageBar>
+                }
+                else
+                {
+                    @foreach (var vs in snapshot.VariableStates)
+                    {
+                        var rows = GetVariableRows(vs);
+                        <FluentLabel Typo="Typography.Subject" Style="margin-top: 12px;">
+                            Variables @vs.VariablesId.ToString()[..8]...
+                        </FluentLabel>
+                        <FluentDataGrid Items="@rows" GridTemplateColumns="1fr 2fr">
+                            <PropertyColumn Property="@(v => v.Key)" Title="Key" Sortable="true" />
+                            <PropertyColumn Property="@(v => v.Value)" Title="Value" Sortable="true" />
+                        </FluentDataGrid>
+                    }
+                }
+            </FluentTab>
+
+            <FluentTab Label="Conditions">
+                @if (snapshot!.ConditionSequences.Count == 0)
+                {
+                    <FluentMessageBar Intent="MessageIntent.Info">
+                        No condition evaluations recorded.
+                    </FluentMessageBar>
+                }
+                else
+                {
+                    <FluentDataGrid Items="@filteredConditions" GridTemplateColumns="1fr 2fr 1.5fr 0.5fr">
+                        <PropertyColumn Property="@(c => c.SequenceFlowId)" Title="Sequence Flow" Sortable="true">
+                            <ColumnOptions>
+                                <FluentSearch @bind-Value="conditionFlowFilter"
+                                              @bind-Value:after="ApplyConditionFilters"
+                                              Placeholder="Filter..." />
+                            </ColumnOptions>
+                        </PropertyColumn>
+                        <PropertyColumn Property="@(c => c.Condition)" Title="Condition" Sortable="true">
+                            <ColumnOptions>
+                                <FluentSearch @bind-Value="conditionExprFilter"
+                                              @bind-Value:after="ApplyConditionFilters"
+                                              Placeholder="Filter..." />
+                            </ColumnOptions>
+                        </PropertyColumn>
+                        <TemplateColumn Title="Path" SortBy="@conditionPathSort">
+                            <ColumnOptions>
+                                <FluentSearch @bind-Value="conditionPathFilter"
+                                              @bind-Value:after="ApplyConditionFilters"
+                                              Placeholder="Filter..." />
+                            </ColumnOptions>
+                            <ChildContent>
+                                <span>@context.SourceActivityId → @context.TargetActivityId</span>
+                            </ChildContent>
+                        </TemplateColumn>
+                        <TemplateColumn Title="Result" SortBy="@conditionResultSort">
+                            <ColumnOptions>
+                                <FluentSelect TOption="string" @bind-Value="conditionResultFilter"
+                                              @bind-Value:after="ApplyConditionFilters">
+                                    <FluentOption Value="">All</FluentOption>
+                                    <FluentOption Value="true">True</FluentOption>
+                                    <FluentOption Value="false">False</FluentOption>
+                                </FluentSelect>
+                            </ColumnOptions>
+                            <ChildContent>
+                                @if (context.Result)
+                                {
+                                    <FluentBadge Color="Color.Success">True</FluentBadge>
+                                }
+                                else
+                                {
+                                    <FluentBadge Color="Color.Error">False</FluentBadge>
+                                }
+                            </ChildContent>
+                        </TemplateColumn>
+                    </FluentDataGrid>
+                }
+            </FluentTab>
+        </FluentTabs>
     }
 </FluentStack>
 
@@ -99,7 +221,39 @@
     private InstanceStateSnapshot? snapshot;
     private string? bpmnXml;
     private bool isLoading = true;
+    private bool isRefreshing;
     private string? errorMessage;
+    private string? selectedActivityId;
+    private DotNetObjectReference<ProcessInstance>? dotNetRef;
+
+    // Activities tab
+    private List<ActivityInstanceSnapshot> allActivitiesList = [];
+    private IQueryable<ActivityInstanceSnapshot> filteredActivities = Enumerable.Empty<ActivityInstanceSnapshot>().AsQueryable();
+    private List<ActivityInstanceSnapshot> failedActivities = [];
+    private string? activityIdFilter;
+    private string? activityTypeFilter;
+    private string? activityStatusFilter;
+    private string? activityErrorFilter;
+
+    private readonly GridSort<ActivityInstanceSnapshot> statusSort =
+        GridSort<ActivityInstanceSnapshot>.ByAscending(a => GetStatusLabel(a));
+    private readonly GridSort<ActivityInstanceSnapshot> errorSort =
+        GridSort<ActivityInstanceSnapshot>.ByAscending(a => a.ErrorState != null ? a.ErrorState.Message : "");
+
+    // Conditions tab
+    private List<ConditionSequenceSnapshot> allConditionsList = [];
+    private IQueryable<ConditionSequenceSnapshot> filteredConditions = Enumerable.Empty<ConditionSequenceSnapshot>().AsQueryable();
+    private string? conditionFlowFilter;
+    private string? conditionExprFilter;
+    private string? conditionPathFilter;
+    private string? conditionResultFilter;
+
+    private readonly GridSort<ConditionSequenceSnapshot> conditionPathSort =
+        GridSort<ConditionSequenceSnapshot>.ByAscending(c => c.SourceActivityId).ThenAscending(c => c.TargetActivityId);
+    private readonly GridSort<ConditionSequenceSnapshot> conditionResultSort =
+        GridSort<ConditionSequenceSnapshot>.ByAscending(c => c.Result);
+
+    private record VariableRow(string Key, string Value);
 
     protected override async Task OnInitializedAsync()
     {
@@ -123,6 +277,8 @@
 
             snapshot = await WorkflowEngine.GetInstanceDetail(InstanceId);
             bpmnXml = await WorkflowEngine.GetBpmnXml(InstanceId);
+
+            BuildDerivedState();
         }
         catch (Exception ex)
         {
@@ -135,28 +291,126 @@
         }
     }
 
+    private void BuildDerivedState()
+    {
+        if (snapshot == null) return;
+
+        allActivitiesList = snapshot.CompletedActivities
+            .Concat(snapshot.ActiveActivities)
+            .ToList();
+        failedActivities = allActivitiesList.Where(a => a.ErrorState != null).ToList();
+
+        allConditionsList = snapshot.ConditionSequences;
+
+        ApplyActivityFilters();
+        ApplyConditionFilters();
+    }
+
+    private void ApplyActivityFilters()
+    {
+        IEnumerable<ActivityInstanceSnapshot> result = allActivitiesList;
+
+        if (!string.IsNullOrWhiteSpace(activityIdFilter))
+            result = result.Where(a => a.ActivityId.Contains(activityIdFilter, StringComparison.OrdinalIgnoreCase));
+        if (!string.IsNullOrWhiteSpace(activityTypeFilter))
+            result = result.Where(a => a.ActivityType.Contains(activityTypeFilter, StringComparison.OrdinalIgnoreCase));
+        if (!string.IsNullOrWhiteSpace(activityStatusFilter))
+            result = result.Where(a => GetStatusLabel(a).Contains(activityStatusFilter, StringComparison.OrdinalIgnoreCase));
+        if (!string.IsNullOrWhiteSpace(activityErrorFilter))
+            result = result.Where(a => a.ErrorState != null &&
+                $"[{a.ErrorState.Code}] {a.ErrorState.Message}".Contains(activityErrorFilter, StringComparison.OrdinalIgnoreCase));
+
+        filteredActivities = result.AsQueryable();
+    }
+
+    private void ApplyConditionFilters()
+    {
+        IEnumerable<ConditionSequenceSnapshot> result = allConditionsList;
+
+        if (!string.IsNullOrWhiteSpace(conditionFlowFilter))
+            result = result.Where(c => c.SequenceFlowId.Contains(conditionFlowFilter, StringComparison.OrdinalIgnoreCase));
+        if (!string.IsNullOrWhiteSpace(conditionExprFilter))
+            result = result.Where(c => c.Condition.Contains(conditionExprFilter, StringComparison.OrdinalIgnoreCase));
+        if (!string.IsNullOrWhiteSpace(conditionPathFilter))
+            result = result.Where(c => $"{c.SourceActivityId} {c.TargetActivityId}".Contains(conditionPathFilter, StringComparison.OrdinalIgnoreCase));
+        if (!string.IsNullOrWhiteSpace(conditionResultFilter))
+            result = result.Where(c => c.Result.ToString().Equals(conditionResultFilter, StringComparison.OrdinalIgnoreCase));
+
+        filteredConditions = result.AsQueryable();
+    }
+
     private async Task RenderDiagram()
     {
         if (bpmnXml == null || snapshot == null) return;
 
         await JS.InvokeVoidAsync("bpmnViewer.init", "bpmn-canvas", bpmnXml);
         await JS.InvokeVoidAsync("bpmnViewer.highlight", snapshot.CompletedActivityIds, snapshot.ActiveActivityIds);
+
+        dotNetRef = DotNetObjectReference.Create(this);
+        await JS.InvokeVoidAsync("bpmnViewer.registerClickHandler", dotNetRef);
     }
 
     private async Task Refresh()
     {
-        await LoadInstance();
-        StateHasChanged();
-        await Task.Yield();
-        if (snapshot != null)
+        isRefreshing = true;
+        try
         {
-            await JS.InvokeVoidAsync("bpmnViewer.highlight", snapshot.CompletedActivityIds, snapshot.ActiveActivityIds);
+            errorMessage = null;
+            snapshot = await WorkflowEngine.GetInstanceDetail(InstanceId);
+            BuildDerivedState();
+            StateHasChanged();
+            await Task.Yield();
+            if (snapshot != null)
+            {
+                await JS.InvokeVoidAsync("bpmnViewer.highlight", snapshot.CompletedActivityIds, snapshot.ActiveActivityIds);
+                if (selectedActivityId != null)
+                {
+                    await JS.InvokeVoidAsync("bpmnViewer.selectElement", selectedActivityId);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error refreshing instance {InstanceId}", InstanceId);
+            errorMessage = $"Failed to refresh instance: {ex.Message}";
+        }
+        finally
+        {
+            isRefreshing = false;
         }
     }
 
     private async Task GoBack()
     {
         await JS.InvokeVoidAsync("history.back");
+    }
+
+    private static IQueryable<VariableRow> GetVariableRows(VariableStateSnapshot vs)
+        => vs.Variables.Select(kvp => new VariableRow(kvp.Key, kvp.Value)).AsQueryable();
+
+    private async Task OnActivityRowClick(FluentDataGridRow<ActivityInstanceSnapshot> row)
+    {
+        if (row.Item is null) return;
+        selectedActivityId = row.Item.ActivityId;
+        await JS.InvokeVoidAsync("bpmnViewer.selectElement", row.Item.ActivityId);
+    }
+
+    [JSInvokable]
+    public void OnBpmnElementClicked(string elementId)
+    {
+        selectedActivityId = string.IsNullOrEmpty(elementId) ? null : elementId;
+        StateHasChanged();
+    }
+
+    private string? GetActivityRowClass(ActivityInstanceSnapshot item)
+        => selectedActivityId != null && item.ActivityId == selectedActivityId ? "activity-row-selected" : null;
+
+    private static string GetStatusLabel(ActivityInstanceSnapshot a)
+    {
+        if (a.ErrorState != null) return "Failed";
+        if (a.IsCompleted) return "Completed";
+        if (a.IsExecuting) return "Running";
+        return "Pending";
     }
 
     public async ValueTask DisposeAsync()
@@ -169,5 +423,6 @@
         {
             // JS interop may fail during disposal
         }
+        dotNetRef?.Dispose();
     }
 }

--- a/src/Fleans/Fleans.Web/wwwroot/app.css
+++ b/src/Fleans/Fleans.Web/wwwroot/app.css
@@ -1,5 +1,6 @@
 html, body {
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    --text-100: 60 2.6% 7.6%;
 }
 
 body {
@@ -47,6 +48,8 @@ h1:focus {
     border: 1px solid var(--neutral-stroke-rest);
     border-radius: 4px;
     overflow: hidden;
+    background-image: radial-gradient(circle, hsl(var(--text-100) / 15%) 1px, transparent 1px);
+    background-size: 16px 16px;
 }
 
 .bpmn-completed .djs-visual > :nth-child(1) {
@@ -58,6 +61,16 @@ h1:focus {
     stroke: #3b82f6 !important;
     fill: rgba(59, 130, 246, 0.15) !important;
     stroke-width: 3px !important;
+}
+
+.bpmn-selected .djs-visual > :nth-child(1) {
+    stroke: #f59e0b !important;
+    stroke-width: 3px !important;
+    filter: drop-shadow(0 0 6px rgba(245, 158, 11, 0.5));
+}
+
+.activity-row-selected {
+    background: rgba(245, 158, 11, 0.15) !important;
 }
 
 /* BPMN Editor Styles */
@@ -89,6 +102,8 @@ h1:focus {
 .editor-canvas {
     flex: 1;
     min-height: 0;
+    background-image: radial-gradient(circle, hsl(var(--text-100) / 15%) 1px, transparent 1px);
+    background-size: 16px 16px;
 }
 
 /* Properties Panel */


### PR DESCRIPTION
## Summary
- **Enriched InstanceStateSnapshot** with detailed `ActivityInstanceSnapshot`, `VariableStateSnapshot`, and `ConditionSequenceSnapshot` DTOs (Orleans-serializable)
- **GetSnapshot() batching** on `IActivityInstance` — reduces grain calls from 7N to N per state query via `Task.WhenAll`
- **CompletedAt tracking** on `ActivityInstance` with `DateTimeOffset?`
- **[ReadOnly] annotations** on all read-only grain interface methods (`IWorkflowInstanceState`, `IActivityInstance`, `IWorkflowInstance`)
- **Tabbed UI** (Activities/Variables/Conditions) with `FluentDataGrid`, column sorting, and text/dropdown filtering
- **Bidirectional selection** between Activities datagrid and BPMN diagram — click a row to highlight the element, click a BPMN element to highlight the row (amber color, viewport centering, deselect on background click)
- **9 new tests** (5 TaskActivityTests + 4 WorkflowInstanceStateTests) — 120/120 total passing

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 120/120 pass (71 Domain + 12 Application + 37 Infrastructure)
- [ ] Manual: deploy BPMN, start instance, navigate to instance detail page
- [ ] Verify Activities/Variables/Conditions tabs render with correct data
- [ ] Verify sorting and filtering on all columns
- [ ] Verify click row → BPMN element highlights and centers
- [ ] Verify click BPMN element → datagrid row highlights
- [ ] Verify click background/sequence flow → deselects both
- [ ] Verify Refresh preserves selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)