### PR TITLE
feat: add CreatedAt and ExecutionStartedAt timestamps to ActivityInstance

### DIFF
--- a/src/Fleans/Fleans.Domain/ActivityInstance.cs
+++ b/src/Fleans/Fleans.Domain/ActivityInstance.cs
@@ -15,6 +15,8 @@ namespace Fleans.Domain
 
         private bool _isCompleted;
         private bool _isExecuting;
+        private DateTimeOffset? _createdAt;
+        private DateTimeOffset? _executionStartedAt;
         private DateTimeOffset? _completedAt;
         private ActivityErrorState? _errorState;
         private Guid _variablesId;
@@ -56,6 +58,7 @@ namespace Fleans.Domain
             _errorState = null;
             _isCompleted = false;
             _isExecuting = true;
+            _executionStartedAt = DateTimeOffset.UtcNow;
             RequestContext.Set("VariablesId", _variablesId.ToString());
             LogExecutionStarted();
             return ValueTask.CompletedTask;
@@ -66,6 +69,10 @@ namespace Fleans.Domain
         public ValueTask<Activity> GetCurrentActivity() => ValueTask.FromResult(_currentActivity);
 
         public ValueTask<ActivityErrorState?> GetErrorState() => ValueTask.FromResult(_errorState);
+
+        public ValueTask<DateTimeOffset?> GetCreatedAt() => ValueTask.FromResult(_createdAt);
+
+        public ValueTask<DateTimeOffset?> GetExecutionStartedAt() => ValueTask.FromResult(_executionStartedAt);
 
         public ValueTask<DateTimeOffset?> GetCompletedAt() => ValueTask.FromResult(_completedAt);
 
@@ -78,6 +85,8 @@ namespace Fleans.Domain
                 _isExecuting,
                 _variablesId,
                 _errorState,
+                _createdAt,
+                _executionStartedAt,
                 _completedAt));
 
         ValueTask<bool> IActivityInstance.IsCompleted()
@@ -97,6 +106,7 @@ namespace Fleans.Domain
         public ValueTask SetActivity(Activity nextActivity)
         {
             _currentActivity = nextActivity;
+            _createdAt = DateTimeOffset.UtcNow;
             return ValueTask.CompletedTask;
         }
 

--- a/src/Fleans/Fleans.Domain/IActivityInstance.cs
+++ b/src/Fleans/Fleans.Domain/IActivityInstance.cs
@@ -16,6 +16,12 @@ namespace Fleans.Domain
         ValueTask<ActivityErrorState?> GetErrorState();
 
         [ReadOnly]
+        ValueTask<DateTimeOffset?> GetCreatedAt();
+
+        [ReadOnly]
+        ValueTask<DateTimeOffset?> GetExecutionStartedAt();
+
+        [ReadOnly]
         ValueTask<DateTimeOffset?> GetCompletedAt();
 
         [ReadOnly]

--- a/src/Fleans/Fleans.Domain/ProcessDefinitions.cs
+++ b/src/Fleans/Fleans.Domain/ProcessDefinitions.cs
@@ -65,7 +65,9 @@ public sealed record ActivityInstanceSnapshot(
     [property: Id(4)] bool IsExecuting,
     [property: Id(5)] Guid VariablesStateId,
     [property: Id(6)] ActivityErrorState? ErrorState,
-    [property: Id(7)] DateTimeOffset? CompletedAt);
+    [property: Id(7)] DateTimeOffset? CreatedAt,
+    [property: Id(8)] DateTimeOffset? ExecutionStartedAt,
+    [property: Id(9)] DateTimeOffset? CompletedAt);
 
 [GenerateSerializer]
 public sealed record VariableStateSnapshot(

--- a/src/Fleans/Fleans.Web/Components/Pages/ProcessInstance.razor
+++ b/src/Fleans/Fleans.Web/Components/Pages/ProcessInstance.razor
@@ -67,7 +67,7 @@
 
         <FluentTabs>
             <FluentTab Label="Activities">
-                <FluentDataGrid Items="@filteredActivities" GridTemplateColumns="1fr 1fr 1fr 1fr 2fr"
+                <FluentDataGrid Items="@filteredActivities" GridTemplateColumns="1fr 1fr 1fr 1fr 1fr 1fr 2fr"
                                 TGridItem="ActivityInstanceSnapshot"
                                 OnRowClick="@OnActivityRowClick"
                                 RowClass="@GetActivityRowClass">
@@ -110,6 +110,8 @@
                             }
                         </ChildContent>
                     </TemplateColumn>
+                    <PropertyColumn Property="@(a => a.CreatedAt)" Title="Created At" Sortable="true" Format="yyyy-MM-dd HH:mm:ss" />
+                    <PropertyColumn Property="@(a => a.ExecutionStartedAt)" Title="Started At" Sortable="true" Format="yyyy-MM-dd HH:mm:ss" />
                     <PropertyColumn Property="@(a => a.CompletedAt)" Title="Completed At" Sortable="true" Format="yyyy-MM-dd HH:mm:ss" />
                     <TemplateColumn Title="Error" SortBy="@errorSort">
                         <ColumnOptions>


### PR DESCRIPTION
## Summary
- Add `CreatedAt` timestamp to `ActivityInstance`, set when the instance is initialized via `SetActivity()`
- Add `ExecutionStartedAt` timestamp, set when `Execute()` begins
- Both exposed on `IActivityInstance` interface, included in `ActivityInstanceSnapshot`, and displayed in the admin UI activities grid

## Test plan
- [x] 5 new tests covering null-before and set-after states for both timestamps, plus failure path
- [x] 2 existing snapshot tests updated to assert on new fields
- [x] All 125 tests pass (76 domain + 12 application + 37 infrastructure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)