### PR TITLE
feat: consolidate boundary event buttons into popup submenu

### DIFF
--- a/docs/plans/2026-02-20-boundary-event-submenu-design.md
+++ b/docs/plans/2026-02-20-boundary-event-submenu-design.md
@@ -1,0 +1,33 @@
+# Boundary Event Context Pad Submenu Design
+
+## Goal
+
+Replace the 3 individual boundary event buttons (Timer, Message, Error) in the bpmn-js context pad with a single button that opens a popup submenu containing those options.
+
+## Current Behavior
+
+When clicking a boundaryable activity (Task, ScriptTask, etc.), the context pad shows 3 separate buttons directly:
+- Timer Boundary Event
+- Message Boundary Event
+- Error Boundary Event
+
+This clutters the context pad, especially as more boundary event types are added.
+
+## Proposed Behavior
+
+A single "Attach Boundary Event" button appears in the context pad. Clicking it opens a bpmn-js popup menu with the 3 options. User selects one, and the boundary event is created — same as today.
+
+## Approach: bpmn-js PopupMenu
+
+Use bpmn-js's built-in `popupMenu` service — the same infrastructure used by the "change type" wrench button. This handles positioning, keyboard navigation, and dismiss-on-click-away automatically.
+
+### Changes
+
+**Single file change:** `src/Fleans/Fleans.Web/wwwroot/js/boundaryEventContextPad.js`
+
+1. Inject `popupMenu` dependency
+2. Register a `PopupMenuProvider` for `'boundary-event'` menu ID
+3. Replace 3 context pad entries with 1 entry whose click handler opens the popup menu
+4. Each popup entry's action calls `_createBoundaryEvent()`
+
+No changes to `bpmnEditor.js`, `Editor.razor`, or backend code.

--- a/docs/plans/2026-02-20-boundary-event-submenu-implementation.md
+++ b/docs/plans/2026-02-20-boundary-event-submenu-implementation.md
@@ -1,0 +1,132 @@
+# Boundary Event Context Pad Submenu Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace 3 separate boundary event context pad buttons with a single button that opens a popup submenu.
+
+**Architecture:** Use bpmn-js's built-in `popupMenu` service to register a custom popup menu provider. A single context pad entry opens the menu on click.
+
+**Tech Stack:** bpmn-js v17 (PopupMenu, ContextPad), vanilla JS
+
+---
+
+### Task 1: Refactor boundaryEventContextPad.js to use PopupMenu
+
+**Files:**
+- Modify: `src/Fleans/Fleans.Web/wwwroot/js/boundaryEventContextPad.js`
+
+**Step 1: Add `popupMenu` to the dependency injection**
+
+Change the constructor and `$inject` to include `popupMenu`:
+
+```javascript
+function BoundaryEventContextPadProvider(contextPad, modeling, elementFactory, bpmnFactory, selection, popupMenu) {
+    contextPad.registerProvider(600, this);
+
+    this._modeling = modeling;
+    this._elementFactory = elementFactory;
+    this._bpmnFactory = bpmnFactory;
+    this._selection = selection;
+    this._popupMenu = popupMenu;
+}
+
+BoundaryEventContextPadProvider.$inject = [
+    'contextPad', 'modeling', 'elementFactory', 'bpmnFactory', 'selection', 'popupMenu'
+];
+```
+
+**Step 2: Register a PopupMenu provider for `'boundary-event'`**
+
+Add this after the constructor:
+
+```javascript
+BoundaryEventContextPadProvider.prototype._registerPopupMenuProvider = function () {
+    var self = this;
+
+    this._popupMenu.registerProvider('boundary-event', {
+        getPopupMenuEntries: function () {
+            return {
+                'attach-boundary-timer': {
+                    label: 'Timer Boundary Event',
+                    className: 'bpmn-icon-intermediate-event-catch-timer',
+                    action: function () {
+                        self._createBoundaryEvent(self._currentElement, 'bpmn:TimerEventDefinition');
+                    }
+                },
+                'attach-boundary-message': {
+                    label: 'Message Boundary Event',
+                    className: 'bpmn-icon-intermediate-event-catch-message',
+                    action: function () {
+                        self._createBoundaryEvent(self._currentElement, 'bpmn:MessageEventDefinition');
+                    }
+                },
+                'attach-boundary-error': {
+                    label: 'Error Boundary Event',
+                    className: 'bpmn-icon-intermediate-event-catch-error',
+                    action: function () {
+                        self._createBoundaryEvent(self._currentElement, 'bpmn:ErrorEventDefinition');
+                    }
+                }
+            };
+        }
+    });
+};
+```
+
+Call `this._registerPopupMenuProvider()` at the end of the constructor.
+
+**Step 3: Replace 3 context pad entries with 1 that opens popup menu**
+
+Replace `getContextPadEntries` to return a single entry:
+
+```javascript
+BoundaryEventContextPadProvider.prototype.getContextPadEntries = function (element) {
+    var bo = element.businessObject;
+    if (BOUNDARABLE_TYPES.indexOf(bo.$type) === -1) return {};
+
+    var self = this;
+
+    return {
+        'attach-boundary-event': {
+            group: 'attach',
+            className: 'bpmn-icon-intermediate-event-none',
+            title: 'Attach Boundary Event',
+            action: {
+                click: function (event, element) {
+                    self._currentElement = element;
+
+                    var position = {
+                        x: event.x,
+                        y: event.y
+                    };
+
+                    self._popupMenu.open(element, 'boundary-event', position);
+                }
+            }
+        }
+    };
+};
+```
+
+**Step 4: Verify the `_createBoundaryEvent` method is unchanged**
+
+The existing `_createBoundaryEvent` prototype method stays exactly as-is — no changes needed.
+
+**Step 5: Run the app and verify**
+
+Run: `dotnet run --project src/Fleans/Fleans.Aspire/`
+
+Manual verification:
+1. Open BPMN editor
+2. Add a ScriptTask or other boundaryable activity
+3. Click on the activity — context pad should show ONE boundary event button (circle icon)
+4. Click it — popup menu should appear with 3 options (Timer, Message, Error)
+5. Select Timer — a timer boundary event should be attached to the activity
+6. Repeat for Message and Error
+
+**Step 6: Commit**
+
+```bash
+git add src/Fleans/Fleans.Web/wwwroot/js/boundaryEventContextPad.js
+git commit -m "feat: consolidate boundary event buttons into popup submenu"
+```

