### PR TITLE
Add ProcessDefinitionGrain and EfCore grain storage for process defin…

### DIFF
--- a/docs/plans/2026-02-13-process-definition-grain.md
+++ b/docs/plans/2026-02-13-process-definition-grain.md
@@ -1,0 +1,46 @@
+# ProcessDefinitionGrain — Separate grain for workflow definitions
+
+## Problem
+
+`WorkflowInstance` holds `WorkflowDefinition` as an in-memory property that is lost on grain deactivation. Only `ProcessDefinitionId` survives in `WorkflowInstanceState`. After reactivation, the grain has no way to restore its definition.
+
+## Decision
+
+Introduce a read-only `ProcessDefinitionGrain` keyed by `ProcessDefinitionId`. `WorkflowInstance` lazy-loads the definition from this grain on first use after reactivation.
+
+### Why a separate grain (not embedded in WorkflowInstanceState)
+
+- Definitions are immutable and shared across many instances — no need to duplicate per instance.
+- Fits the grain-per-entity model: one grain per deployed definition.
+- Reuses `EfCoreProcessDefinitionGrainStorage` already in place.
+
+## Design
+
+### ProcessDefinitionGrain
+
+- **Key:** string (`ProcessDefinitionId`)
+- **State:** `ProcessDefinition` via `[PersistentState("state", "processDefinitions")]`
+- **Interface:** `IProcessDefinitionGrain : IGrainWithStringKey`
+  - `Task<WorkflowDefinition> GetDefinition()` — returns `_state.State.Workflow` (not the full `ProcessDefinition`, to avoid sending `BpmnXml` across grain boundaries)
+- **Read-only:** Factory writes definitions via `IProcessDefinitionRepository`; the grain only reads.
+
+### WorkflowInstance changes
+
+- Add `GetWorkflowDefinitionAsync()` that returns cached `WorkflowDefinition` or lazy-loads from `ProcessDefinitionGrain`.
+- `SetWorkflow()` still sets `WorkflowDefinition` directly on first creation.
+- All call sites that read `WorkflowDefinition` switch to `await GetWorkflowDefinitionAsync()`.
+- Remove the TODO comment.
+
+### What stays unchanged
+
+- `WorkflowInstanceFactoryGrain` — writes via repository, caches in memory.
+- `EfCoreProcessDefinitionRepository` — the write path.
+- `WorkflowInstanceState` — already has `ProcessDefinitionId`.
+
+## Files
+
+| File | Action |
+|------|--------|
+| `Fleans.Application/Grains/IProcessDefinitionGrain.cs` | Create |
+| `Fleans.Application/Grains/ProcessDefinitionGrain.cs` | Create |
+| `Fleans.Application/Grains/WorkflowInstance.cs` | Modify — lazy loading |

--- a/src/Fleans/Fleans.Application/Grains/IProcessDefinitionGrain.cs
+++ b/src/Fleans/Fleans.Application/Grains/IProcessDefinitionGrain.cs
@@ -1,0 +1,8 @@
+using Fleans.Domain;
+
+namespace Fleans.Application.Grains;
+
+public interface IProcessDefinitionGrain : IGrainWithStringKey
+{
+    Task<WorkflowDefinition> GetDefinition();
+}

--- a/src/Fleans/Fleans.Application/Grains/ProcessDefinitionGrain.cs
+++ b/src/Fleans/Fleans.Application/Grains/ProcessDefinitionGrain.cs
@@ -1,0 +1,35 @@
+using Fleans.Domain;
+using Microsoft.Extensions.Logging;
+using Orleans.Runtime;
+
+namespace Fleans.Application.Grains;
+
+public partial class ProcessDefinitionGrain : Grain, IProcessDefinitionGrain
+{
+    private readonly IPersistentState<ProcessDefinition> _state;
+    private readonly ILogger<ProcessDefinitionGrain> _logger;
+
+    public ProcessDefinitionGrain(
+        [PersistentState("state", "processDefinitions")] IPersistentState<ProcessDefinition> state,
+        ILogger<ProcessDefinitionGrain> logger)
+    {
+        _state = state;
+        _logger = logger;
+    }
+
+    public Task<WorkflowDefinition> GetDefinition()
+    {
+        if (!_state.RecordExists)
+        {
+            LogDefinitionNotFound(this.GetPrimaryKeyString());
+            throw new KeyNotFoundException(
+                $"Process definition '{this.GetPrimaryKeyString()}' not found.");
+        }
+
+        return Task.FromResult(_state.State.Workflow);
+    }
+
+    [LoggerMessage(EventId = 7000, Level = LogLevel.Warning,
+        Message = "Process definition '{ProcessDefinitionId}' not found in storage")]
+    private partial void LogDefinitionNotFound(string processDefinitionId);
+}

