### PR TITLE
fix: resolve timer cycle deadlock on non-interrupting boundary events

### DIFF
--- a/src/Fleans/Fleans.Application.Tests/BoundaryEventHandlerTests.cs
+++ b/src/Fleans/Fleans.Application.Tests/BoundaryEventHandlerTests.cs
@@ -371,7 +371,7 @@ public class BoundaryEventHandlerTests
     // --- Non-interrupting cycle timer re-registration tests ---
 
     [TestMethod]
-    public async Task HandleBoundaryTimerFired_NonInterruptingCycle_ShouldReRegisterTimer()
+    public async Task HandleBoundaryTimerFired_NonInterruptingCycle_ShouldReturnNextCycleDueTime()
     {
         // Arrange
         var hostInstanceId = Guid.NewGuid();
@@ -390,9 +390,6 @@ public class BoundaryEventHandlerTests
         var boundaryGrain = Substitute.For<IActivityInstanceGrain>();
         _grainFactory.GetGrain<IActivityInstanceGrain>(Arg.Is<Guid>(id => id != hostInstanceId)).Returns(boundaryGrain);
 
-        var timerCallbackGrain = Substitute.For<ITimerCallbackGrain>();
-        _grainFactory.GetGrain<ITimerCallbackGrain>(_state.Id, $"{hostInstanceId}:bt1").Returns(timerCallbackGrain);
-
         var definition = Substitute.For<IWorkflowDefinition>();
         definition.Activities.Returns(new List<Activity> { boundaryTimer });
         definition.SequenceFlows.Returns(new List<SequenceFlow>());
@@ -402,14 +399,15 @@ public class BoundaryEventHandlerTests
         _accessor.WorkflowExecutionContext.Returns(Substitute.For<IWorkflowExecutionContext>());
 
         // Act
-        await _handler.HandleBoundaryTimerFiredAsync(boundaryTimer, hostInstanceId, definition);
+        var result = await _handler.HandleBoundaryTimerFiredAsync(boundaryTimer, hostInstanceId, definition);
 
-        // Assert — timer was re-registered with decremented cycle
-        await timerCallbackGrain.Received(1).Activate(TimeSpan.FromSeconds(10));
+        // Assert — returns the next cycle's due time (no direct Activate call)
+        Assert.IsNotNull(result, "Should return non-null TimeSpan for cycle re-registration");
+        Assert.AreEqual(TimeSpan.FromSeconds(10), result.Value);
     }
 
     [TestMethod]
-    public async Task HandleBoundaryTimerFired_NonInterruptingCycleLastRepetition_ShouldNotReRegister()
+    public async Task HandleBoundaryTimerFired_NonInterruptingCycleLastRepetition_ShouldReturnNull()
     {
         // Arrange
         var hostInstanceId = Guid.NewGuid();
@@ -428,9 +426,6 @@ public class BoundaryEventHandlerTests
         var boundaryGrain = Substitute.For<IActivityInstanceGrain>();
         _grainFactory.GetGrain<IActivityInstanceGrain>(Arg.Is<Guid>(id => id != hostInstanceId)).Returns(boundaryGrain);
 
-        var timerCallbackGrain = Substitute.For<ITimerCallbackGrain>();
-        _grainFactory.GetGrain<ITimerCallbackGrain>(_state.Id, $"{hostInstanceId}:bt1").Returns(timerCallbackGrain);
-
         var definition = Substitute.For<IWorkflowDefinition>();
         definition.Activities.Returns(new List<Activity> { boundaryTimer });
         definition.SequenceFlows.Returns(new List<SequenceFlow>());
@@ -440,10 +435,10 @@ public class BoundaryEventHandlerTests
         _accessor.WorkflowExecutionContext.Returns(Substitute.For<IWorkflowExecutionContext>());
 
         // Act
-        await _handler.HandleBoundaryTimerFiredAsync(boundaryTimer, hostInstanceId, definition);
+        var result = await _handler.HandleBoundaryTimerFiredAsync(boundaryTimer, hostInstanceId, definition);
 
-        // Assert — timer NOT re-registered (last repetition, DecrementCycle returns null)
-        await timerCallbackGrain.DidNotReceive().Activate(Arg.Any<TimeSpan>());
+        // Assert — returns null (last repetition, DecrementCycle returns null)
+        Assert.IsNull(result, "Should return null when no more cycles remain");
     }
 
     // --- Verify boundary path is created for non-interrupting ---

