### PR TITLE
Extract grain storage name constants and fix ValueComparer snapshot

### DIFF
--- a/src/Fleans/Fleans.Application.Tests/EventPublisherTests.cs
+++ b/src/Fleans/Fleans.Application.Tests/EventPublisherTests.cs
@@ -178,11 +178,11 @@ public class EventPublisherTests
                     services.AddDbContextFactory<FleanQueryDbContext>(options =>
                         options.UseSqlite("DataSource=file::memory:?cache=shared"));
 
-                    services.AddKeyedSingleton<IGrainStorage>("workflowInstances",
+                    services.AddKeyedSingleton<IGrainStorage>(GrainStorageNames.WorkflowInstances,
                         (sp, _) => new EfCoreWorkflowInstanceGrainStorage(
                             sp.GetRequiredService<IDbContextFactory<FleanCommandDbContext>>()));
 
-                    services.AddKeyedSingleton<IGrainStorage>("activityInstances",
+                    services.AddKeyedSingleton<IGrainStorage>(GrainStorageNames.ActivityInstances,
                         (sp, _) => new EfCoreActivityInstanceGrainStorage(
                             sp.GetRequiredService<IDbContextFactory<FleanCommandDbContext>>()));
 

--- a/src/Fleans/Fleans.Application.Tests/WorkflowInstanceFactoryGrainTests.cs
+++ b/src/Fleans/Fleans.Application.Tests/WorkflowInstanceFactoryGrainTests.cs
@@ -185,8 +185,8 @@ namespace Fleans.Application.Tests
         {
             public void Configure(ISiloBuilder hostBuilder) =>
                 hostBuilder
-                    .AddMemoryGrainStorage("workflowInstances")
-                    .AddMemoryGrainStorage("activityInstances")
+                    .AddMemoryGrainStorage(GrainStorageNames.WorkflowInstances)
+                    .AddMemoryGrainStorage(GrainStorageNames.ActivityInstances)
                     .ConfigureServices(services =>
                     {
                         services.AddSingleton<IProcessDefinitionRepository, StubProcessDefinitionRepository>();

--- a/src/Fleans/Fleans.Application.Tests/WorkflowTestBase.cs
+++ b/src/Fleans/Fleans.Application.Tests/WorkflowTestBase.cs
@@ -1,5 +1,6 @@
 using Fleans.Application;
 using Fleans.Application.Events;
+using Fleans.Domain;
 using Fleans.Domain.Persistence;
 using Fleans.Persistence;
 using Microsoft.Data.Sqlite;
@@ -65,11 +66,11 @@ public abstract class WorkflowTestBase
                     services.AddDbContextFactory<FleanQueryDbContext>(options =>
                         options.UseSqlite("DataSource=file::memory:?cache=shared"));
 
-                    services.AddKeyedSingleton<IGrainStorage>("workflowInstances",
+                    services.AddKeyedSingleton<IGrainStorage>(GrainStorageNames.WorkflowInstances,
                         (sp, _) => new EfCoreWorkflowInstanceGrainStorage(
                             sp.GetRequiredService<IDbContextFactory<FleanCommandDbContext>>()));
 
-                    services.AddKeyedSingleton<IGrainStorage>("activityInstances",
+                    services.AddKeyedSingleton<IGrainStorage>(GrainStorageNames.ActivityInstances,
                         (sp, _) => new EfCoreActivityInstanceGrainStorage(
                             sp.GetRequiredService<IDbContextFactory<FleanCommandDbContext>>()));
 

--- a/src/Fleans/Fleans.Application/Grains/ActivityInstance.cs
+++ b/src/Fleans/Fleans.Application/Grains/ActivityInstance.cs
@@ -15,7 +15,7 @@ public partial class ActivityInstance : Grain, IActivityInstanceGrain
     private ActivityInstanceState State => _state.State;
 
     public ActivityInstance(
-        [PersistentState("state", "activityInstances")] IPersistentState<ActivityInstanceState> state,
+        [PersistentState("state", GrainStorageNames.ActivityInstances)] IPersistentState<ActivityInstanceState> state,
         ILogger<ActivityInstance> logger)
     {
         _state = state;

--- a/src/Fleans/Fleans.Application/Grains/ProcessDefinitionGrain.cs
+++ b/src/Fleans/Fleans.Application/Grains/ProcessDefinitionGrain.cs
@@ -10,7 +10,7 @@ public partial class ProcessDefinitionGrain : Grain, IProcessDefinitionGrain
     private readonly ILogger<ProcessDefinitionGrain> _logger;
 
     public ProcessDefinitionGrain(
-        [PersistentState("state", "processDefinitions")] IPersistentState<ProcessDefinition> state,
+        [PersistentState("state", GrainStorageNames.ProcessDefinitions)] IPersistentState<ProcessDefinition> state,
         ILogger<ProcessDefinitionGrain> logger)
     {
         _state = state;

--- a/src/Fleans/Fleans.Application/Grains/WorkflowInstance.cs
+++ b/src/Fleans/Fleans.Application/Grains/WorkflowInstance.cs
@@ -20,7 +20,7 @@ public partial class WorkflowInstance : Grain, IWorkflowInstanceGrain
     private WorkflowInstanceState State => _state.State;
 
     public WorkflowInstance(
-        [PersistentState("state", "workflowInstances")] IPersistentState<WorkflowInstanceState> state,
+        [PersistentState("state", GrainStorageNames.WorkflowInstances)] IPersistentState<WorkflowInstanceState> state,
         IGrainFactory grainFactory,
         ILogger<WorkflowInstance> logger)
     {

--- a/src/Fleans/Fleans.Domain/GrainStorageNames.cs
+++ b/src/Fleans/Fleans.Domain/GrainStorageNames.cs
@@ -1,0 +1,12 @@
+namespace Fleans.Domain;
+
+/// <summary>
+/// Named grain storage provider identifiers used in [PersistentState] attributes
+/// and DI registration. Must match between grain constructors and silo configuration.
+/// </summary>
+public static class GrainStorageNames
+{
+    public const string ActivityInstances = "activityInstances";
+    public const string WorkflowInstances = "workflowInstances";
+    public const string ProcessDefinitions = "processDefinitions";
+}

--- a/src/Fleans/Fleans.Persistence/DependencyInjection.cs
+++ b/src/Fleans/Fleans.Persistence/DependencyInjection.cs
@@ -1,4 +1,5 @@
 using Fleans.Application;
+using Fleans.Domain;
 using Fleans.Domain.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -16,15 +17,15 @@ public static class EfCorePersistenceDependencyInjection
         services.AddDbContextFactory<FleanCommandDbContext>(configureCommandDb);
         services.AddDbContextFactory<FleanQueryDbContext>(configureQueryDb ?? configureCommandDb);
 
-        services.AddKeyedSingleton<IGrainStorage>("activityInstances",
+        services.AddKeyedSingleton<IGrainStorage>(GrainStorageNames.ActivityInstances,
             (sp, _) => new EfCoreActivityInstanceGrainStorage(
                 sp.GetRequiredService<IDbContextFactory<FleanCommandDbContext>>()));
 
-        services.AddKeyedSingleton<IGrainStorage>("workflowInstances",
+        services.AddKeyedSingleton<IGrainStorage>(GrainStorageNames.WorkflowInstances,
             (sp, _) => new EfCoreWorkflowInstanceGrainStorage(
                 sp.GetRequiredService<IDbContextFactory<FleanCommandDbContext>>()));
 
-        services.AddKeyedSingleton<IGrainStorage>("processDefinitions",
+        services.AddKeyedSingleton<IGrainStorage>(GrainStorageNames.ProcessDefinitions,
             (sp, _) => new EfCoreProcessDefinitionGrainStorage(
                 sp.GetRequiredService<IDbContextFactory<FleanCommandDbContext>>()));
 

--- a/src/Fleans/Fleans.Persistence/FleanModelConfiguration.cs
+++ b/src/Fleans/Fleans.Persistence/FleanModelConfiguration.cs
@@ -119,9 +119,11 @@ internal static class FleanModelConfiguration
                     v => JsonConvert.DeserializeObject<WorkflowDefinition>(v, jsonSettings)!)
                 .Metadata.SetValueComparer(
                     new ValueComparer<WorkflowDefinition>(
-                        (a, b) => ReferenceEquals(a, b),
-                        v => RuntimeHelpers.GetHashCode(v),
-                        v => v));
+                        (a, b) => JsonConvert.SerializeObject(a, jsonSettings) ==
+                                  JsonConvert.SerializeObject(b, jsonSettings),
+                        v => JsonConvert.SerializeObject(v, jsonSettings).GetHashCode(),
+                        v => JsonConvert.DeserializeObject<WorkflowDefinition>(
+                            JsonConvert.SerializeObject(v, jsonSettings), jsonSettings)!));
         });
     }
 }


### PR DESCRIPTION
- Add GrainStorageNames constants class in Fleans.Domain, replacing 12 magic string occurrences across grains, DI registration, and tests
- Fix WorkflowDefinition ValueComparer: use JSON round-trip for snapshot (deep copy) and JSON string comparison for equality/hash instead of ReferenceEquals, so EF Core correctly detects actual content changes
- Remove empty Fleans.Persistence.InMemory directories (bin/obj only)