--- a/src/Fleans/Fleans.Domain/Definitions/ProcessDefinition.cs
+++ b/src/Fleans/Fleans.Domain/Definitions/ProcessDefinition.cs
@@ -34,4 +34,7 @@ public sealed class ProcessDefinition
 
     [Id(5)]
     public required string BpmnXml { get; set; }
+
+    [Id(6)]
+    public string? ETag { get; set; }
 }

--- a/src/Fleans/Fleans.Persistence.Tests/EfCoreActivityInstanceGrainStorageTests.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/EfCoreActivityInstanceGrainStorageTests.cs
@@ -370,26 +370,4 @@ public class EfCoreActivityInstanceGrainStorageTests
 
     private static TestGrainState<ActivityInstanceState> CreateGrainState()
         => new() { State = new ActivityInstanceState() };
-
-    private class TestGrainState<T> : IGrainState<T> where T : new()
-    {
-        public T State { get; set; } = new();
-        public string? ETag { get; set; }
-        public bool RecordExists { get; set; }
-    }
-
-    private class TestDbContextFactory : IDbContextFactory<FleanCommandDbContext>
-    {
-        private readonly DbContextOptions<FleanCommandDbContext> _options;
-
-        public TestDbContextFactory(DbContextOptions<FleanCommandDbContext> options)
-        {
-            _options = options;
-        }
-
-        public FleanCommandDbContext CreateDbContext() => new(_options);
-
-        public Task<FleanCommandDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default)
-            => Task.FromResult(CreateDbContext());
-    }
 }