--- a/src/Fleans/Fleans.Web/wwwroot/app.css
+++ b/src/Fleans/Fleans.Web/wwwroot/app.css
@@ -218,6 +218,14 @@ marker[id*="conditional"] path {
     background: rgba(245, 158, 11, 0.15) !important;
 }
 
+/* Context pad: boundary event submenu icon (vertical three dots) */
+.djs-context-pad .entry.bpmn-icon-boundary-more::before {
+    content: '\22EE';
+    font-family: inherit;
+    font-size: 20px;
+    font-weight: bold;
+}
+
 /* BPMN Editor Styles */
 .editor-page {
     display: flex;

--- a/src/Fleans/Fleans.Web/wwwroot/js/boundaryEventContextPad.js
+++ b/src/Fleans/Fleans.Web/wwwroot/js/boundaryEventContextPad.js
@@ -8,18 +8,53 @@
         'bpmn:SubProcess'
     ];
 
-    function BoundaryEventContextPadProvider(contextPad, modeling, elementFactory, bpmnFactory, selection) {
+    function BoundaryEventContextPadProvider(contextPad, modeling, elementFactory, bpmnFactory, selection, popupMenu) {
         contextPad.registerProvider(600, this);
 
         this._modeling = modeling;
         this._elementFactory = elementFactory;
         this._bpmnFactory = bpmnFactory;
         this._selection = selection;
+        this._popupMenu = popupMenu;
+
+        this._registerPopupMenuProvider();
     }
 
     BoundaryEventContextPadProvider.$inject = [
-        'contextPad', 'modeling', 'elementFactory', 'bpmnFactory', 'selection'
+        'contextPad', 'modeling', 'elementFactory', 'bpmnFactory', 'selection', 'popupMenu'
     ];
+
+    BoundaryEventContextPadProvider.prototype._registerPopupMenuProvider = function () {
+        var self = this;
+
+        this._popupMenu.registerProvider('boundary-event', {
+            getPopupMenuEntries: function (target) {
+                return {
+                    'attach-boundary-timer': {
+                        label: 'Timer Boundary Event',
+                        className: 'bpmn-icon-intermediate-event-catch-timer',
+                        action: function () {
+                            self._createBoundaryEvent(target, 'bpmn:TimerEventDefinition');
+                        }
+                    },
+                    'attach-boundary-message': {
+                        label: 'Message Boundary Event',
+                        className: 'bpmn-icon-intermediate-event-catch-message',
+                        action: function () {
+                            self._createBoundaryEvent(target, 'bpmn:MessageEventDefinition');
+                        }
+                    },
+                    'attach-boundary-error': {
+                        label: 'Error Boundary Event',
+                        className: 'bpmn-icon-intermediate-event-catch-error',
+                        action: function () {
+                            self._createBoundaryEvent(target, 'bpmn:ErrorEventDefinition');
+                        }
+                    }
+                };
+            }
+        });
+    };
 
     BoundaryEventContextPadProvider.prototype.getContextPadEntries = function (element) {
         var bo = element.businessObject;
@@ -28,33 +63,16 @@
         var self = this;
 
         return {
-            'attach-boundary-timer': {
+            'attach-boundary-event': {
                 group: 'attach',
-                className: 'bpmn-icon-intermediate-event-catch-timer',
-                title: 'Attach Timer Boundary Event',
+                className: 'bpmn-icon-boundary-more',
+                title: 'Attach Boundary Event',
                 action: {
                     click: function (event, element) {
-                        self._createBoundaryEvent(element, 'bpmn:TimerEventDefinition');
-                    }
-                }
-            },
-            'attach-boundary-message': {
-                group: 'attach',
-                className: 'bpmn-icon-intermediate-event-catch-message',
-                title: 'Attach Message Boundary Event',
-                action: {
-                    click: function (event, element) {
-                        self._createBoundaryEvent(element, 'bpmn:MessageEventDefinition');
-                    }
-                }
-            },
-            'attach-boundary-error': {
-                group: 'attach',
-                className: 'bpmn-icon-intermediate-event-catch-error',
-                title: 'Attach Error Boundary Event',
-                action: {
-                    click: function (event, element) {
-                        self._createBoundaryEvent(element, 'bpmn:ErrorEventDefinition');
+                        self._popupMenu.open(element, 'boundary-event', {
+                            x: event.x,
+                            y: event.y
+                        });
                     }
                 }
             }


### PR DESCRIPTION
Replace 3 separate boundary event context pad buttons with a single button that opens a bpmn-js popup menu with Timer, Message, and Error options.