### PR TITLE
Restore domain types as records for immutability

### DIFF
--- a/docs/plans/2026-02-15-records-restoration-design.md
+++ b/docs/plans/2026-02-15-records-restoration-design.md
@@ -1,0 +1,140 @@
+# Design: Restore Domain Types as Records
+
+**Goal:** Convert JSON-serialized domain types back to records with `init` setters for immutability. `ProcessDefinition` stays as a class (EF Core entity).
+
+---
+
+## Scope
+
+14 types converted from `class` back to `record`:
+
+| Layer | Types | Pattern |
+|-------|-------|---------|
+| Activities (10) | `Activity`, `StartEvent`, `EndEvent`, `TaskActivity`, `ScriptTask`, `Gateway`, `ConditionalGateway`, `ExclusiveGateway`, `ParallelGateway`, `ErrorEvent` | Positional `record` with constructor params |
+| Sequences (3) | `SequenceFlow`, `ConditionalSequenceFlow`, `DefaultSequenceFlow` | Positional `record` with constructor params |
+| Definitions (1) | `WorkflowDefinition` | `record` with `required init` properties |
+
+**Stays as class:** `ProcessDefinition` — mapped as EF Core entity, needs mutable `set`.
+
+---
+
+## Why This Is Safe
+
+- Newtonsoft.Json matches constructor parameters by name — no need for `set` accessors
+- `PreserveReferencesHandling.Objects` preserves shared Activity references across JSON round-trip
+- Orleans `[GenerateSerializer]` works with records
+- No `with` expressions exist in the codebase
+- Value equality from records is safe — activities in a workflow graph are unique by property values
+
+---
+
+## Activity Hierarchy
+
+```csharp
+[GenerateSerializer]
+public abstract record Activity([property: Id(0)] string ActivityId)
+{
+    internal virtual async Task ExecuteAsync(...) { ... }
+    internal virtual Task<List<Activity>> GetNextActivities(...) { ... }
+}
+
+[GenerateSerializer]
+public record StartEvent(string ActivityId) : Activity(ActivityId);
+
+[GenerateSerializer]
+public record EndEvent(string ActivityId) : Activity(ActivityId);
+
+[GenerateSerializer]
+public record TaskActivity(string ActivityId) : Activity(ActivityId);
+
+[GenerateSerializer]
+public record ScriptTask(
+    string ActivityId,
+    [property: Id(1)] string Script,
+    [property: Id(2)] string ScriptFormat = "csharp") : TaskActivity(ActivityId);
+
+[GenerateSerializer]
+public record ErrorEvent(string ActivityId) : Activity(ActivityId);
+
+[GenerateSerializer]
+public abstract record Gateway(string ActivityId) : Activity(ActivityId);
+
+[GenerateSerializer]
+public abstract record ConditionalGateway(string ActivityId) : Gateway(ActivityId);
+
+[GenerateSerializer]
+public record ExclusiveGateway(string ActivityId) : ConditionalGateway(ActivityId);
+
+[GenerateSerializer]
+public record ParallelGateway(
+    string ActivityId,
+    [property: Id(1)] bool IsFork) : Gateway(ActivityId);
+```
+
+---
+
+## SequenceFlow Hierarchy
+
+```csharp
+[GenerateSerializer]
+public record SequenceFlow(
+    [property: Id(0)] string SequenceFlowId,
+    [property: Id(1)] Activity Source,
+    [property: Id(2)] Activity Target);
+
+[GenerateSerializer]
+public record ConditionalSequenceFlow(
+    string SequenceFlowId,
+    Activity Source,
+    Activity Target,
+    [property: Id(3)] string Condition) : SequenceFlow(SequenceFlowId, Source, Target);
+
+[GenerateSerializer]
+public record DefaultSequenceFlow(
+    string SequenceFlowId,
+    Activity Source,
+    Activity Target) : SequenceFlow(SequenceFlowId, Source, Target);
+```
+
+---
+
+## WorkflowDefinition
+
+Uses `required init` properties (not positional) — constructed via object initializer:
+
+```csharp
+[GenerateSerializer]
+public record WorkflowDefinition : IWorkflowDefinition
+{
+    [Id(0)]
+    public required string WorkflowId { get; init; }
+
+    [Id(1)]
+    public required List<Activity> Activities { get; init; }
+
+    [Id(2)]
+    public required List<SequenceFlow> SequenceFlows { get; init; }
+
+    [Id(3)]
+    public string? ProcessDefinitionId { get; init; }
+
+    public Activity GetActivity(string activityId)
+        => Activities.First(a => a.ActivityId == activityId);
+}
+```
+
+---
+
+## Notable: ScriptTask Orleans `[Id]` renumbering
+
+The old class-based `ScriptTask` had `Script` as `[Id(0)]` and `ScriptFormat` as `[Id(1)]`. The base `Activity` also uses `[Id(0)]` for `ActivityId` — this was an ID collision in the Orleans serialization hierarchy. The record conversion fixes this: `Script` is now `[Id(1)]`, `ScriptFormat` is `[Id(2)]`. Safe because grain state is in-memory only and EF Core persistence uses Newtonsoft.Json (matches by parameter name, not Orleans `[Id]` ordinal).
+
+---
+
+## Verification
+
+```bash
+cd src/Fleans && dotnet build && dotnet test
+```
+
+All 195 tests must pass, especially EF Core persistence tests verifying JSON round-trip with polymorphic types and shared references.

