### PR TITLE
refactor: remove UploadBpmn and GetAllWorkflows API endpoints

### DIFF
--- a/src/Fleans/Fleans.ServiceDefaults/DTOs/StartWorkflowRequest.cs
+++ b/src/Fleans/Fleans.ServiceDefaults/DTOs/StartWorkflowRequest.cs
@@ -1,4 +1,3 @@
 namespace Fleans.ServiceDefaults.DTOs;
 
 public record StartWorkflowRequest(string WorkflowId);
-

--- a/src/Fleans/Fleans.ServiceDefaults/DTOs/StartWorkflowResponse.cs
+++ b/src/Fleans/Fleans.ServiceDefaults/DTOs/StartWorkflowResponse.cs
@@ -1,4 +1,3 @@
 namespace Fleans.ServiceDefaults.DTOs;
 
 public record StartWorkflowResponse(Guid WorkflowInstanceId);
-

--- a/src/Fleans/Fleans.ServiceDefaults/DTOs/UploadBpmnResponse.cs
+++ b/src/Fleans/Fleans.ServiceDefaults/DTOs/UploadBpmnResponse.cs
@@ -1,8 +1,0 @@
-namespace Fleans.ServiceDefaults.DTOs;
-
-public record UploadBpmnResponse(
-    string Message,
-    string WorkflowId,
-    int ActivitiesCount,
-    int SequenceFlowsCount);
-


### PR DESCRIPTION
## Summary
- Remove `UploadBpmn` and `GetAllWorkflows` endpoints from `WorkflowController`
- Delete unused `UploadBpmnResponse` DTO
- Clean up unused constructor dependencies (`IWorkflowQueryService`, `IBpmnConverter`) and related constants/logger methods
- `StartWorkflow` and `SendMessage` endpoints remain

## Test plan
- [x] Build succeeds with 0 errors
- [x] No remaining references to deleted code

🤖 Generated with [Claude Code](https://claude.com/claude-code)