### PR TITLE
Remove grain references from WorkflowInstanceState

### DIFF
--- a/src/Fleans/Fleans.Domain/States/ActivityInstanceEntry.cs
+++ b/src/Fleans/Fleans.Domain/States/ActivityInstanceEntry.cs
@@ -1,0 +1,4 @@
+namespace Fleans.Domain.States;
+
+[GenerateSerializer]
+public record ActivityInstanceEntry([property: Id(0)] Guid ActivityInstanceId, [property: Id(1)] string ActivityId);


### PR DESCRIPTION
WorkflowInstanceState stored List<IActivityInstance> (Orleans grain proxies), which breaks serialization/persistence. Replace with List<ActivityInstanceEntry> (a simple serializable record) and move grain-interaction logic to the WorkflowInstance grain. State is now pure data with no async RPC methods.

- Introduce ActivityInstanceEntry record with [GenerateSerializer]
- Make GetFirstActive synchronous (LINQ lookup on entries)
- Move AnyNotExecuting, GetNotExecutingNotCompletedActivities, GetStateSnapshot from state to grain (they need grain factory to resolve references)
- Convert WorkflowInstanceStateTests to pure unit tests (no TestCluster)