### PR TITLE
feat: make header logo color match text using currentColor

### DIFF
--- a/src/Fleans/Fleans.Web/Components/Layout/MainLayout.razor
+++ b/src/Fleans/Fleans.Web/Components/Layout/MainLayout.razor
@@ -10,7 +10,31 @@
 
 <FluentLayout>
     <FluentHeader>
-        <img src="favicon.svg" alt="Fleans logo" style="height: 28px; margin-right: 10px;" />
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" style="height: 28px; margin-right: 10px;" aria-label="Fleans logo">
+            <defs>
+                <marker id="arr" viewBox="0 0 8 6" refX="8" refY="3"
+                        markerWidth="5" markerHeight="4" orient="auto">
+                    <path d="M 0 0 L 8 3 L 0 6 Z" fill="currentColor"/>
+                </marker>
+            </defs>
+            <polygon points="256,36 446,146 446,366 256,476 66,366 66,146"
+                     fill="none" stroke="currentColor" stroke-width="36"/>
+            <rect x="176" y="158" width="44" height="28" rx="5" fill="currentColor"/>
+            <rect x="234" y="158" width="44" height="28" rx="5" fill="currentColor"/>
+            <rect x="292" y="158" width="44" height="28" rx="5" fill="currentColor"/>
+            <rect x="176" y="200" width="44" height="28" rx="5" fill="currentColor"/>
+            <rect x="176" y="242" width="44" height="28" rx="5" fill="currentColor"/>
+            <rect x="176" y="284" width="44" height="28" rx="5" fill="currentColor"/>
+            <rect x="176" y="326" width="44" height="28" rx="5" fill="currentColor"/>
+            <rect x="234" y="242" width="44" height="28" rx="5" fill="currentColor"/>
+            <line x1="220" y1="172" x2="234" y2="172" stroke="currentColor" stroke-width="2.5" marker-end="url(#arr)"/>
+            <line x1="278" y1="172" x2="292" y2="172" stroke="currentColor" stroke-width="2.5" marker-end="url(#arr)"/>
+            <line x1="220" y1="256" x2="234" y2="256" stroke="currentColor" stroke-width="2.5" marker-end="url(#arr)"/>
+            <line x1="198" y1="186" x2="198" y2="200" stroke="currentColor" stroke-width="2.5" marker-end="url(#arr)"/>
+            <line x1="198" y1="228" x2="198" y2="242" stroke="currentColor" stroke-width="2.5" marker-end="url(#arr)"/>
+            <line x1="198" y1="270" x2="198" y2="284" stroke="currentColor" stroke-width="2.5" marker-end="url(#arr)"/>
+            <line x1="198" y1="312" x2="198" y2="326" stroke="currentColor" stroke-width="2.5" marker-end="url(#arr)"/>
+        </svg>
         Fleans Management
         <FluentSpacer />
     </FluentHeader>


### PR DESCRIPTION
Inline the SVG with currentColor so it inherits the header's text color instead of using a hardcoded teal fill.

https://claude.ai/code/session_01GhcKUNVq8iPHvcKKNFRQUm