--- a/src/Fleans/Fleans.Persistence.Tests/EfCoreProcessDefinitionGrainStorageTests.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/EfCoreProcessDefinitionGrainStorageTests.cs
@@ -1,0 +1,338 @@
+using Fleans.Domain;
+using Fleans.Domain.Activities;
+using Fleans.Domain.Sequences;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Orleans.Runtime;
+using Orleans.Storage;
+
+namespace Fleans.Persistence.Tests;
+
+[TestClass]
+public class EfCoreProcessDefinitionGrainStorageTests
+{
+    private SqliteConnection _connection = null!;
+    private IDbContextFactory<FleanCommandDbContext> _dbContextFactory = null!;
+    private EfCoreProcessDefinitionGrainStorage _storage = null!;
+    private const string StateName = "state";
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        var options = new DbContextOptionsBuilder<FleanCommandDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        _dbContextFactory = new TestDbContextFactory(options);
+        _storage = new EfCoreProcessDefinitionGrainStorage(_dbContextFactory);
+
+        using var db = _dbContextFactory.CreateDbContext();
+        db.Database.EnsureCreated();
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        _connection.Dispose();
+    }
+
+    [TestMethod]
+    public async Task WriteAndRead_RoundTrip_ReturnsStoredState()
+    {
+        var id = "myProcess:1:ts";
+        var grainId = NewGrainId(id);
+        var state = CreateGrainState(id, "myProcess", 1);
+        var deployedAt = state.State.DeployedAt;
+
+        await _storage.WriteStateAsync(StateName, grainId, state);
+        Assert.IsNotNull(state.ETag);
+        Assert.IsTrue(state.RecordExists);
+
+        var readState = CreateEmptyGrainState();
+        await _storage.ReadStateAsync(StateName, grainId, readState);
+
+        Assert.AreEqual(id, readState.State.ProcessDefinitionId);
+        Assert.AreEqual("myProcess", readState.State.ProcessDefinitionKey);
+        Assert.AreEqual(1, readState.State.Version);
+        Assert.AreEqual(deployedAt, readState.State.DeployedAt);
+        Assert.AreEqual("<bpmn/>", readState.State.BpmnXml);
+        Assert.AreEqual(state.ETag, readState.ETag);
+        Assert.IsTrue(readState.RecordExists);
+    }
+
+    [TestMethod]
+    public async Task WriteAndRead_RoundTrip_WorkflowJsonPreserved()
+    {
+        var id = "poly:1:ts";
+        var grainId = NewGrainId(id);
+        var state = CreateGrainStateWithMixedActivities(id);
+
+        await _storage.WriteStateAsync(StateName, grainId, state);
+
+        var readState = CreateEmptyGrainState();
+        await _storage.ReadStateAsync(StateName, grainId, readState);
+
+        var workflow = readState.State.Workflow;
+        Assert.AreEqual(4, workflow.Activities.Count);
+        Assert.IsInstanceOfType<StartEvent>(workflow.Activities[0]);
+        Assert.IsInstanceOfType<ScriptTask>(workflow.Activities[1]);
+        Assert.IsInstanceOfType<ExclusiveGateway>(workflow.Activities[2]);
+        Assert.IsInstanceOfType<EndEvent>(workflow.Activities[3]);
+
+        Assert.AreEqual(4, workflow.SequenceFlows.Count);
+        Assert.IsInstanceOfType<ConditionalSequenceFlow>(workflow.SequenceFlows[1]);
+        Assert.IsInstanceOfType<DefaultSequenceFlow>(workflow.SequenceFlows[3]);
+    }
+
+    [TestMethod]
+    public async Task Write_WithCorrectETag_Succeeds()
+    {
+        var id = "upd:1:ts";
+        var grainId = NewGrainId(id);
+        var state = CreateGrainState(id, "upd", 1);
+        await _storage.WriteStateAsync(StateName, grainId, state);
+        var firstETag = state.ETag;
+
+        state.State.BpmnXml = "<bpmn updated/>";
+        await _storage.WriteStateAsync(StateName, grainId, state);
+
+        Assert.AreNotEqual(firstETag, state.ETag);
+
+        var readState = CreateEmptyGrainState();
+        await _storage.ReadStateAsync(StateName, grainId, readState);
+        Assert.AreEqual("<bpmn updated/>", readState.State.BpmnXml);
+    }
+
+    [TestMethod]
+    public async Task Write_WithStaleETag_ThrowsInconsistentStateException()
+    {
+        var id = "stale:1:ts";
+        var grainId = NewGrainId(id);
+        var state = CreateGrainState(id, "stale", 1);
+        await _storage.WriteStateAsync(StateName, grainId, state);
+
+        var concurrentState = CreateEmptyGrainState();
+        await _storage.ReadStateAsync(StateName, grainId, concurrentState);
+        concurrentState.State.BpmnXml = "<concurrent/>";
+        await _storage.WriteStateAsync(StateName, grainId, concurrentState);
+
+        state.State.BpmnXml = "<stale/>";
+        await Assert.ThrowsExactlyAsync<InconsistentStateException>(
+            () => _storage.WriteStateAsync(StateName, grainId, state));
+    }
+
+    [TestMethod]
+    public async Task FirstWrite_WithoutETag_Succeeds()
+    {
+        var id = "first:1:ts";
+        var grainId = NewGrainId(id);
+        var state = CreateGrainState(id, "first", 1);
+        Assert.IsNull(state.ETag);
+
+        await _storage.WriteStateAsync(StateName, grainId, state);
+
+        Assert.IsNotNull(state.ETag);
+        Assert.IsTrue(state.RecordExists);
+    }
+
+    [TestMethod]
+    public async Task Write_WithStaleETagToNonExistentKey_ThrowsInconsistentStateException()
+    {
+        var grainId = NewGrainId("nope:1:ts");
+        var state = CreateGrainState("nope:1:ts", "nope", 1);
+        state.ETag = "stale-etag";
+
+        await Assert.ThrowsExactlyAsync<InconsistentStateException>(
+            () => _storage.WriteStateAsync(StateName, grainId, state));
+    }
+
+    [TestMethod]
+    public async Task Clear_RemovesState_SubsequentReadReturnsDefault()
+    {
+        var id = "clr:1:ts";
+        var grainId = NewGrainId(id);
+        var state = CreateGrainState(id, "clr", 1);
+        await _storage.WriteStateAsync(StateName, grainId, state);
+
+        await _storage.ClearStateAsync(StateName, grainId, state);
+        Assert.IsNull(state.ETag);
+        Assert.IsFalse(state.RecordExists);
+
+        var readState = CreateEmptyGrainState();
+        await _storage.ReadStateAsync(StateName, grainId, readState);
+        Assert.IsNull(readState.ETag);
+        Assert.IsFalse(readState.RecordExists);
+    }
+
+    [TestMethod]
+    public async Task Clear_WithStaleETag_ThrowsInconsistentStateException()
+    {
+        var id = "clrstale:1:ts";
+        var grainId = NewGrainId(id);
+        var state = CreateGrainState(id, "clrstale", 1);
+        await _storage.WriteStateAsync(StateName, grainId, state);
+
+        var concurrentState = CreateEmptyGrainState();
+        await _storage.ReadStateAsync(StateName, grainId, concurrentState);
+        concurrentState.State.BpmnXml = "<concurrent/>";
+        await _storage.WriteStateAsync(StateName, grainId, concurrentState);
+
+        await Assert.ThrowsExactlyAsync<InconsistentStateException>(
+            () => _storage.ClearStateAsync(StateName, grainId, state));
+    }
+
+    [TestMethod]
+    public async Task Clear_NonExistentGrain_IsNoOp()
+    {
+        var grainId = NewGrainId("noop:1:ts");
+        var state = CreateEmptyGrainState();
+
+        await _storage.ClearStateAsync(StateName, grainId, state);
+
+        Assert.IsNull(state.ETag);
+        Assert.IsFalse(state.RecordExists);
+    }
+
+    [TestMethod]
+    public async Task Read_NonExistentKey_LeavesStateUnchanged()
+    {
+        var grainId = NewGrainId("missing:1:ts");
+        var state = CreateEmptyGrainState();
+
+        await _storage.ReadStateAsync(StateName, grainId, state);
+
+        Assert.IsNull(state.ETag);
+        Assert.IsFalse(state.RecordExists);
+    }
+
+    [TestMethod]
+    public async Task DifferentGrainIds_AreIsolated()
+    {
+        var id1 = "iso1:1:ts";
+        var id2 = "iso2:1:ts";
+        var grainId1 = NewGrainId(id1);
+        var grainId2 = NewGrainId(id2);
+
+        var state1 = CreateGrainState(id1, "iso1", 1);
+        var state2 = CreateGrainState(id2, "iso2", 2);
+
+        await _storage.WriteStateAsync(StateName, grainId1, state1);
+        await _storage.WriteStateAsync(StateName, grainId2, state2);
+
+        var read1 = CreateEmptyGrainState();
+        var read2 = CreateEmptyGrainState();
+        await _storage.ReadStateAsync(StateName, grainId1, read1);
+        await _storage.ReadStateAsync(StateName, grainId2, read2);
+
+        Assert.AreEqual("iso1", read1.State.ProcessDefinitionKey);
+        Assert.AreEqual(1, read1.State.Version);
+        Assert.AreEqual("iso2", read2.State.ProcessDefinitionKey);
+        Assert.AreEqual(2, read2.State.Version);
+    }
+
+    [TestMethod]
+    public async Task WriteClearWrite_ReCreatesSameGrainId()
+    {
+        var id = "recreate:1:ts";
+        var grainId = NewGrainId(id);
+        var state = CreateGrainState(id, "recreate", 1);
+        await _storage.WriteStateAsync(StateName, grainId, state);
+
+        await _storage.ClearStateAsync(StateName, grainId, state);
+
+        var newState = CreateGrainState(id, "recreate", 2);
+        await _storage.WriteStateAsync(StateName, grainId, newState);
+
+        var readState = CreateEmptyGrainState();
+        await _storage.ReadStateAsync(StateName, grainId, readState);
+
+        Assert.AreEqual("recreate", readState.State.ProcessDefinitionKey);
+        Assert.AreEqual(2, readState.State.Version);
+        Assert.IsTrue(readState.RecordExists);
+    }
+
+    private static GrainId NewGrainId(string key)
+        => GrainId.Create("processDefinition", key);
+
+    private static TestGrainState<ProcessDefinition> CreateGrainState(
+        string id, string key, int version)
+    {
+        var start = new StartEvent("start");
+        var end = new EndEvent("end");
+        var flow = new SequenceFlow("flow1", start, end);
+
+        return new TestGrainState<ProcessDefinition>
+        {
+            State = new ProcessDefinition
+            {
+                ProcessDefinitionId = id,
+                ProcessDefinitionKey = key,
+                Version = version,
+                DeployedAt = DateTimeOffset.UtcNow,
+                BpmnXml = "<bpmn/>",
+                Workflow = new WorkflowDefinition
+                {
+                    WorkflowId = key,
+                    ProcessDefinitionId = id,
+                    Activities = [start, end],
+                    SequenceFlows = [flow]
+                }
+            }
+        };
+    }
+
+    private static TestGrainState<ProcessDefinition> CreateGrainStateWithMixedActivities(string id)
+    {
+        var start = new StartEvent("start");
+        var script = new ScriptTask("script1", "return 42;", "csharp");
+        var gateway = new ExclusiveGateway("gw1");
+        var end = new EndEvent("end");
+
+        var flow1 = new SequenceFlow("flow1", start, script);
+        var condFlow1 = new ConditionalSequenceFlow("condFlow1", gateway, end, "x > 10");
+        var condFlow2 = new ConditionalSequenceFlow("condFlow2", gateway, script, "x <= 10");
+        var defaultFlow = new DefaultSequenceFlow("defaultFlow", gateway, end);
+
+        return new TestGrainState<ProcessDefinition>
+        {
+            State = new ProcessDefinition
+            {
+                ProcessDefinitionId = id,
+                ProcessDefinitionKey = "poly",
+                Version = 1,
+                DeployedAt = DateTimeOffset.UtcNow,
+                BpmnXml = "<bpmn:definitions/>",
+                Workflow = new WorkflowDefinition
+                {
+                    WorkflowId = "poly",
+                    ProcessDefinitionId = id,
+                    Activities = [start, script, gateway, end],
+                    SequenceFlows = [flow1, condFlow1, condFlow2, defaultFlow]
+                }
+            }
+        };
+    }
+
+    private static TestGrainState<ProcessDefinition> CreateEmptyGrainState()
+        => new()
+        {
+            State = new ProcessDefinition
+            {
+                ProcessDefinitionId = string.Empty,
+                ProcessDefinitionKey = string.Empty,
+                Version = 0,
+                DeployedAt = default,
+                BpmnXml = string.Empty,
+                Workflow = new WorkflowDefinition
+                {
+                    WorkflowId = string.Empty,
+                    Activities = [],
+                    SequenceFlows = []
+                }
+            }
+        };
+
+}

