### PR TITLE
refactor: remove GetWorkflowDefinition from IWorkflowInstanceGrain

### DIFF
--- a/src/Fleans/Fleans.Application.Tests/WorkflowInstanceFactoryGrainTests.cs
+++ b/src/Fleans/Fleans.Application.Tests/WorkflowInstanceFactoryGrainTests.cs
@@ -61,12 +61,10 @@ namespace Fleans.Application.Tests
 
             // Act
             var instance = await factoryGrain.CreateWorkflowInstanceGrain(workflowId);
-            var definition = await instance.GetWorkflowDefinition();
 
-            // Assert
-            Assert.AreEqual(workflowId, definition.WorkflowId);
-            Assert.AreEqual(workflow.Activities.Count, definition.Activities.Count);
-            Assert.AreEqual(workflow.SequenceFlows.Count, definition.SequenceFlows.Count);
+            // Assert — workflow was set correctly: instance has an active start activity
+            var activeActivities = await instance.GetActiveActivities();
+            Assert.HasCount(1, activeActivities);
         }
 
         [TestMethod]

--- a/src/Fleans/Fleans.Application.Tests/WorkflowInstanceTests.cs
+++ b/src/Fleans/Fleans.Application.Tests/WorkflowInstanceTests.cs
@@ -24,9 +24,6 @@ namespace Fleans.Application.Tests
             await workflowInstance.StartWorkflow();
 
             // Assert
-            var definition = await workflowInstance.GetWorkflowDefinition();
-            Assert.AreEqual(workflow.WorkflowId, definition.WorkflowId);
-
             var instanceId = workflowInstance.GetPrimaryKey();
             var snapshot = await QueryService.GetStateSnapshot(instanceId);
             Assert.IsNotNull(snapshot);

--- a/src/Fleans/Fleans.Application/Grains/IWorkflowInstanceGrain.cs
+++ b/src/Fleans/Fleans.Application/Grains/IWorkflowInstanceGrain.cs
@@ -12,9 +12,6 @@ public interface IWorkflowInstanceGrain : IGrainWithGuidKey, IWorkflowExecutionC
     new ValueTask<Guid> GetWorkflowInstanceId();
 
     [ReadOnly]
-    ValueTask<IWorkflowDefinition> GetWorkflowDefinition();
-
-    [ReadOnly]
     new ValueTask<IReadOnlyDictionary<Guid, ConditionSequenceState[]>> GetConditionSequenceStates();
 
     [ReadOnly]
@@ -39,6 +36,7 @@ public interface IWorkflowInstanceGrain : IGrainWithGuidKey, IWorkflowExecutionC
     [AlwaysInterleave]
     Task OnChildWorkflowFailed(string parentActivityId, Exception exception);
 
+    Task HandleMessageDelivery(string activityId, Guid hostActivityInstanceId, ExpandoObject variables);
     Task HandleBoundaryMessageFired(string boundaryActivityId, Guid hostActivityInstanceId);
     Task HandleTimerFired(string timerActivityId, Guid hostActivityInstanceId);
 }


### PR DESCRIPTION
Move message routing logic into WorkflowInstance.HandleMessageDelivery() so MessageCorrelationGrain no longer needs workflow definition knowledge.