### PR TITLE
Replace Activity reference with ID in ActivityInstanceState and fix r…

### DIFF
--- a/src/Fleans/Fleans.Domain.Tests/ErrorHandlingTests.cs
+++ b/src/Fleans/Fleans.Domain.Tests/ErrorHandlingTests.cs
@@ -117,7 +117,7 @@ namespace Fleans.Domain.Tests
         {
             // Arrange
             var activityInstance = _cluster.GrainFactory.GetGrain<IActivityInstance>(Guid.NewGuid());
-            await activityInstance.SetActivity(new TaskActivity("task"));
+            await activityInstance.SetActivity("task", "TaskActivity");
             await activityInstance.Execute();
 
             var exception = new Exception("Test error");
@@ -139,7 +139,7 @@ namespace Fleans.Domain.Tests
         {
             // Arrange
             var activityInstance = _cluster.GrainFactory.GetGrain<IActivityInstance>(Guid.NewGuid());
-            await activityInstance.SetActivity(new TaskActivity("task"));
+            await activityInstance.SetActivity("task", "TaskActivity");
             await activityInstance.Fail(new Exception("Previous error"));
 
             // Act

--- a/src/Fleans/Fleans.Domain.Tests/TaskActivityTests.cs
+++ b/src/Fleans/Fleans.Domain.Tests/TaskActivityTests.cs
@@ -330,7 +330,7 @@ namespace Fleans.Domain.Tests
             // Arrange
             var before = DateTimeOffset.UtcNow;
             var activity = _cluster.GrainFactory.GetGrain<IActivityInstance>(Guid.NewGuid());
-            await activity.SetActivity(new TaskActivity("task"));
+            await activity.SetActivity("task", "TaskActivity");
             var after = DateTimeOffset.UtcNow;
 
             // Act
@@ -347,7 +347,7 @@ namespace Fleans.Domain.Tests
         {
             // Arrange
             var activity = _cluster.GrainFactory.GetGrain<IActivityInstance>(Guid.NewGuid());
-            await activity.SetActivity(new TaskActivity("task"));
+            await activity.SetActivity("task", "TaskActivity");
 
             // Act
             var executionStartedAt = await activity.GetExecutionStartedAt();
@@ -404,7 +404,7 @@ namespace Fleans.Domain.Tests
         {
             // Arrange
             var activity = _cluster.GrainFactory.GetGrain<IActivityInstance>(Guid.NewGuid());
-            await activity.SetActivity(new TaskActivity("task"));
+            await activity.SetActivity("task", "TaskActivity");
 
             // Act
             var completedAt = await activity.GetCompletedAt();

--- a/src/Fleans/Fleans.Domain.Tests/WorkflowInstanceStateTests.cs
+++ b/src/Fleans/Fleans.Domain.Tests/WorkflowInstanceStateTests.cs
@@ -1,5 +1,3 @@
-using Fleans.Domain.Activities;
-using Fleans.Domain.Sequences;
 using Fleans.Domain.States;
 using System.Dynamic;
 
@@ -53,7 +51,7 @@ namespace Fleans.Domain.Tests
             state.Start();
 
             // Assert
-            Assert.IsTrue(state.IsStarted());
+            Assert.IsTrue(state.IsStarted);
         }
 
         [TestMethod]
@@ -80,7 +78,7 @@ namespace Fleans.Domain.Tests
             state.Complete();
 
             // Assert
-            Assert.IsTrue(state.IsCompleted());
+            Assert.IsTrue(state.IsCompleted);
         }
 
         [TestMethod]
@@ -210,16 +208,10 @@ namespace Fleans.Domain.Tests
         {
             // Arrange
             var state = new WorkflowInstanceState();
-            var source = new TaskActivity("task1");
-            var target = new TaskActivity("task2");
             var activityInstanceId = Guid.NewGuid();
-            var sequences = new[]
-            {
-                new ConditionalSequenceFlow("seq1", source, target, "x > 0")
-            };
 
             // Act
-            state.AddConditionSequenceStates(activityInstanceId, sequences);
+            state.AddConditionSequenceStates(activityInstanceId, new[] { "seq1" });
 
             // Assert
             var conditionStates = state.GetConditionSequenceStates();
@@ -232,14 +224,8 @@ namespace Fleans.Domain.Tests
         {
             // Arrange
             var state = new WorkflowInstanceState();
-            var source = new TaskActivity("task1");
-            var target = new TaskActivity("task2");
             var activityInstanceId = Guid.NewGuid();
-            var sequences = new[]
-            {
-                new ConditionalSequenceFlow("seq1", source, target, "x > 0")
-            };
-            state.AddConditionSequenceStates(activityInstanceId, sequences);
+            state.AddConditionSequenceStates(activityInstanceId, new[] { "seq1" });
 
             // Act
             state.SetConditionSequenceResult(activityInstanceId, "seq1", true);
@@ -254,17 +240,11 @@ namespace Fleans.Domain.Tests
         {
             // Arrange
             var state = new WorkflowInstanceState();
-            var source = new TaskActivity("task1");
-            var target = new TaskActivity("task2");
             var activityInstanceId = Guid.NewGuid();
-            var sequences = new[]
-            {
-                new ConditionalSequenceFlow("seq1", source, target, "x > 0")
-            };
-            state.AddConditionSequenceStates(activityInstanceId, sequences);
+            state.AddConditionSequenceStates(activityInstanceId, new[] { "seq1" });
 
             // Act & Assert
-            Assert.ThrowsExactly<NullReferenceException>(() =>
+            Assert.ThrowsExactly<InvalidOperationException>(() =>
             {
                 state.SetConditionSequenceResult(activityInstanceId, "non-existent", true);
             });

--- a/src/Fleans/Fleans.Domain/Activities/ExclusiveGateway.cs
+++ b/src/Fleans/Fleans.Domain/Activities/ExclusiveGateway.cs
@@ -28,13 +28,14 @@ public record ExclusiveGateway : ConditionalGateway
 
     private static async Task<IEnumerable<ConditionalSequenceFlow>> AddConditionalSequencesToWorkflowInstance(IWorkflowInstance workflowInstance, IActivityInstance activityInstance)
     {
-        var currentActivity = await activityInstance.GetCurrentActivity();
+        var activityId = await activityInstance.GetActivityId();
 
         var sequences = (await workflowInstance.GetWorkflowDefinition()).SequenceFlows.OfType<ConditionalSequenceFlow>()
-                                .Where(sf => sf.Source.ActivityId == currentActivity.ActivityId)
+                                .Where(sf => sf.Source.ActivityId == activityId)
                                 .ToArray();
 
-        await workflowInstance.AddConditionSequenceStates(await activityInstance.GetActivityInstanceId(), sequences);
+        var sequenceFlowIds = sequences.Select(s => s.SequenceFlowId).ToArray();
+        await workflowInstance.AddConditionSequenceStates(await activityInstance.GetActivityInstanceId(), sequenceFlowIds);
         return sequences;
     }
 

--- a/src/Fleans/Fleans.Domain/Activities/ParallelGateway.cs
+++ b/src/Fleans/Fleans.Domain/Activities/ParallelGateway.cs
@@ -60,7 +60,7 @@ public record ParallelGateway : Gateway
         {
             foreach (var completedActivity in completedActivities)
             {
-                if (await completedActivity.GetCurrentActivity() == incomingFlow.Source)
+                if (await completedActivity.GetActivityId() == incomingFlow.Source.ActivityId)
                 {
                     if(! await completedActivity.IsCompleted())
                     {
@@ -71,7 +71,7 @@ public record ParallelGateway : Gateway
 
             foreach (var activeActivity in activeActivities)
             {
-                if (await activeActivity.GetCurrentActivity() == incomingFlow.Source)
+                if (await activeActivity.GetActivityId() == incomingFlow.Source.ActivityId)
                 {
                     any = true;
                 }

--- a/src/Fleans/Fleans.Domain/ActivityInstance.cs
+++ b/src/Fleans/Fleans.Domain/ActivityInstance.cs
@@ -1,5 +1,4 @@
 
-using Fleans.Domain.Activities;
 using Fleans.Domain.Events;
 using Fleans.Domain.States;
 using Microsoft.Extensions.Logging;
@@ -49,7 +48,7 @@ namespace Fleans.Domain
 
         public ValueTask<Guid> GetActivityInstanceId() => ValueTask.FromResult(this.GetPrimaryKey());
 
-        public ValueTask<Activity> GetCurrentActivity() => ValueTask.FromResult(State.CurrentActivity!);
+        public ValueTask<string> GetActivityId() => ValueTask.FromResult(State.ActivityId!);
 
         public ValueTask<ActivityErrorState?> GetErrorState() => ValueTask.FromResult(State.ErrorState);
 
@@ -75,9 +74,9 @@ namespace Fleans.Domain
             await _state.WriteStateAsync();
         }
 
-        public async ValueTask SetActivity(Activity nextActivity)
+        public async ValueTask SetActivity(string activityId, string activityType)
         {
-            State.SetActivity(nextActivity);
+            State.SetActivity(activityId, activityType);
             await _state.WriteStateAsync();
         }
 

--- a/src/Fleans/Fleans.Domain/IActivityInstance.cs
+++ b/src/Fleans/Fleans.Domain/IActivityInstance.cs
@@ -1,4 +1,3 @@
-using Fleans.Domain.Activities;
 using Fleans.Domain.Events;
 using Orleans.Concurrency;
 
@@ -10,7 +9,7 @@ namespace Fleans.Domain
         ValueTask<Guid> GetActivityInstanceId();
 
         [ReadOnly]
-        ValueTask<Activity> GetCurrentActivity();
+        ValueTask<string> GetActivityId();
 
         [ReadOnly]
         ValueTask<ActivityErrorState?> GetErrorState();
@@ -39,7 +38,7 @@ namespace Fleans.Domain
         ValueTask Complete();
         ValueTask Fail(Exception exception);
         ValueTask Execute();
-        ValueTask SetActivity(Activity nextActivity);
+        ValueTask SetActivity(string activityId, string activityType);
         ValueTask SetVariablesId(Guid guid);
         Task PublishEvent(IDomainEvent domainEvent);
     }

--- a/src/Fleans/Fleans.Domain/IWorkflowInstance.cs
+++ b/src/Fleans/Fleans.Domain/IWorkflowInstance.cs
@@ -1,5 +1,4 @@
 using Fleans.Domain.Activities;
-using Fleans.Domain.Sequences;
 using Fleans.Domain.States;
 using Orleans;
 using Orleans.Concurrency;
@@ -41,6 +40,6 @@ public interface IWorkflowInstance : IGrainWithGuidKey
     ValueTask<IReadOnlyList<IActivityInstance>> GetCompletedActivities();
     [ReadOnly]
     ValueTask<IReadOnlyDictionary<Guid, ConditionSequenceState[]>> GetConditionSequenceStates();
-    ValueTask AddConditionSequenceStates(Guid activityInstanceId, ConditionalSequenceFlow[] sequences);
+    ValueTask AddConditionSequenceStates(Guid activityInstanceId, string[] sequenceFlowIds);
     ValueTask SetConditionSequenceResult(Guid activityInstanceId, string sequenceId, bool result);
 }

--- a/src/Fleans/Fleans.Domain/States/ActivityInstanceState.cs
+++ b/src/Fleans/Fleans.Domain/States/ActivityInstanceState.cs
@@ -1,18 +1,35 @@
-using Fleans.Domain.Activities;
 using Fleans.Domain.Errors;
 
 namespace Fleans.Domain.States;
 
-// TODO: Add [GenerateSerializer] and [Id] attributes before implementing real storage.
+[GenerateSerializer]
 public class ActivityInstanceState
 {
-    public Activity? CurrentActivity { get; private set; }
+    [Id(0)]
+    public string? ActivityId { get; private set; }
+
+    [Id(1)]
+    public string? ActivityType { get; private set; }
+
+    [Id(2)]
     public bool IsExecuting { get; private set; }
+
+    [Id(3)]
     public bool IsCompleted { get; private set; }
+
+    [Id(4)]
     public Guid VariablesId { get; private set; }
+
+    [Id(5)]
     public ActivityErrorState? ErrorState { get; private set; }
+
+    [Id(6)]
     public DateTimeOffset? CreatedAt { get; private set; }
+
+    [Id(7)]
     public DateTimeOffset? ExecutionStartedAt { get; private set; }
+
+    [Id(8)]
     public DateTimeOffset? CompletedAt { get; private set; }
 
     public void Complete()
@@ -38,16 +55,17 @@ public class ActivityInstanceState
         ExecutionStartedAt = DateTimeOffset.UtcNow;
     }
 
-    public void SetActivity(Activity activity)
+    public void SetActivity(string activityId, string activityType)
     {
-        CurrentActivity = activity;
+        ActivityId = activityId;
+        ActivityType = activityType;
         CreatedAt = DateTimeOffset.UtcNow;
     }
 
     public void SetVariablesId(Guid id) => VariablesId = id;
 
     public ActivityInstanceSnapshot GetSnapshot(Guid grainId) =>
-        new(grainId, CurrentActivity!.ActivityId, CurrentActivity.GetType().Name,
+        new(grainId, ActivityId!, ActivityType!,
             IsCompleted, IsExecuting, VariablesId, ErrorState,
             CreatedAt, ExecutionStartedAt, CompletedAt);
 }

--- a/src/Fleans/Fleans.Domain/States/WorkflowInstanceState.cs
+++ b/src/Fleans/Fleans.Domain/States/WorkflowInstanceState.cs
@@ -1,99 +1,112 @@
-using Fleans.Domain.Sequences;
 using System.Dynamic;
 
 namespace Fleans.Domain.States;
 
-// TODO: Add [GenerateSerializer] and [Id] attributes before implementing real storage.
-// Fields must become public properties for Orleans serialization.
+[GenerateSerializer]
 public class WorkflowInstanceState
 {
-    private readonly List<ActivityInstanceEntry> _activeActivities = new();
-    private readonly List<ActivityInstanceEntry> _completedActivities = new();
-    private readonly Dictionary<Guid, WorklfowVariablesState> _variableStates = new();
-    private readonly Dictionary<Guid, ConditionSequenceState[]> _conditionSequenceStates = new();
-    private bool _isStarted;
-    private bool _isCompleted;
+    [Id(0)]
+    public List<ActivityInstanceEntry> ActiveActivities { get; private set; } = new();
 
+    [Id(1)]
+    public List<ActivityInstanceEntry> CompletedActivities { get; private set; } = new();
+
+    [Id(2)]
+    public Dictionary<Guid, WorkflowVariablesState> VariableStates { get; private set; } = new();
+
+    [Id(3)]
+    public Dictionary<Guid, ConditionSequenceState[]> ConditionSequenceStates { get; private set; } = new();
+
+    [Id(4)]
+    public bool IsStarted { get; private set; }
+
+    [Id(5)]
+    public bool IsCompleted { get; private set; }
+
+    [Id(6)]
     public Guid InstanceId { get; internal set; }
+
+    [Id(7)]
     public DateTimeOffset? CreatedAt { get; internal set; }
+
+    [Id(8)]
     public DateTimeOffset? ExecutionStartedAt { get; internal set; }
+
+    [Id(9)]
     public DateTimeOffset? CompletedAt { get; internal set; }
 
-    public bool IsStarted() => _isStarted;
-    public bool IsCompleted() => _isCompleted;
-
     public IReadOnlyList<ActivityInstanceEntry> GetCompletedActivities()
-        => _completedActivities;
+        => CompletedActivities;
 
-    public IReadOnlyDictionary<Guid, WorklfowVariablesState> GetVariableStates()
-        => _variableStates;
+    public IReadOnlyDictionary<Guid, WorkflowVariablesState> GetVariableStates()
+        => VariableStates;
 
     public IReadOnlyDictionary<Guid, ConditionSequenceState[]> GetConditionSequenceStates()
-        => _conditionSequenceStates;
+        => ConditionSequenceStates;
 
     public IReadOnlyList<ActivityInstanceEntry> GetActiveActivities()
-        => _activeActivities;
+        => ActiveActivities;
 
     public void StartWith(ActivityInstanceEntry entry, Guid variablesId)
     {
-        _variableStates.Add(variablesId, new WorklfowVariablesState());
-        _activeActivities.Add(entry);
+        VariableStates.Add(variablesId, new WorkflowVariablesState());
+        ActiveActivities.Add(entry);
     }
 
     public void Start()
     {
-        if (_isStarted)
+        if (IsStarted)
             throw new InvalidOperationException("Workflow is already started");
 
-        _isStarted = true;
+        IsStarted = true;
     }
 
     public void Complete()
     {
-        if (_isCompleted)
+        if (IsCompleted)
             throw new InvalidOperationException("Workflow is already completed");
 
-        _isCompleted = true;
+        IsCompleted = true;
     }
 
     public Guid AddCloneOfVariableState(Guid variableStateId)
     {
-        var clonedState = new WorklfowVariablesState();
-        clonedState.CloneWithNewIdFrom(_variableStates[variableStateId]);
+        var clonedState = new WorkflowVariablesState();
+        clonedState.CloneWithNewIdFrom(VariableStates[variableStateId]);
 
-        _variableStates.Add(clonedState.Id, clonedState);
+        VariableStates.Add(clonedState.Id, clonedState);
         return clonedState.Id;
     }
 
-    public void AddConditionSequenceStates(Guid activityInstanceId, ConditionalSequenceFlow[] sequences)
+    public void AddConditionSequenceStates(Guid activityInstanceId, string[] sequenceFlowIds)
     {
-        var sequenceStates = sequences.Select(sequence => new ConditionSequenceState(sequence.SequenceFlowId)).ToArray();
-        _conditionSequenceStates.Add(activityInstanceId, sequenceStates);
+        var sequenceStates = sequenceFlowIds.Select(id => new ConditionSequenceState(id)).ToArray();
+        ConditionSequenceStates.Add(activityInstanceId, sequenceStates);
     }
 
     public void RemoveActiveActivities(List<ActivityInstanceEntry> removeEntries)
     {
-        _activeActivities.RemoveAll(removeEntries.Contains);
+        ActiveActivities.RemoveAll(removeEntries.Contains);
     }
 
     public void AddActiveActivities(IEnumerable<ActivityInstanceEntry> entries)
     {
-        _activeActivities.AddRange(entries);
+        ActiveActivities.AddRange(entries);
     }
 
     public void AddCompletedActivities(IEnumerable<ActivityInstanceEntry> entries)
     {
-        _completedActivities.AddRange(entries);
+        CompletedActivities.AddRange(entries);
     }
 
     public ActivityInstanceEntry? GetFirstActive(string activityId)
     {
-        return _activeActivities.FirstOrDefault(a => a.ActivityId == activityId);
+        return ActiveActivities.FirstOrDefault(a => a.ActivityId == activityId);
     }
 
     public void SetConditionSequenceResult(Guid activityInstanceId, string sequenceId, bool result)
     {
-        var sequences = _conditionSequenceStates[activityInstanceId];
+        var sequences = ConditionSequenceStates[activityInstanceId];
 
         var sequence = sequences.FirstOrDefault(s => s.ConditionalSequenceFlowId == sequenceId);
 
@@ -103,12 +116,12 @@ public class WorkflowInstanceState
         }
         else
         {
-            throw new NullReferenceException("Sequence not found");
+            throw new InvalidOperationException("Sequence not found");
         }
     }
 
     public void MergeState(Guid variablesId, ExpandoObject variables)
     {
-        _variableStates[variablesId].Merge(variables);
+        VariableStates[variablesId].Merge(variables);
     }
 }

--- a/src/Fleans/Fleans.Domain/States/WorkflowVariablesState.cs
+++ b/src/Fleans/Fleans.Domain/States/WorkflowVariablesState.cs
@@ -3,7 +3,7 @@
 namespace Fleans.Domain.States;
 
 [GenerateSerializer]
-public class WorklfowVariablesState
+public class WorkflowVariablesState
 {
     [Id(0)]
     public Guid Id { get; private set; }
@@ -16,7 +16,7 @@ public class WorklfowVariablesState
     {
         Variables = Combine(Variables, variables) ;
     }
-    internal void CloneWithNewIdFrom(WorklfowVariablesState source)
+    internal void CloneWithNewIdFrom(WorkflowVariablesState source)
     {
         Merge(source.Variables);
         Id = Guid.NewGuid();

--- a/src/Fleans/Fleans.Domain/Workflow.cs
+++ b/src/Fleans/Fleans.Domain/Workflow.cs
@@ -16,11 +16,12 @@ namespace Fleans.Domain
         string? ProcessDefinitionId { get; }
         List<Activity> Activities { get; }
         List<SequenceFlow> SequenceFlows { get; }
+        Activity GetActivity(string activityId);
     }
    
     public interface ICondition
     {
-        bool Evaluate(WorklfowVariablesState worklfowVariablesState);
+        bool Evaluate(WorkflowVariablesState worklfowVariablesState);
     }
 
     [GenerateSerializer]
@@ -37,5 +38,8 @@ namespace Fleans.Domain
 
         [Id(3)]
         public string? ProcessDefinitionId { get; init; }
+
+        public Activity GetActivity(string activityId)
+            => Activities.First(a => a.ActivityId == activityId);
     }
 }


### PR DESCRIPTION
…eview issues

Replace Activity? CurrentActivity with string ActivityId + ActivityType in ActivityInstanceState, decoupling grain state serialization from the Activity hierarchy. Add [GenerateSerializer]/[Id] attributes to both state classes, fix NullReferenceException misuse, add GetStateSnapshot null guard, change AddConditionSequenceStates to accept string[] IDs, and rename WorklfowVariablesState → WorkflowVariablesState.