### PR TITLE
Remove dead ICondition interface from Domain

### DIFF
--- a/src/Fleans/Fleans.Domain/Definitions/Workflow.cs
+++ b/src/Fleans/Fleans.Domain/Definitions/Workflow.cs
@@ -6,7 +6,6 @@ using System.Text;
 using System.Threading.Tasks;
 using Fleans.Domain.Activities;
 using Fleans.Domain.Sequences;
-using Fleans.Domain.States;
 
 namespace Fleans.Domain
 {
@@ -19,11 +18,6 @@ namespace Fleans.Domain
         Activity GetActivity(string activityId);
     }
    
-    public interface ICondition
-    {
-        bool Evaluate(WorkflowVariablesState worklfowVariablesState);
-    }
-
     [GenerateSerializer]
     public record WorkflowDefinition : IWorkflowDefinition
     {


### PR DESCRIPTION
## Summary
- Remove unused `ICondition` interface from `Workflow.cs` — it was never implemented or referenced anywhere
- Conditions are handled via `IConditionExpressionEvaluator` in the Application layer
- Remove now-unused `using Fleans.Domain.States` import

## Test plan
- [x] Solution builds with 0 errors
- [x] All 202 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)