### PR TITLE
Fix Web UI not seeing deployed workflows

### DIFF
--- a/src/Fleans/Fleans.Aspire/Program.cs
+++ b/src/Fleans/Fleans.Aspire/Program.cs
@@ -1,5 +1,9 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
+// Shared SQLite database file for EF Core persistence (dev only)
+var sqliteDbPath = Path.Combine(Path.GetTempPath(), "fleans-dev.db");
+var sqliteConnectionString = $"DataSource={sqliteDbPath}";
+
 // Add Redis for Orleans clustering and storage
 var redis = builder.AddRedis("redis");
 
@@ -15,10 +19,12 @@ var redis = builder.AddRedis("redis");
 
 builder.AddProject<Projects.Fleans_Api>("fleans")
        .WithReference(redis)
+       .WithEnvironment("FLEANS_SQLITE_CONNECTION", sqliteConnectionString)
        .WithReplicas(1);
 
 builder.AddProject<Projects.Fleans_Web>("fleans-client")
        .WithReference(redis)
+       .WithEnvironment("FLEANS_SQLITE_CONNECTION", sqliteConnectionString)
        .WithReplicas(1);
 
 // Reference the Orleans resource as a client from the 'frontend'

--- a/src/Fleans/Fleans.Web/Fleans.Web.csproj
+++ b/src/Fleans/Fleans.Web/Fleans.Web.csproj
@@ -15,6 +15,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.1" />
       <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.13.2" />
       <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Emoji" Version="4.13.2" />
       <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.13.2" />


### PR DESCRIPTION
## Summary
- Api and Web each had separate in-memory SQLite databases — Web query service always read from an empty DB
- Switch both to a shared file-based SQLite, path passed via `FLEANS_SQLITE_CONNECTION` env var from Aspire
- Wire up missing `AddEfCorePersistence()` + `EnsureCreated()` in the Web project
- Remove unused `SqliteConnectionLifetime` and `Microsoft.Data.Sqlite.Core` packages

## Test plan
- [x] All 206 tests pass
- [ ] Deploy a BPMN workflow via Api, verify it appears in Web UI Workflows page

🤖 Generated with [Claude Code](https://claude.com/claude-code)