### PR TITLE
fix: add output mapping to cardinality-based MI tests

### DIFF
--- a/src/Fleans/Fleans.Application.Tests/MultiInstanceTests.cs
+++ b/src/Fleans/Fleans.Application.Tests/MultiInstanceTests.cs
@@ -13,13 +13,15 @@ public class MultiInstanceTests : WorkflowTestBase
     [TestMethod]
     public async Task ParallelCardinality_ShouldExecuteNTimes()
     {
-        // Arrange — workflow: start → script (MI x3) → end
+        // Arrange — workflow: start → script (MI x3 with output aggregation) → end
         var start = new StartEvent("start");
         var script = new MultiInstanceActivity(
             "script",
             new ScriptTask("script", "_context.result = \"done-\" + _context.loopCounter"),
             IsSequential: false,
-            LoopCardinality: 3);
+            LoopCardinality: 3,
+            OutputCollection: "results",
+            OutputDataItem: "result");
         var end = new EndEvent("end");
 
         var workflow = new WorkflowDefinition
@@ -51,6 +53,11 @@ public class MultiInstanceTests : WorkflowTestBase
         // Script should appear 3 times in completed (iterations) + 1 time for host = 4
         var scriptCompletions = snapshot.CompletedActivities.Count(a => a.ActivityId == "script");
         Assert.AreEqual(4, scriptCompletions, "Script should have completed 4 times (3 iterations + 1 host)");
+
+        // Verify output aggregation
+        var rootVars = snapshot.VariableStates.FirstOrDefault();
+        Assert.IsNotNull(rootVars, "Root variable state should exist");
+        Assert.IsTrue(rootVars.Variables.ContainsKey("results"), "Output collection 'results' should be present");
     }
 
     [TestMethod]
@@ -118,7 +125,9 @@ public class MultiInstanceTests : WorkflowTestBase
             "script",
             new ScriptTask("script", "_context.result = \"done-\" + _context.loopCounter"),
             IsSequential: true,
-            LoopCardinality: 3);
+            LoopCardinality: 3,
+            OutputCollection: "results",
+            OutputDataItem: "result");
         var end = new EndEvent("end");
 
         var workflow = new WorkflowDefinition
@@ -159,7 +168,9 @@ public class MultiInstanceTests : WorkflowTestBase
             "script",
             new ScriptTask("script", "_context.iterResult = \"val\""),
             IsSequential: false,
-            LoopCardinality: 3);
+            LoopCardinality: 3,
+            OutputCollection: "results",
+            OutputDataItem: "iterResult");
         var end = new EndEvent("end");
 
         var workflow = new WorkflowDefinition
@@ -248,7 +259,9 @@ public class MultiInstanceTests : WorkflowTestBase
             "script",
             new ScriptTask("script", "FAIL"),
             IsSequential: false,
-            LoopCardinality: 3);
+            LoopCardinality: 3,
+            OutputCollection: "results",
+            OutputDataItem: "result");
         var end = new EndEvent("end");
 
         var workflow = new WorkflowDefinition

--- a/src/Fleans/Fleans.Infrastructure.Tests/MultiInstanceScriptIntegrationTests.cs
+++ b/src/Fleans/Fleans.Infrastructure.Tests/MultiInstanceScriptIntegrationTests.cs
@@ -72,7 +72,9 @@ public class MultiInstanceScriptIntegrationTests
             "script",
             new ScriptTask("script", "_context.result = \"done-\" + _context.loopCounter"),
             IsSequential: false,
-            LoopCardinality: 3);
+            LoopCardinality: 3,
+            OutputCollection: "results",
+            OutputDataItem: "result");
         var end = new EndEvent("end");
 
         var workflow = new WorkflowDefinition
@@ -102,6 +104,19 @@ public class MultiInstanceScriptIntegrationTests
 
         var scriptCompletions = snapshot.CompletedActivities.Count(a => a.ActivityId == "script");
         Assert.AreEqual(4, scriptCompletions, "3 iterations + 1 host");
+
+        // Verify output aggregation via grain API
+        var rootVarsSnapshot = snapshot.VariableStates.FirstOrDefault();
+        Assert.IsNotNull(rootVarsSnapshot, "Root variable state should exist");
+
+        var resultsObj = await instance.GetVariable(rootVarsSnapshot.VariablesId, "results");
+        Assert.IsNotNull(resultsObj, "Output collection 'results' should be present");
+
+        var results = ((IEnumerable<object?>)resultsObj).Select(v => v?.ToString()).ToList();
+        Assert.AreEqual(3, results.Count, "Should have 3 output items");
+        CollectionAssert.Contains(results, "done-0", "Should contain done-0");
+        CollectionAssert.Contains(results, "done-1", "Should contain done-1");
+        CollectionAssert.Contains(results, "done-2", "Should contain done-2");
     }
 
     [TestMethod]
@@ -230,7 +245,9 @@ public class MultiInstanceScriptIntegrationTests
             "script",
             new ScriptTask("script", "_context.result = 1 / (_context.loopCounter - 1)"),
             IsSequential: false,
-            LoopCardinality: 3);
+            LoopCardinality: 3,
+            OutputCollection: "results",
+            OutputDataItem: "result");
         var end = new EndEvent("end");
 
         var workflow = new WorkflowDefinition

--- a/tests/manual/13-multi-instance/parallel-cardinality.bpmn
+++ b/tests/manual/13-multi-instance/parallel-cardinality.bpmn
@@ -8,7 +8,8 @@
     <startEvent id="start" />
     <scriptTask id="repeatTask" scriptFormat="csharp">
       <script>_context.result = "iter-" + _context.loopCounter</script>
-      <multiInstanceLoopCharacteristics isSequential="false">
+      <multiInstanceLoopCharacteristics isSequential="false"
+        outputCollection="results" outputElement="result">
         <loopCardinality>3</loopCardinality>
       </multiInstanceLoopCharacteristics>
     </scriptTask>

--- a/tests/manual/13-multi-instance/test-plan.md
+++ b/tests/manual/13-multi-instance/test-plan.md
@@ -32,6 +32,7 @@ Tests parallel multi-instance with fixed loop count.
 ### Expected
 - [ ] Instance status: Completed
 - [ ] Completed activities: start, repeatTask (3 iterations), end
+- [ ] Variables: `results` contains `["iter-0","iter-1","iter-2"]`
 
 ---
 


### PR DESCRIPTION
## Summary
- Cardinality-based multi-instance tests and the `parallel-cardinality.bpmn` fixture lacked `OutputCollection`/`OutputDataItem`, so iteration results were written to child variable scopes that got cleaned up — leaving zero variables visible after completion
- Added `OutputCollection` + `OutputDataItem` to all cardinality MI test definitions and the BPMN fixture
- Added assertions verifying the aggregated output collection exists and contains expected values
- Updated manual test-plan expected outcomes to include `results` variable check

## Test plan
- [x] All 386 tests pass (112 Domain + 102 Persistence + 73 Infrastructure + 99 Application)
- [x] MI-specific tests verify output aggregation with `results` collection
- [x] Manual test: deploy `parallel-cardinality.bpmn`, verify `results` variable is visible after completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)