### PR TITLE
refactor: move Start() from StartEvent to WorkflowInstance.StartWorkflow

### DIFF
--- a/src/Fleans/Fleans.Domain/Activities/StartEvent.cs
+++ b/src/Fleans/Fleans.Domain/Activities/StartEvent.cs
@@ -17,7 +17,6 @@ public record StartEvent : Activity
         await base.ExecuteAsync(workflowInstance, activityInstance);
 
         await activityInstance.Complete();
-        await workflowInstance.Start();
         
     }
 

--- a/src/Fleans/Fleans.Domain/IWorkflowInstance.cs
+++ b/src/Fleans/Fleans.Domain/IWorkflowInstance.cs
@@ -29,7 +29,6 @@ public interface IWorkflowInstance : IGrainWithGuidKey
     Task StartWorkflow();        
     Task SetWorkflow(IWorkflowDefinition workflow);
     void EnqueueEvent(IDomainEvent domainEvent);
-    ValueTask Start();
     ValueTask Complete();
 
     [ReadOnly]

--- a/src/Fleans/Fleans.Domain/WorkflowInstance.cs
+++ b/src/Fleans/Fleans.Domain/WorkflowInstance.cs
@@ -44,6 +44,7 @@ public partial class WorkflowInstance : Grain, IWorkflowInstance
         using var scope = BeginWorkflowScope();
         _executionStartedAt = DateTimeOffset.UtcNow;
         LogWorkflowStarted();
+        await Start();
         await ExecuteWorkflow();
     }
 
@@ -139,7 +140,7 @@ public partial class WorkflowInstance : Grain, IWorkflowInstance
         await activityInstance.Fail(exception);
     }
 
-    public ValueTask Start()
+    private ValueTask Start()
         => State.Start();
 
     public async ValueTask Complete()


### PR DESCRIPTION
## Summary
- Moved `await workflowInstance.Start()` from `StartEvent.ExecuteAsync` into `WorkflowInstance.StartWorkflow`
- Removed `Start()` from `IWorkflowInstance` interface (no longer needed externally)
- Made `Start()` private in `WorkflowInstance`

## Test plan
- [x] `dotnet build` passes
- [x] All 142 tests pass (`dotnet test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)