--- a/src/Fleans/Fleans.Application/Grains/IWorkflowInstanceGrain.cs
+++ b/src/Fleans/Fleans.Application/Grains/IWorkflowInstanceGrain.cs
@@ -43,7 +43,7 @@ public interface IWorkflowInstanceGrain : IGrainWithGuidKey, IWorkflowExecutionC
 
     Task HandleMessageDelivery(string activityId, Guid hostActivityInstanceId, ExpandoObject variables);
     Task HandleBoundaryMessageFired(string boundaryActivityId, Guid hostActivityInstanceId);
-    Task HandleTimerFired(string timerActivityId, Guid hostActivityInstanceId);
+    Task<TimeSpan?> HandleTimerFired(string timerActivityId, Guid hostActivityInstanceId);
     [AlwaysInterleave]
     Task HandleSignalDelivery(string activityId, Guid hostActivityInstanceId);
     [AlwaysInterleave]

--- a/src/Fleans/Fleans.Application/Grains/TimerCallbackGrain.cs
+++ b/src/Fleans/Fleans.Application/Grains/TimerCallbackGrain.cs
@@ -51,10 +51,13 @@ public partial class TimerCallbackGrain : Grain, ITimerCallbackGrain, IRemindabl
         // Call back to WorkflowInstance first — if this fails, the periodic
         // reminder will fire again and retry. HandleTimerFired is idempotent
         // (stale-timer guards check if the activity is still active).
+        // Returns non-null TimeSpan when a cycle timer needs re-registration.
         var workflowInstance = GrainFactory.GetGrain<IWorkflowInstanceGrain>(workflowInstanceId);
-        await workflowInstance.HandleTimerFired(timerActivityId, hostActivityInstanceId);
+        var cycleReRegistration = await workflowInstance.HandleTimerFired(timerActivityId, hostActivityInstanceId);
 
-        // Unregister only after successful callback
+        // Unregister the current reminder first, then re-register if needed.
+        // This ordering prevents the unregister-race: we always unregister the
+        // old reminder before creating a new one for the next cycle.
         try
         {
             var reminder = await this.GetReminder(ReminderName);
@@ -66,6 +69,13 @@ public partial class TimerCallbackGrain : Grain, ITimerCallbackGrain, IRemindabl
             // If unregister fails, the next periodic tick will retry —
             // HandleTimerFired is idempotent so this is safe.
             LogReminderUnregisterFailed(workflowInstanceId, timerActivityId, ex);
+        }
+
+        // Re-register locally for cycle timers (no cross-grain call — avoids deadlock)
+        if (cycleReRegistration.HasValue)
+        {
+            LogCycleReRegistering(workflowInstanceId, timerActivityId, cycleReRegistration.Value);
+            await this.RegisterOrUpdateReminder(ReminderName, cycleReRegistration.Value, TimeSpan.FromMinutes(1));
         }
     }
 
@@ -101,4 +111,8 @@ public partial class TimerCallbackGrain : Grain, ITimerCallbackGrain, IRemindabl
     [LoggerMessage(EventId = 10004, Level = LogLevel.Debug,
         Message = "Timer callback reminder unregister failed for workflow {WorkflowInstanceId}, activity {TimerActivityId}")]
     private partial void LogReminderUnregisterFailed(Guid workflowInstanceId, string timerActivityId, Exception exception);
+
+    [LoggerMessage(EventId = 10005, Level = LogLevel.Information,
+        Message = "Cycle timer re-registering locally for workflow {WorkflowInstanceId}, activity {TimerActivityId}, due in {DueTime}")]
+    private partial void LogCycleReRegistering(Guid workflowInstanceId, string timerActivityId, TimeSpan dueTime);
 }

