### PR TITLE
Add end-to-end tests for event stream consumer handlers

### DIFF
--- a/src/Fleans/Fleans.Application.Tests/EventPublisherTests.cs
+++ b/src/Fleans/Fleans.Application.Tests/EventPublisherTests.cs
@@ -1,97 +1,180 @@
+using Fleans.Application.Conditions;
+using Fleans.Application.Events;
+using Fleans.Application.Scripts;
+using Fleans.Domain;
 using Fleans.Domain.Activities;
 using Fleans.Domain.Sequences;
-using Fleans.Domain;
-using Orleans.TestingHost;
-using Fleans.Application.Events;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Orleans.Serialization;
+using Orleans.TestingHost;
 using System.Dynamic;
 
-namespace Fleans.Application.Tests
+namespace Fleans.Application.Tests;
+
+[TestClass]
+public class EventPublisherTests
 {
-    [TestClass]
-    public class EventPublisherTests
+    private TestCluster _cluster = null!;
+
+    [TestInitialize]
+    public void Setup()
     {
-        private IWorkflowDefinition _workflow = null!;
-        private TestCluster _cluster;
+        _cluster = CreateCluster();
+    }
 
-        [TestInitialize]
-        public void Setup()
+    [TestCleanup]
+    public void Cleanup()
+    {
+        _cluster?.StopAllSilos();
+    }
+
+    [TestMethod]
+    public async Task ConsumeEvent_ConditionHandler_ShouldEvaluateAndCompleteWorkflow()
+    {
+        // Arrange
+        var workflow = CreateWorkflowWithExclusiveGateway();
+        var workflowInstance = _cluster.GrainFactory.GetGrain<IWorkflowInstance>(Guid.NewGuid());
+        await workflowInstance.SetWorkflow(workflow);
+
+        // Act
+        await workflowInstance.StartWorkflow();
+
+        // Assert — stream handler evaluates "true" condition and completes the workflow
+        var snapshot = await PollForCompletion(workflowInstance);
+        Assert.IsTrue(snapshot.IsCompleted);
+        CollectionAssert.Contains(snapshot.CompletedActivityIds, "start");
+        CollectionAssert.Contains(snapshot.CompletedActivityIds, "if");
+        CollectionAssert.Contains(snapshot.CompletedActivityIds, "end1");
+        Assert.AreEqual(0, snapshot.ActiveActivities.Count);
+    }
+
+    [TestMethod]
+    public async Task ConsumeEvent_ScriptHandler_ShouldExecuteAndCompleteWorkflow()
+    {
+        // Arrange
+        var workflow = CreateWorkflowWithScriptTask();
+        var workflowInstance = _cluster.GrainFactory.GetGrain<IWorkflowInstance>(Guid.NewGuid());
+        await workflowInstance.SetWorkflow(workflow);
+
+        // Act
+        await workflowInstance.StartWorkflow();
+
+        // Assert — stream handler executes script and completes the workflow
+        var snapshot = await PollForCompletion(workflowInstance);
+        Assert.IsTrue(snapshot.IsCompleted);
+        CollectionAssert.Contains(snapshot.CompletedActivityIds, "start");
+        CollectionAssert.Contains(snapshot.CompletedActivityIds, "script1");
+        CollectionAssert.Contains(snapshot.CompletedActivityIds, "end");
+        Assert.AreEqual(0, snapshot.ActiveActivities.Count);
+    }
+
+    private static async Task<InstanceStateSnapshot> PollForCompletion(
+        IWorkflowInstance workflowInstance, int timeoutMs = 10000)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTime.UtcNow < deadline)
         {
-            _workflow = CreateSimpleWorkflowWithExclusiveGateway();
-            _cluster = CreateCluster();
+            var snapshot = await workflowInstance.GetStateSnapshot();
+            if (snapshot.IsCompleted)
+                return snapshot;
+            await Task.Delay(100);
         }
 
-        [TestMethod]
-        public async Task ConsumeEventTest()
+        return await workflowInstance.GetStateSnapshot();
+    }
+
+    private static IWorkflowDefinition CreateWorkflowWithExclusiveGateway()
+    {
+        var start = new StartEvent("start");
+        var end1 = new EndEvent("end1");
+        var end2 = new EndEvent("end2");
+        var ifActivity = new ExclusiveGateway("if");
+
+        return new WorkflowDefinition
         {
-            // Arrange
-            //             
-            var testWF = _cluster.GrainFactory.GetGrain<IWorkflowInstance>(Guid.NewGuid());
-                        
-            // Act
-            await testWF.SetWorkflow(_workflow);
-            await testWF.StartWorkflow();
+            WorkflowId = "workflow1",
+            Activities = [start, ifActivity, end1, end2],
+            SequenceFlows =
+            [
+                new SequenceFlow("seq1", start, ifActivity),
+                new ConditionalSequenceFlow("seq2", ifActivity, end1, "true"),
+                new DefaultSequenceFlow("seqDefault", ifActivity, end2)
+            ]
+        };
+    }
 
-            //TODO test consumer IWorkflowEventsHandler
-        }
+    private static IWorkflowDefinition CreateWorkflowWithScriptTask()
+    {
+        var start = new StartEvent("start");
+        var script = new ScriptTask("script1", "_context.x = 10");
+        var end = new EndEvent("end");
 
-        private static TestCluster CreateCluster()
+        return new WorkflowDefinition
         {
-            var builder = new TestClusterBuilder();
+            WorkflowId = "workflow2",
+            Activities = [start, script, end],
+            SequenceFlows =
+            [
+                new SequenceFlow("seq1", start, script),
+                new SequenceFlow("seq2", script, end)
+            ]
+        };
+    }
 
