### PR TITLE
Introduce separate EF entity for ActivityInstanceState

### DIFF
--- a/src/Fleans/Fleans.Domain/States/ActivityInstanceState.cs
+++ b/src/Fleans/Fleans.Domain/States/ActivityInstanceState.cs
@@ -6,37 +6,31 @@ namespace Fleans.Domain.States;
 public class ActivityInstanceState
 {
     [Id(0)]
-    public string? ActivityId { get; private set; }
+    public string? ActivityId { get; internal set; }
 
     [Id(1)]
-    public string? ActivityType { get; private set; }
+    public string? ActivityType { get; internal set; }
 
     [Id(2)]
-    public bool IsExecuting { get; private set; }
+    public bool IsExecuting { get; internal set; }
 
     [Id(3)]
-    public bool IsCompleted { get; private set; }
+    public bool IsCompleted { get; internal set; }
 
     [Id(4)]
-    public Guid VariablesId { get; private set; }
+    public Guid VariablesId { get; internal set; }
 
     [Id(5)]
-    public ActivityErrorState? ErrorState { get; private set; }
+    public ActivityErrorState? ErrorState { get; internal set; }
 
     [Id(6)]
-    public DateTimeOffset? CreatedAt { get; private set; }
+    public DateTimeOffset? CreatedAt { get; internal set; }
 
     [Id(7)]
-    public DateTimeOffset? ExecutionStartedAt { get; private set; }
+    public DateTimeOffset? ExecutionStartedAt { get; internal set; }
 
     [Id(8)]
-    public DateTimeOffset? CompletedAt { get; private set; }
-
-    [Id(9)]
-    public Guid Id { get; internal set; }
-
-    [Id(10)]
-    public string? ETag { get; internal set; }
+    public DateTimeOffset? CompletedAt { get; internal set; }
 
     public void Complete()
     {

--- a/src/Fleans/Fleans.Persistence/Entities/ActivityInstanceEntity.cs
+++ b/src/Fleans/Fleans.Persistence/Entities/ActivityInstanceEntity.cs
@@ -1,0 +1,17 @@
+namespace Fleans.Persistence.Entities;
+
+public class ActivityInstanceEntity
+{
+    public Guid Id { get; set; }
+    public string? ActivityId { get; set; }
+    public string? ActivityType { get; set; }
+    public bool IsExecuting { get; set; }
+    public bool IsCompleted { get; set; }
+    public Guid VariablesId { get; set; }
+    public int? ErrorCode { get; set; }
+    public string? ErrorMessage { get; set; }
+    public DateTimeOffset? CreatedAt { get; set; }
+    public DateTimeOffset? ExecutionStartedAt { get; set; }
+    public DateTimeOffset? CompletedAt { get; set; }
+    public string? ETag { get; set; }
+}

--- a/src/Fleans/Fleans.Persistence/GrainStateDbContext.cs
+++ b/src/Fleans/Fleans.Persistence/GrainStateDbContext.cs
@@ -1,5 +1,4 @@
 using System.Dynamic;
-using Fleans.Domain.States;
 using Fleans.Persistence.Entities;
 using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
@@ -8,7 +7,7 @@ namespace Fleans.Persistence;
 
 public class GrainStateDbContext : DbContext
 {
-    public DbSet<ActivityInstanceState> ActivityInstances => Set<ActivityInstanceState>();
+    public DbSet<ActivityInstanceEntity> ActivityInstances => Set<ActivityInstanceEntity>();
     public DbSet<WorkflowInstanceEntity> WorkflowInstances => Set<WorkflowInstanceEntity>();
     public DbSet<ActivityInstanceEntryEntity> WorkflowActivityInstanceEntries => Set<ActivityInstanceEntryEntity>();
     public DbSet<WorkflowVariablesEntity> WorkflowVariableStates => Set<WorkflowVariablesEntity>();
@@ -18,7 +17,7 @@ public class GrainStateDbContext : DbContext
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        modelBuilder.Entity<ActivityInstanceState>(entity =>
+        modelBuilder.Entity<ActivityInstanceEntity>(entity =>
         {
             entity.ToTable("ActivityInstances");
             entity.HasKey(e => e.Id);
@@ -32,11 +31,8 @@ public class GrainStateDbContext : DbContext
             entity.Property(e => e.ActivityType)
                 .HasMaxLength(256);
 
-            entity.OwnsOne(e => e.ErrorState, error =>
-            {
-                error.Property(e => e.Code).HasColumnName("ErrorCode");
-                error.Property(e => e.Message).HasColumnName("ErrorMessage").HasMaxLength(2000);
-            });
+            entity.Property(e => e.ErrorMessage)
+                .HasMaxLength(2000);
         });
 
         modelBuilder.Entity<WorkflowInstanceEntity>(entity =>


### PR DESCRIPTION
## Summary
- Introduces `ActivityInstanceEntity` as a dedicated EF Core persistence class, decoupling `ActivityInstanceState` from database concerns
- Removes `Id` and `ETag` properties from the domain class, flattens `ErrorState` into `ErrorCode`/`ErrorMessage` columns on the entity
- Rewrites `EfCoreActivityInstanceGrainStorage` with `MapToEntity`/`MapToDomain` methods, matching the existing `WorkflowInstanceEntity` pattern

## Test plan
- [x] All 191 existing tests pass unchanged (build + `dotnet test`)
- [x] 17 persistence-specific tests in `EfCoreActivityInstanceGrainStorageTests` cover round-trips, ETag concurrency, error state CRUD, timestamps, isolation, and re-creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)