### PR TITLE
feat: add lifecycle timestamps and GetInstanceInfo to WorkflowInstance

### DIFF
--- a/src/Fleans/Fleans.Application/WorkflowFactory/WorkflowInstanceFactoryGrain.cs
+++ b/src/Fleans/Fleans.Application/WorkflowFactory/WorkflowInstanceFactoryGrain.cs
@@ -197,11 +197,8 @@ public partial class WorkflowInstanceFactoryGrain : Grain, IWorkflowInstanceFact
         foreach (var id in instanceIds)
         {
             var instance = _grainFactory.GetGrain<IWorkflowInstance>(id);
-            var state = await instance.GetState();
-            var isStarted = await state.IsStarted();
-            var isCompleted = await state.IsCompleted();
-            var defId = _instanceToDefinitionId[id];
-            result.Add(new WorkflowInstanceInfo(id, defId, isStarted, isCompleted));
+            var info = await instance.GetInstanceInfo();
+            result.Add(info);
         }
         return result;
     }

--- a/src/Fleans/Fleans.Domain/IWorkflowInstance.cs
+++ b/src/Fleans/Fleans.Domain/IWorkflowInstance.cs
@@ -11,6 +11,14 @@ public interface IWorkflowInstance : IGrainWithGuidKey
     [ReadOnly]
     ValueTask<Guid> GetWorkflowInstanceId();
     [ReadOnly]
+    ValueTask<DateTimeOffset?> GetCreatedAt();
+    [ReadOnly]
+    ValueTask<DateTimeOffset?> GetExecutionStartedAt();
+    [ReadOnly]
+    ValueTask<DateTimeOffset?> GetCompletedAt();
+    [ReadOnly]
+    ValueTask<WorkflowInstanceInfo> GetInstanceInfo();
+    [ReadOnly]
     ValueTask<IWorkflowInstanceState> GetState();
     [ReadOnly]
     ValueTask<IWorkflowDefinition> GetWorkflowDefinition();

--- a/src/Fleans/Fleans.Domain/ProcessDefinitions.cs
+++ b/src/Fleans/Fleans.Domain/ProcessDefinitions.cs
@@ -87,4 +87,7 @@ public sealed record WorkflowInstanceInfo(
     [property: Id(0)] Guid InstanceId,
     [property: Id(1)] string ProcessDefinitionId,
     [property: Id(2)] bool IsStarted,
-    [property: Id(3)] bool IsCompleted);
+    [property: Id(3)] bool IsCompleted,
+    [property: Id(4)] DateTimeOffset? CreatedAt,
+    [property: Id(5)] DateTimeOffset? ExecutionStartedAt,
+    [property: Id(6)] DateTimeOffset? CompletedAt);

--- a/src/Fleans/Fleans.Web/Components/Pages/ProcessInstances.razor
+++ b/src/Fleans/Fleans.Web/Components/Pages/ProcessInstances.razor
@@ -51,6 +51,9 @@
                     <FluentBadge Color="Color.Neutral">Pending</FluentBadge>
                 }
             </TemplateColumn>
+            <PropertyColumn Property="@(i => i.CreatedAt)" Title="Created At" Sortable="true" Format="yyyy-MM-dd HH:mm:ss" />
+            <PropertyColumn Property="@(i => i.ExecutionStartedAt)" Title="Started At" Sortable="true" Format="yyyy-MM-dd HH:mm:ss" />
+            <PropertyColumn Property="@(i => i.CompletedAt)" Title="Completed At" Sortable="true" Format="yyyy-MM-dd HH:mm:ss" />
             <TemplateColumn Title="Actions">
                 <FluentButton Appearance="Appearance.Stealth"
                               IconStart="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size20.Eye())"


### PR DESCRIPTION
## Summary
- Add `CreatedAt`, `ExecutionStartedAt`, and `CompletedAt` timestamps to `WorkflowInstance`
- Add `GetInstanceInfo()` snapshot method on `IWorkflowInstance` — returns all fields in a single grain call
- Simplify `WorkflowInstanceFactoryGrain.GetInstancesByKey()` from 5 sequential per-field grain calls to 1 `GetInstanceInfo()` call per instance
- Display all three timestamps in the admin UI instances list

## Test plan
- [x] 8 new tests covering null-before, set-after, stability, completion, and snapshot
- [x] All 133 tests pass (84 domain + 12 application + 37 infrastructure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)