-            builder.AddSiloBuilderConfigurator<SiloConfigurator>();
-            builder.AddClientBuilderConfigurator<ClientConfiguretor>();
+    private static TestCluster CreateCluster()
+    {
+        var builder = new TestClusterBuilder();
+        builder.AddSiloBuilderConfigurator<SiloConfigurator>();
+        builder.AddClientBuilderConfigurator<ClientConfigurator>();
+        var cluster = builder.Build();
+        cluster.Deploy();
+        return cluster;
+    }
 
-            var cluster = builder.Build();
-            cluster.Deploy();
-            return cluster;
-        }
+    private class SiloConfigurator : ISiloConfigurator
+    {
+        public void Configure(ISiloBuilder hostBuilder) =>
+            hostBuilder
+                .AddMemoryStreams(WorkflowEventsPublisher.StreamProvider)
+                .AddMemoryGrainStorage("PubSubStore")
+                .AddMemoryGrainStorage("workflowInstances")
+                .AddMemoryGrainStorage("activityInstances")
+                .ConfigureServices(services =>
+                {
+                    services.AddSingleton<IConditionExpressionEvaluator, SimpleConditionEvaluator>();
+                    services.AddSingleton<IScriptExpressionExecutor, SimpleScriptExecutor>();
+                    services.AddSerializer(serializerBuilder =>
+                    {
+                        serializerBuilder.AddNewtonsoftJsonSerializer(
+                            isSupported: type => type == typeof(ExpandoObject),
+                            new Newtonsoft.Json.JsonSerializerSettings
+                            {
+                                TypeNameHandling = Newtonsoft.Json.TypeNameHandling.All
+                            });
+                    });
+                });
+    }
 
-        private static IWorkflowDefinition CreateSimpleWorkflowWithExclusiveGateway()
+    private class ClientConfigurator : IClientBuilderConfigurator
+    {
+        public void Configure(IConfiguration configuration, IClientBuilder clientBuilder) =>
+            clientBuilder.AddMemoryStreams(WorkflowEventsPublisher.StreamProvider);
+    }
+
+    private class SimpleConditionEvaluator : IConditionExpressionEvaluator
+    {
+        public Task<bool> Evaluate(string expression, ExpandoObject variables)
         {
-            var start = new StartEvent("start");
-            var end1 = new EndEvent("end1");
-            var end2 = new EndEvent("end2");
-            var ifActivity = new ExclusiveGateway("if");
-
-            var workflow = new WorkflowDefinition { WorkflowId = "workflow1", Activities = new List<Domain.Activities.Activity>(), SequenceFlows = new List<SequenceFlow>() };
-            workflow.Activities.Add(start);
-            workflow.Activities.Add(end1);
-            workflow.Activities.Add(end2);
-            workflow.Activities.Add(ifActivity);
-
-            workflow.SequenceFlows.Add(new SequenceFlow("seq1", start, ifActivity));
-            workflow.SequenceFlows.Add(new ConditionalSequenceFlow("seq2", ifActivity, end1, "trueCondition"));
-            workflow.SequenceFlows.Add(new ConditionalSequenceFlow("seq3", ifActivity, end2, "falseCondition"));
-            return workflow;
-        }
-
-        private class SiloConfigurator : ISiloConfigurator
-        {
-            public void Configure(ISiloBuilder hostBuilder) =>
-               hostBuilder.AddMemoryStreams(WorkflowEventsPublisher.StreamProvider)
-                          .AddMemoryGrainStorage("PubSubStore")
-                          .AddMemoryGrainStorage("workflowInstances")
-                          .AddMemoryGrainStorage("activityInstances")
-                            //.ConfigureServices(services => services.AddSerializer(serializerBuilder =>
-                            //{
-                            //    serializerBuilder.AddNewtonsoftJsonSerializer(
-                            //        isSupported: type => type == typeof(ExpandoObject), new Newtonsoft.Json.JsonSerializerSettings
-                            //        {
-                            //            TypeNameHandling = Newtonsoft.Json.TypeNameHandling.All
-                            //        });
-                            //}))
-                ;
-        }
-
-        private class ClientConfiguretor : IClientBuilderConfigurator
-        {
-            public void Configure(IConfiguration configuration, IClientBuilder clientBuilder) =>
-              clientBuilder.AddMemoryStreams(WorkflowEventsPublisher.StreamProvider);
+            return Task.FromResult(string.Equals(expression, "true", StringComparison.OrdinalIgnoreCase));
         }
     }
 
-  
-
+    private class SimpleScriptExecutor : IScriptExpressionExecutor
+    {
+        public Task<ExpandoObject> Execute(string script, ExpandoObject variables, string scriptFormat)
+        {
+            return Task.FromResult(variables);
+        }
+    }
 }


### PR DESCRIPTION
Implement the TODO to test IWorkflowEventsHandler consumers. The tests
verify the full event pipeline: activity publishes event to Orleans
stream, handler grain receives it, processes it, and calls back to
advance the workflow.

- ConsumeEvent_ConditionHandler: ExclusiveGateway publishes
  EvaluateConditionEvent, handler evaluates condition via stream,
  workflow completes through the true branch
- ConsumeEvent_ScriptHandler: ScriptTask publishes ExecuteScriptEvent,
  handler executes script via stream, workflow completes

Also fixes the SiloConfigurator to register required services
(IConditionExpressionEvaluator, IScriptExpressionExecutor) and enables
Newtonsoft JSON serialization for ExpandoObject (was commented out).

https://claude.ai/code/session_01PZAfh8US11gL9EMrhqq2dr