### PR TITLE
feat: move navigation from MainLayout to NavMenu component

### DIFF
--- a/src/Fleans/Fleans.Web/Components/Layout/MainLayout.razor
+++ b/src/Fleans/Fleans.Web/Components/Layout/MainLayout.razor
@@ -7,14 +7,7 @@
     </FluentHeader>
     
     <FluentStack Orientation="Orientation.Horizontal" Width="100%">
-        <FluentAppBar Style="height: calc(100vh - 50px);">
-            <FluentAppBarItem Href="/workflows"
-                              Text="Workflows"
-                              IconRest="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size24.Flow())" />
-            <FluentAppBarItem Href="/editor"
-                              Text="Editor"
-                              IconRest="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size24.DrawShape())" />
-        </FluentAppBar>
+        <NavMenu />
 
         <FluentBodyContent Style="padding: calc(var(--design-unit) * 1px) 0">
             @Body

--- a/src/Fleans/Fleans.Web/Components/Layout/NavMenu.razor
+++ b/src/Fleans/Fleans.Web/Components/Layout/NavMenu.razor
@@ -1,1 +1,12 @@
-@* Navigation moved to FluentAppBar in MainLayout *@
+<div class="navmenu">
+    <FluentAppBar>
+        <FluentAppBarItem Href="/workflows"
+                          Text="Workflows"
+                          IconRest="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size24.Flow())"
+                          IconActive="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Filled.Size24.Flow())"/>
+        <FluentAppBarItem Href="/editor"
+                          Text="Editor"
+                          IconRest="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size24.DrawShape())"
+                          IconActive="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Filled.Size24.DrawShape())" />
+    </FluentAppBar>
+</div>

--- a/src/Fleans/Fleans.Web/Components/Layout/NavMenu.razor.css
+++ b/src/Fleans/Fleans.Web/Components/Layout/NavMenu.razor.css
@@ -1,0 +1,4 @@
+.navmenu {
+    height: calc(100vh - 50px);
+    border-right: 1px solid var(--neutral-stroke-rest);
+}

--- a/src/Fleans/Fleans.Web/Components/Shared/PageHeader.razor
+++ b/src/Fleans/Fleans.Web/Components/Shared/PageHeader.razor
@@ -10,7 +10,7 @@
                           Title="Go back"
                           @onclick="HandleGoBack" />
         }
-        <FluentLabel Typo="Typography.EmailHeader">@Title</FluentLabel>
+        <FluentLabel Typo="Typography.PaneHeader">@Title</FluentLabel>
     </FluentStack>
 
     @if (Actions is not null)


### PR DESCRIPTION
Extract FluentAppBar from MainLayout into its own NavMenu component with a 1px right border, and add filled IconActive variants. Also update PageHeader typography from EmailHeader to PaneHeader.