--- a/src/Fleans/Fleans.Application/Grains/WorkflowInstance.EventHandling.cs
+++ b/src/Fleans/Fleans.Application/Grains/WorkflowInstance.EventHandling.cs
@@ -7,7 +7,7 @@ namespace Fleans.Application.Grains;
 
 public partial class WorkflowInstance
 {
-    public async Task HandleTimerFired(string timerActivityId, Guid hostActivityInstanceId)
+    public async Task<TimeSpan?> HandleTimerFired(string timerActivityId, Guid hostActivityInstanceId)
     {
         await EnsureWorkflowDefinitionAsync();
         var definition = await GetWorkflowDefinition();
@@ -20,8 +20,9 @@ public partial class WorkflowInstance
             SetWorkflowRequestContext();
             using var scope = BeginWorkflowScope();
             LogTimerReminderFired(timerActivityId);
-            await HandleBoundaryTimerFired(boundaryTimer, hostActivityInstanceId);
+            var cycleReRegistration = await HandleBoundaryTimerFired(boundaryTimer, hostActivityInstanceId);
             await _state.WriteStateAsync();
+            return cycleReRegistration;
         }
         else
         {
@@ -36,16 +37,17 @@ public partial class WorkflowInstance
             if (entry == null)
             {
                 LogStaleTimerIgnored(timerActivityId);
-                return;
+                return null;
             }
 
             await CompleteActivityState(timerActivityId, new ExpandoObject());
             await ExecuteWorkflow();
             await _state.WriteStateAsync();
+            return null;
         }
     }
 
-    private Task HandleBoundaryTimerFired(BoundaryTimerEvent boundaryTimer, Guid hostActivityInstanceId)
+    private Task<TimeSpan?> HandleBoundaryTimerFired(BoundaryTimerEvent boundaryTimer, Guid hostActivityInstanceId)
         => _boundaryHandler.HandleBoundaryTimerFiredAsync(boundaryTimer, hostActivityInstanceId, _workflowDefinition!);
 
     public async Task HandleMessageDelivery(string activityId, Guid hostActivityInstanceId, ExpandoObject variables)

--- a/src/Fleans/Fleans.Application/Services/BoundaryEventHandler.cs
+++ b/src/Fleans/Fleans.Application/Services/BoundaryEventHandler.cs
@@ -17,7 +17,7 @@ public partial class BoundaryEventHandler : IBoundaryEventHandler
         _logger = accessor.Logger;
     }
 
-    public async Task HandleBoundaryTimerFiredAsync(BoundaryTimerEvent boundaryTimer, Guid hostActivityInstanceId, IWorkflowDefinition definition)
+    public async Task<TimeSpan?> HandleBoundaryTimerFiredAsync(BoundaryTimerEvent boundaryTimer, Guid hostActivityInstanceId, IWorkflowDefinition definition)
     {
         var attachedActivityId = boundaryTimer.AttachedToActivityId;
 
@@ -27,7 +27,7 @@ public partial class BoundaryEventHandler : IBoundaryEventHandler
         if (attachedEntry == null)
         {
             LogStaleBoundaryTimerIgnored(boundaryTimer.ActivityId, hostActivityInstanceId);
-            return;
+            return null;
         }
 
         var attachedInstance = _accessor.GrainFactory.GetGrain<IActivityInstanceGrain>(attachedEntry.ActivityInstanceId);
@@ -55,18 +55,20 @@ public partial class BoundaryEventHandler : IBoundaryEventHandler
         await CreateAndExecuteBoundaryInstanceAsync(boundaryTimer, attachedInstance, definition,
             cloneVariables: !boundaryTimer.IsInterrupting);
 
-        // Re-register cycle timer for non-interrupting boundaries
+        // Return cycle re-registration info instead of calling back to the same grain
+        // (avoids Orleans grain deadlock — see issue #130)
         if (!boundaryTimer.IsInterrupting && boundaryTimer.TimerDefinition.Type == TimerType.Cycle)
         {
             var nextCycle = boundaryTimer.TimerDefinition.DecrementCycle();
             if (nextCycle != null)
             {
-                var callbackGrain = _accessor.GrainFactory.GetGrain<ITimerCallbackGrain>(
-                    _accessor.State.Id, $"{hostActivityInstanceId}:{boundaryTimer.ActivityId}");
-                await callbackGrain.Activate(nextCycle.GetDueTime());
+                var dueTime = nextCycle.GetDueTime();
                 LogCycleTimerReRegistered(boundaryTimer.ActivityId, nextCycle.Expression);
+                return dueTime;
             }
         }
+
+        return null;
     }
 
     public async Task HandleBoundaryMessageFiredAsync(MessageBoundaryEvent boundaryMessage, Guid hostActivityInstanceId, IWorkflowDefinition definition)

