### PR TITLE
Add Architecture Principles section to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,10 @@ dotnet run --project Fleans.Aspire
 
 Add it to `Fleans.Api/Controllers/WorkflowController.cs`. DTOs go in `Fleans.ServiceDefaults/`.
 
+## Architecture Principles
+
+- **Always respect SOLID, DDD, and Clean Architecture principles.** Keep domain logic in `Fleans.Domain` free of infrastructure concerns. Depend on abstractions, not concretions. Ensure single responsibility across classes and methods. Model the domain with aggregates, value objects, and domain events where appropriate.
+
 ## Code Conventions
 
 - Follow existing patterns — records for immutable DTOs, `[GenerateSerializer]` on anything crossing grain boundaries


### PR DESCRIPTION
## Summary
Added a new "Architecture Principles" section to the CLAUDE.md documentation to establish clear guidelines for maintaining code quality and architectural consistency across the Fleans project.

## Changes
- Added "Architecture Principles" section documenting core architectural standards:
  - SOLID, DDD, and Clean Architecture principles
  - Domain logic isolation in `Fleans.Domain` without infrastructure concerns
  - Dependency on abstractions rather than concretions
  - Single responsibility principle enforcement
  - Domain-driven design patterns (aggregates, value objects, domain events)

## Details
This documentation update serves as a reference guide for contributors to ensure the codebase maintains clean architecture practices and proper separation of concerns, particularly around domain logic isolation and dependency management.

https://claude.ai/code/session_01Y3y9VgxGWsKmM1zgidj6GU