### PR TITLE
fix: display list/object variables as JSON in admin UI

### DIFF
--- a/src/Fleans/Fleans.Persistence/WorkflowQueryService.cs
+++ b/src/Fleans/Fleans.Persistence/WorkflowQueryService.cs
@@ -69,7 +69,7 @@ public class WorkflowQueryService : IWorkflowQueryService
         var variableStates = state.VariableStates.Select(vs =>
         {
             var dict = ((IDictionary<string, object>)vs.Variables)
-                .ToDictionary(e => e.Key, e => e.Value?.ToString() ?? "");
+                .ToDictionary(e => e.Key, e => FormatVariableValue(e.Value));
             return new VariableStateSnapshot(vs.Id, dict);
         }).ToList();
 
@@ -202,6 +202,14 @@ public class WorkflowQueryService : IWorkflowQueryService
             null, null, null,
             entry.ChildWorkflowInstanceId);
     }
+
+    private static string FormatVariableValue(object? value) => value switch
+    {
+        null => "",
+        string s => s,
+        IList<object> or IDictionary<string, object> => JsonConvert.SerializeObject(value, Formatting.None),
+        _ => value.ToString() ?? ""
+    };
 
     private static ConditionSequenceSnapshot ToConditionSnapshot(
         ConditionSequenceState cs,


### PR DESCRIPTION
## Summary
- List and dictionary workflow variables now display as JSON (e.g. `["item1", "item2"]`) instead of .NET type names like `System.Collections.Generic.List'1[System.Object]`
- Simple scalar values (strings, numbers, bools) are unchanged

## Test plan
- [x] All 184 existing tests pass
- [ ] Deploy via Aspire, start a workflow with list variables, verify the Variables tab shows JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)