--- a/src/Fleans/Fleans.Persistence.Tests/EfCoreProcessDefinitionRepositoryTests.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/EfCoreProcessDefinitionRepositoryTests.cs
@@ -255,18 +255,4 @@ public class EfCoreProcessDefinitionRepositoryTests
         };
     }
 
-    private class TestDbContextFactory : IDbContextFactory<FleanCommandDbContext>
-    {
-        private readonly DbContextOptions<FleanCommandDbContext> _options;
-
-        public TestDbContextFactory(DbContextOptions<FleanCommandDbContext> options)
-        {
-            _options = options;
-        }
-
-        public FleanCommandDbContext CreateDbContext() => new(_options);
-
-        public Task<FleanCommandDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default)
-            => Task.FromResult(CreateDbContext());
-    }
 }

--- a/src/Fleans/Fleans.Persistence.Tests/EfCoreWorkflowInstanceGrainStorageTests.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/EfCoreWorkflowInstanceGrainStorageTests.cs
@@ -712,26 +712,4 @@ public class EfCoreWorkflowInstanceGrainStorageTests
 
     private static TestGrainState<WorkflowInstanceState> CreateGrainState()
         => new() { State = new WorkflowInstanceState() };
-
-    private class TestGrainState<T> : IGrainState<T> where T : new()
-    {
-        public T State { get; set; } = new();
-        public string? ETag { get; set; }
-        public bool RecordExists { get; set; }
-    }
-
-    private class TestDbContextFactory : IDbContextFactory<FleanCommandDbContext>
-    {
-        private readonly DbContextOptions<FleanCommandDbContext> _options;
-
-        public TestDbContextFactory(DbContextOptions<FleanCommandDbContext> options)
-        {
-            _options = options;
-        }
-
-        public FleanCommandDbContext CreateDbContext() => new(_options);
-
-        public Task<FleanCommandDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default)
-            => Task.FromResult(CreateDbContext());
-    }
 }