--- a/src/Fleans/Fleans.Application/Services/IBoundaryEventHandler.cs
+++ b/src/Fleans/Fleans.Application/Services/IBoundaryEventHandler.cs
@@ -6,7 +6,7 @@ namespace Fleans.Application.Services;
 public interface IBoundaryEventHandler
 {
     void Initialize(IBoundaryEventStateAccessor accessor);
-    Task HandleBoundaryTimerFiredAsync(BoundaryTimerEvent boundaryTimer, Guid hostActivityInstanceId, IWorkflowDefinition definition);
+    Task<TimeSpan?> HandleBoundaryTimerFiredAsync(BoundaryTimerEvent boundaryTimer, Guid hostActivityInstanceId, IWorkflowDefinition definition);
     Task HandleBoundaryMessageFiredAsync(MessageBoundaryEvent boundaryMessage, Guid hostActivityInstanceId, IWorkflowDefinition definition);
     Task HandleBoundaryErrorAsync(string activityId, BoundaryErrorEvent boundaryError, Guid activityInstanceId, IWorkflowDefinition definition);
     Task UnregisterBoundaryTimerRemindersAsync(string activityId, Guid hostActivityInstanceId, IWorkflowDefinition definition);


### PR DESCRIPTION
## Summary

Fixes #130 — Timer cycle (R3/PT5S) on non-interrupting boundary events caused an Orleans grain deadlock.

**Root cause:** `BoundaryEventHandler.HandleBoundaryTimerFiredAsync` called `callbackGrain.Activate()` on the same `TimerCallbackGrain` currently executing `ReceiveReminder`. Since Orleans grains are non-reentrant by default, both awaits blocked forever (deadlock).

**Secondary issue:** `ReceiveReminder` unconditionally unregistered the reminder after `HandleTimerFired`, which would race with any re-registration performed during the boundary handler.

**Fix (Approach A from issue analysis):** Return `TimeSpan?` from `HandleTimerFired` instead of calling back to the originating grain. `TimerCallbackGrain` handles cycle re-registration locally after unregistering the old reminder.

### Files changed
- `IBoundaryEventHandler.cs` / `BoundaryEventHandler.cs` — Return `Task<TimeSpan?>` from `HandleBoundaryTimerFiredAsync`, removed direct `Activate()` call
- `IWorkflowInstanceGrain.cs` / `WorkflowInstance.EventHandling.cs` — Propagate `TimeSpan?` through the call chain
- `TimerCallbackGrain.cs` — Capture cycle re-registration result, re-register locally after unregister
- `BoundaryEventHandlerTests.cs` — Updated cycle timer tests to verify return value pattern

### Test results
- Build: 0 errors, 0 warnings
- Tests: 493 passed, 0 failed

## Test plan
- [x] `dotnet build` — zero errors
- [x] `dotnet test` — all 493 tests pass
- [ ] Manual test 15C (timer cycle R3/PT5S) — verify cycle fires 3 times at 5s intervals

🤖 Generated with [Claude Code](https://claude.com/claude-code)