--- a/src/Fleans/Fleans.Domain.Tests/ParallelGatewayTests.cs
+++ b/src/Fleans/Fleans.Domain.Tests/ParallelGatewayTests.cs
@@ -65,7 +65,7 @@ namespace Fleans.Domain.Tests
         {
             // Arrange — workflow: start -> fork -> task1/task2/task3
             var start = new StartEvent("start");
-            var fork = new ParallelGateway("fork", isFork: true);
+            var fork = new ParallelGateway("fork", IsFork: true);
             var task1 = new TaskActivity("task1");
             var task2 = new TaskActivity("task2");
             var task3 = new TaskActivity("task3");
@@ -111,10 +111,10 @@ namespace Fleans.Domain.Tests
         private static IWorkflowDefinition CreateForkJoinWorkflow()
         {
             var start = new StartEvent("start");
-            var fork = new ParallelGateway("fork", isFork: true);
+            var fork = new ParallelGateway("fork", IsFork: true);
             var task1 = new TaskActivity("task1");
             var task2 = new TaskActivity("task2");
-            var join = new ParallelGateway("join", isFork: false);
+            var join = new ParallelGateway("join", IsFork: false);
             var end = new EndEvent("end");
 
             return new WorkflowDefinition

--- a/src/Fleans/Fleans.Domain/Activities/Activity.cs
+++ b/src/Fleans/Fleans.Domain/Activities/Activity.cs
@@ -7,16 +7,8 @@ using Orleans;
 namespace Fleans.Domain.Activities;
 
 [GenerateSerializer]
-public abstract class Activity
+public abstract record Activity([property: Id(0)] string ActivityId)
 {
-    [Id(0)]
-    public string ActivityId { get; set; }
-
-    protected Activity(string activityId)
-    {
-        ActivityId = activityId;
-    }
-
     internal virtual async Task ExecuteAsync(IWorkflowInstance workflowInstance, IActivityInstance activityInstance)
     {
         var defintion = await workflowInstance.GetWorkflowDefinition();

--- a/src/Fleans/Fleans.Domain/Activities/ConditionalGateway.cs
+++ b/src/Fleans/Fleans.Domain/Activities/ConditionalGateway.cs
@@ -3,12 +3,8 @@ using Fleans.Domain.Sequences;
 namespace Fleans.Domain.Activities;
 
 [GenerateSerializer]
-public abstract class ConditionalGateway : Gateway
+public abstract record ConditionalGateway(string ActivityId) : Gateway(ActivityId)
 {
-    protected ConditionalGateway(string ActivityId) : base(ActivityId)
-    {
-    }
-
     internal async Task<bool> SetConditionResult(
         IWorkflowInstance workflowInstance,
         IActivityInstance activityInstance,

--- a/src/Fleans/Fleans.Domain/Activities/EndEvent.cs
+++ b/src/Fleans/Fleans.Domain/Activities/EndEvent.cs
@@ -6,13 +6,8 @@ using System.Runtime.CompilerServices;
 namespace Fleans.Domain.Activities;
 
 [GenerateSerializer]
-public class EndEvent : Activity
+public record EndEvent(string ActivityId) : Activity(ActivityId)
 {
-    public EndEvent(string activityId) : base(activityId)
-    { 
-        ActivityId = activityId;
-    }
-
     internal override async Task ExecuteAsync(IWorkflowInstance workflowInstance, IActivityInstance activityState)
     {
         await base.ExecuteAsync(workflowInstance, activityState);

--- a/src/Fleans/Fleans.Domain/Activities/ErrorEvent.cs
+++ b/src/Fleans/Fleans.Domain/Activities/ErrorEvent.cs
@@ -1,15 +1,8 @@
-
-
-
 namespace Fleans.Domain.Activities;
 
 [GenerateSerializer]
-public class ErrorEvent : Activity
+public record ErrorEvent(string ActivityId) : Activity(ActivityId)
 {
-    public ErrorEvent(string ActivityId) : base(ActivityId)
-    {
-    }
-
     internal override async Task ExecuteAsync(IWorkflowInstance workflowInstance, IActivityInstance activityState)
     {
         await base.ExecuteAsync(workflowInstance, activityState);

--- a/src/Fleans/Fleans.Domain/Activities/ExclusiveGateway.cs
+++ b/src/Fleans/Fleans.Domain/Activities/ExclusiveGateway.cs
@@ -4,13 +4,8 @@ using Fleans.Domain.Sequences;
 namespace Fleans.Domain.Activities;
 
 [GenerateSerializer]
-public class ExclusiveGateway : ConditionalGateway
+public record ExclusiveGateway(string ActivityId) : ConditionalGateway(ActivityId)
 {
-    public ExclusiveGateway(string activityId) : base(activityId)
-    {
-        ActivityId = activityId;
-    }
-
     internal override async Task ExecuteAsync(IWorkflowInstance workflowInstance, IActivityInstance activityInstance)
     {
         await base.ExecuteAsync(workflowInstance, activityInstance);

--- a/src/Fleans/Fleans.Domain/Activities/Gateway.cs
+++ b/src/Fleans/Fleans.Domain/Activities/Gateway.cs
@@ -1,9 +1,4 @@
 namespace Fleans.Domain.Activities;
 
 [GenerateSerializer]
-public abstract class Gateway : Activity
-{
-    protected Gateway(string ActivityId) : base(ActivityId)
-    {
-    }
-}
+public abstract record Gateway(string ActivityId) : Activity(ActivityId);

--- a/src/Fleans/Fleans.Domain/Activities/ParallelGateway.cs
+++ b/src/Fleans/Fleans.Domain/Activities/ParallelGateway.cs
@@ -6,16 +6,10 @@ using System.Runtime.CompilerServices;
 namespace Fleans.Domain.Activities;
 
 [GenerateSerializer]
-public class ParallelGateway : Gateway
+public record ParallelGateway(
+    string ActivityId,
+    [property: Id(1)] bool IsFork) : Gateway(ActivityId)
 {
-    [Id(1)]
-    public bool IsFork { get; set; }
-
-    public ParallelGateway(string ActivityId, bool isFork) : base(ActivityId)
-    {
-        IsFork = isFork;
-    }
-
     internal override async Task ExecuteAsync(IWorkflowInstance workflowInstance, IActivityInstance activityState)
     {
         await base.ExecuteAsync(workflowInstance, activityState);

--- a/src/Fleans/Fleans.Domain/Activities/ScriptTask.cs
+++ b/src/Fleans/Fleans.Domain/Activities/ScriptTask.cs
@@ -3,13 +3,13 @@ using Fleans.Domain.Events;
 namespace Fleans.Domain.Activities;
 
 [GenerateSerializer]
-public class ScriptTask : TaskActivity
+public record ScriptTask : TaskActivity
 {
-    [Id(0)]
-    public string Script { get; set; }
-
     [Id(1)]
-    public string ScriptFormat { get; set; }
+    public string Script { get; init; }
+
+    [Id(2)]
+    public string ScriptFormat { get; init; }
 
     public ScriptTask(string ActivityId, string Script, string ScriptFormat = "csharp") : base(ActivityId)
     {

--- a/src/Fleans/Fleans.Domain/Activities/StartEvent.cs
+++ b/src/Fleans/Fleans.Domain/Activities/StartEvent.cs
@@ -6,12 +6,8 @@ using System.Runtime.CompilerServices;
 namespace Fleans.Domain.Activities;
 
 [GenerateSerializer]
-public class StartEvent : Activity
+public record StartEvent(string ActivityId) : Activity(ActivityId)
 {
-    public StartEvent(string activityId): base(activityId)
-    {
-        ActivityId = activityId;
-    }
     internal override async Task ExecuteAsync(IWorkflowInstance workflowInstance, IActivityInstance activityInstance)
     {
         await base.ExecuteAsync(workflowInstance, activityInstance);

--- a/src/Fleans/Fleans.Domain/Activities/TaskActivity.cs
+++ b/src/Fleans/Fleans.Domain/Activities/TaskActivity.cs
@@ -1,4 +1,3 @@
-﻿
 
 using System.Runtime.CompilerServices;
 [assembly:InternalsVisibleTo("Fleans.Domain.Tests")]
@@ -6,12 +5,8 @@ using System.Runtime.CompilerServices;
 namespace Fleans.Domain.Activities;
 
 [GenerateSerializer]
-public class TaskActivity : Activity
+public record TaskActivity(string ActivityId) : Activity(ActivityId)
 {
-    public TaskActivity(string ActivityId) : base(ActivityId)
-    {
-    }
-
     internal override async Task<List<Activity>> GetNextActivities(IWorkflowInstance workflowInstance, IActivityInstance state)
     {
         var definition = await workflowInstance.GetWorkflowDefinition();

--- a/src/Fleans/Fleans.Domain/Definitions/Workflow.cs
+++ b/src/Fleans/Fleans.Domain/Definitions/Workflow.cs
@@ -25,19 +25,19 @@ namespace Fleans.Domain
     }
 
     [GenerateSerializer]
-    public class WorkflowDefinition : IWorkflowDefinition
+    public record WorkflowDefinition : IWorkflowDefinition
     {
         [Id(0)]
-        public required string WorkflowId { get; set; }
+        public required string WorkflowId { get; init; }
 
         [Id(1)]
-        public required List<Activity> Activities { get; set; }
+        public required List<Activity> Activities { get; init; }
 
         [Id(2)]
-        public required List<SequenceFlow> SequenceFlows { get; set; }
+        public required List<SequenceFlow> SequenceFlows { get; init; }
 
         [Id(3)]
-        public string? ProcessDefinitionId { get; set; }
+        public string? ProcessDefinitionId { get; init; }
 
         public Activity GetActivity(string activityId)
             => Activities.First(a => a.ActivityId == activityId);

--- a/src/Fleans/Fleans.Domain/Sequences/ConditionalSequenceFlow.cs
+++ b/src/Fleans/Fleans.Domain/Sequences/ConditionalSequenceFlow.cs
@@ -1,17 +1,10 @@
-﻿using Fleans.Domain.Activities;
+using Fleans.Domain.Activities;
 
 namespace Fleans.Domain.Sequences;
 
-
 [GenerateSerializer]
-public class ConditionalSequenceFlow : SequenceFlow
-{
-    [Id(3)]
-    public string Condition { get; set; }
-
-    public ConditionalSequenceFlow(string sequencId, Activity source, Activity target, string condition)
-        : base(sequencId, source, target)
-    {
-        Condition = condition;
-    }
-}
+public record ConditionalSequenceFlow(
+    string SequenceFlowId,
+    Activity Source,
+    Activity Target,
+    [property: Id(3)] string Condition) : SequenceFlow(SequenceFlowId, Source, Target);

--- a/src/Fleans/Fleans.Domain/Sequences/DefaultSequenceFlow.cs
+++ b/src/Fleans/Fleans.Domain/Sequences/DefaultSequenceFlow.cs
@@ -3,10 +3,7 @@ using Fleans.Domain.Activities;
 namespace Fleans.Domain.Sequences;
 
 [GenerateSerializer]
-public class DefaultSequenceFlow : SequenceFlow
-{
-    public DefaultSequenceFlow(string sequenceFlowId, Activity source, Activity target)
-        : base(sequenceFlowId, source, target)
-    {
-    }
-}
+public record DefaultSequenceFlow(
+    string SequenceFlowId,
+    Activity Source,
+    Activity Target) : SequenceFlow(SequenceFlowId, Source, Target);

--- a/src/Fleans/Fleans.Domain/Sequences/SequenceFlow.cs
+++ b/src/Fleans/Fleans.Domain/Sequences/SequenceFlow.cs
@@ -1,23 +1,9 @@
-﻿using Fleans.Domain.Activities;
+using Fleans.Domain.Activities;
 
 namespace Fleans.Domain.Sequences;
 
 [GenerateSerializer]
-public class SequenceFlow
-{
-    [Id(0)]
-    public string SequenceFlowId { get; set; }
-
-    [Id(1)]
-    public Activity Source { get; set; }
-
-    [Id(2)]
-    public Activity Target { get; set; }
-
-    public SequenceFlow(string sequenceFlowId, Activity source, Activity target)
-    {
-        SequenceFlowId = sequenceFlowId;
-        Source = source;
-        Target = target;
-    }
-}
+public record SequenceFlow(
+    [property: Id(0)] string SequenceFlowId,
+    [property: Id(1)] Activity Source,
+    [property: Id(2)] Activity Target);

--- a/src/Fleans/Fleans.Infrastructure/Bpmn/BpmnConverter.cs
+++ b/src/Fleans/Fleans.Infrastructure/Bpmn/BpmnConverter.cs
@@ -158,7 +158,7 @@ public partial class BpmnConverter : IBpmnConverter
                     "Mixed parallel gateways (both join and fork) are not supported. " +
                     "Split into separate join and fork gateways.");
             }
-            var activity = new ParallelGateway(id, isFork);
+            var activity = new ParallelGateway(id, IsFork: isFork);
             activities.Add(activity);
             activityMap[id] = activity;
         }


### PR DESCRIPTION
## Summary
- Convert 14 JSON-serialized domain types back from `class` to `record` with `init` setters for immutability
- Activity hierarchy (10 types) and SequenceFlow hierarchy (3 types) use positional records
- `WorkflowDefinition` uses `record` with `required init` properties
- `ScriptTask` uses non-positional record to preserve `ArgumentNullException` validation
- `ProcessDefinition` stays as class (EF Core entity)
- Fixes pre-existing Orleans `[Id]` collision on `ScriptTask` (base and derived both used `[Id(0)]`)

## Test plan
- [x] All 195 tests pass (Domain: 90, Persistence: 52, Infrastructure: 40, Application: 13)
- [x] Build succeeds with zero errors
- [x] EF Core JSON round-trip tests pass (polymorphic types + shared references)

🤖 Generated with [Claude Code](https://claude.com/claude-code)