--- a/src/Fleans/Fleans.Persistence.Tests/TestInfrastructure.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/TestInfrastructure.cs
@@ -1,0 +1,26 @@
+using Microsoft.EntityFrameworkCore;
+using Orleans.Runtime;
+
+namespace Fleans.Persistence.Tests;
+
+internal class TestGrainState<T> : IGrainState<T>
+{
+    public T State { get; set; } = default!;
+    public string? ETag { get; set; }
+    public bool RecordExists { get; set; }
+}
+
+internal class TestDbContextFactory : IDbContextFactory<FleanCommandDbContext>
+{
+    private readonly DbContextOptions<FleanCommandDbContext> _options;
+
+    public TestDbContextFactory(DbContextOptions<FleanCommandDbContext> options)
+    {
+        _options = options;
+    }
+
+    public FleanCommandDbContext CreateDbContext() => new(_options);
+
+    public Task<FleanCommandDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(CreateDbContext());
+}

--- a/src/Fleans/Fleans.Persistence/DependencyInjection.cs
+++ b/src/Fleans/Fleans.Persistence/DependencyInjection.cs
@@ -24,6 +24,10 @@ public static class EfCorePersistenceDependencyInjection
             (sp, _) => new EfCoreWorkflowInstanceGrainStorage(
                 sp.GetRequiredService<IDbContextFactory<FleanCommandDbContext>>()));
 
+        services.AddKeyedSingleton<IGrainStorage>("processDefinitions",
+            (sp, _) => new EfCoreProcessDefinitionGrainStorage(
+                sp.GetRequiredService<IDbContextFactory<FleanCommandDbContext>>()));
+
         services.AddSingleton<IProcessDefinitionRepository, EfCoreProcessDefinitionRepository>();
         services.AddSingleton<IWorkflowQueryService, WorkflowQueryService>();
     }

--- a/src/Fleans/Fleans.Persistence/EfCoreProcessDefinitionGrainStorage.cs
+++ b/src/Fleans/Fleans.Persistence/EfCoreProcessDefinitionGrainStorage.cs
@@ -1,0 +1,88 @@
+using Fleans.Domain;
+using Microsoft.EntityFrameworkCore;
+using Orleans.Runtime;
+using Orleans.Storage;
+
+namespace Fleans.Persistence;
+
+public class EfCoreProcessDefinitionGrainStorage : IGrainStorage
+{
+    private readonly IDbContextFactory<FleanCommandDbContext> _dbContextFactory;
+
+    public EfCoreProcessDefinitionGrainStorage(IDbContextFactory<FleanCommandDbContext> dbContextFactory)
+    {
+        _dbContextFactory = dbContextFactory;
+    }
+
+    public async Task ReadStateAsync<T>(string stateName, GrainId grainId, IGrainState<T> grainState)
+    {
+        await using var db = await _dbContextFactory.CreateDbContextAsync();
+        var id = grainId.Key.ToString();
+
+        var state = await db.ProcessDefinitions.AsNoTracking()
+            .FirstOrDefaultAsync(e => e.ProcessDefinitionId == id);
+
+        if (state is not null)
+        {
+            grainState.State = (T)(object)state;
+            grainState.ETag = state.ETag;
+            grainState.RecordExists = true;
+        }
+    }
+
+    public async Task WriteStateAsync<T>(string stateName, GrainId grainId, IGrainState<T> grainState)
+    {
+        await using var db = await _dbContextFactory.CreateDbContextAsync();
+        var id = grainId.Key.ToString();
+        var state = (ProcessDefinition)(object)grainState.State!;
+        var newETag = Guid.NewGuid().ToString("N");
+
+        var existing = await db.ProcessDefinitions.FindAsync(id);
+
+        if (existing is null)
+        {
+            if (grainState.ETag is not null)
+                throw new InconsistentStateException(
+                    $"ETag mismatch: expected '{grainState.ETag}', but no record exists");
+
+            db.ProcessDefinitions.Add(state);
+            db.Entry(state).Property(s => s.ProcessDefinitionId).CurrentValue = id;
+            db.Entry(state).Property(s => s.ETag).CurrentValue = newETag;
+        }
+        else
+        {
+            if (existing.ETag != grainState.ETag)
+                throw new InconsistentStateException(
+                    $"ETag mismatch: expected '{grainState.ETag}', stored '{existing.ETag}'");
+
+            db.Entry(existing).CurrentValues.SetValues(state);
+            db.Entry(existing).Property(s => s.ProcessDefinitionId).IsModified = false;
+            db.Entry(existing).Property(s => s.ETag).CurrentValue = newETag;
+        }
+
+        await db.SaveChangesAsync();
+
+        grainState.ETag = newETag;
+        grainState.RecordExists = true;
+    }
+
+    public async Task ClearStateAsync<T>(string stateName, GrainId grainId, IGrainState<T> grainState)
+    {
+        await using var db = await _dbContextFactory.CreateDbContextAsync();
+        var id = grainId.Key.ToString();
+        var existing = await db.ProcessDefinitions.FindAsync(id);
+
+        if (existing is not null)
+        {
+            if (existing.ETag != grainState.ETag)
+                throw new InconsistentStateException(
+                    $"ETag mismatch on clear: expected '{grainState.ETag}', stored '{existing.ETag}'");
+
+            db.ProcessDefinitions.Remove(existing);
+            await db.SaveChangesAsync();
+        }
+
+        grainState.ETag = null;
+        grainState.RecordExists = false;
+    }
+}

--- a/src/Fleans/Fleans.Persistence/EfCoreProcessDefinitionRepository.cs
+++ b/src/Fleans/Fleans.Persistence/EfCoreProcessDefinitionRepository.cs
@@ -50,6 +50,7 @@ public class EfCoreProcessDefinitionRepository : IProcessDefinitionRepository
             throw new InvalidOperationException(
                 $"Process definition '{definition.ProcessDefinitionId}' already exists.");
 
+        definition.ETag ??= Guid.NewGuid().ToString("N");
         db.ProcessDefinitions.Add(definition);
         await db.SaveChangesAsync();
     }

--- a/src/Fleans/Fleans.Persistence/FleanModelConfiguration.cs
+++ b/src/Fleans/Fleans.Persistence/FleanModelConfiguration.cs
@@ -100,6 +100,7 @@ internal static class FleanModelConfiguration
 
             entity.Property(e => e.ProcessDefinitionId).HasMaxLength(512);
             entity.Property(e => e.ProcessDefinitionKey).HasMaxLength(256);
+            entity.Property(e => e.ETag).HasMaxLength(64);
             entity.Property(e => e.BpmnXml);
 
             entity.HasIndex(e => e.ProcessDefinitionKey);


### PR DESCRIPTION
…itions

WorkflowInstance now lazy-loads its WorkflowDefinition from a read-only ProcessDefinitionGrain instead of holding a non-persisted in-memory property. This ensures the definition survives grain deactivation/reactivation.

- Add EfCoreProcessDefinitionGrainStorage (IGrainStorage with string keys)
- Add ETag to ProcessDefinition; repository sets it on save
- Add ProcessDefinitionGrain: returns WorkflowDefinition (not full ProcessDefinition, to avoid sending BpmnXml across grain boundaries)
- Refactor WorkflowInstance: lazy-load definition via EnsureWorkflowDefinitionAsync
- Extract shared TestDbContextFactory/TestGrainState into TestInfrastructure.cs
- 12 new grain storage tests; all 214 tests pass