### PR TITLE
Add JournaledGrain PoC for Orleans EventSourcing validation (#140)

### DIFF
--- a/src/Fleans/Fleans.Application.Tests/Poc/JournaledCounterTestBase.cs
+++ b/src/Fleans/Fleans.Application.Tests/Poc/JournaledCounterTestBase.cs
@@ -1,0 +1,31 @@
+using Orleans.TestingHost;
+
+namespace Fleans.Application.Tests.Poc;
+
+public abstract class JournaledCounterTestBase
+{
+    protected TestCluster Cluster { get; private set; } = null!;
+
+    [TestInitialize]
+    public void BaseSetup()
+    {
+        var builder = new TestClusterBuilder();
+        builder.AddSiloBuilderConfigurator<JournaledCounterSiloConfigurator>();
+        Cluster = builder.Build();
+        Cluster.Deploy();
+    }
+
+    [TestCleanup]
+    public void BaseCleanup()
+    {
+        Cluster?.StopAllSilos();
+    }
+
+    private class JournaledCounterSiloConfigurator : ISiloConfigurator
+    {
+        public void Configure(ISiloBuilder hostBuilder) =>
+            hostBuilder
+                .AddLogStorageBasedLogConsistencyProviderAsDefault()
+                .AddMemoryGrainStorageAsDefault();
+    }
+}

--- a/src/Fleans/Fleans.Application.Tests/Poc/JournaledCounterTests.cs
+++ b/src/Fleans/Fleans.Application.Tests/Poc/JournaledCounterTests.cs
@@ -1,0 +1,143 @@
+using Fleans.Domain.Poc;
+
+namespace Fleans.Application.Tests.Poc;
+
+[TestClass]
+public class JournaledCounterTests : JournaledCounterTestBase
+{
+    [TestMethod]
+    public async Task Increment_ThreeTimes_ValueEqualsSum()
+    {
+        // Arrange
+        var grain = Cluster.GrainFactory.GetGrain<IJournaledCounterGrain>("test-1");
+
+        // Act
+        await grain.Increment(5);
+        await grain.Increment(3);
+        await grain.Increment(7);
+
+        // Assert
+        Assert.AreEqual(15, await grain.GetValue());
+        Assert.AreEqual(3, await grain.GetVersion());
+        Assert.AreEqual(3, await grain.GetEventCount());
+    }
+
+    [TestMethod]
+    public async Task MultipleEventTypes_CorrectFinalState()
+    {
+        // Arrange
+        var grain = Cluster.GrainFactory.GetGrain<IJournaledCounterGrain>("test-2");
+
+        // Act
+        await grain.Increment(10);
+        await grain.Decrement(3);
+        await grain.Increment(5);
+        await grain.Reset();
+        await grain.Increment(42);
+
+        // Assert
+        Assert.AreEqual(42, await grain.GetValue());
+        Assert.AreEqual(5, await grain.GetVersion());
+        Assert.AreEqual(5, await grain.GetEventCount());
+    }
+
+    [TestMethod]
+    public async Task StateRecovery_AfterDeactivation_StateMatchesPreDeactivation()
+    {
+        // Arrange — perform a multi-operation sequence
+        var grain = Cluster.GrainFactory.GetGrain<IJournaledCounterGrain>("test-3");
+        await grain.Increment(5);
+        await grain.Increment(3);
+        await grain.Decrement(2);
+        await grain.Reset();
+        await grain.Increment(10);
+
+        // Verify pre-deactivation state
+        Assert.AreEqual(10, await grain.GetValue());
+        Assert.AreEqual(5, await grain.GetVersion());
+        Assert.AreEqual(5, await grain.GetEventCount());
+
+        // Act — deactivate the grain via self-deactivation
+        await grain.Deactivate();
+        await Task.Delay(1000);
+
+        // Assert — reactivate by calling a method, state should be restored from event replay
+        var reactivated = Cluster.GrainFactory.GetGrain<IJournaledCounterGrain>("test-3");
+        Assert.AreEqual(10, await reactivated.GetValue());
+        Assert.AreEqual(5, await reactivated.GetVersion());
+        Assert.AreEqual(5, await reactivated.GetEventCount());
+    }
+
+    [TestMethod]
+    public async Task BatchRaiseEvent_SingleConfirmEvents_VersionIncrementsCorrectly()
+    {
+        // Arrange
+        var grain = Cluster.GrainFactory.GetGrain<IJournaledCounterGrain>("test-4");
+
+        // Act — each Increment drains one event via RaiseEvent + ConfirmEvents
+        await grain.Increment(1);
+        await grain.Increment(1);
+        await grain.Increment(1);
+
+        // Assert
+        Assert.AreEqual(3, await grain.GetValue());
+        Assert.AreEqual(3, await grain.GetVersion());
+    }
+
+    [TestMethod]
+    public async Task VersionTracking_IncrementsAcrossOperations()
+    {
+        // Arrange
+        var grain = Cluster.GrainFactory.GetGrain<IJournaledCounterGrain>("test-5");
+
+        // Act & Assert — verify version increments after each operation
+        await grain.Increment(1);
+        Assert.AreEqual(1, await grain.GetVersion());
+
+        await grain.Decrement(1);
+        Assert.AreEqual(2, await grain.GetVersion());
+
+        await grain.Reset();
+        Assert.AreEqual(3, await grain.GetVersion());
+
+        await grain.Increment(100);
+        Assert.AreEqual(4, await grain.GetVersion());
+        Assert.AreEqual(100, await grain.GetValue());
+    }
+
+    [TestMethod]
+    public async Task DoubleApply_AggregateAndJournaledGrainStayInSync()
+    {
+        // This validates the "double-apply" concern: events are applied once by
+        // the aggregate (for immediate consistency) and once by JournaledGrain
+        // (for persistence/recovery). After deactivation+reactivation, the
+        // JournaledGrain-replayed state should match what the aggregate had.
+        var grain = Cluster.GrainFactory.GetGrain<IJournaledCounterGrain>("test-6");
+
+        // Build up state through aggregate
+        await grain.Increment(100);
+        await grain.Decrement(30);
+        await grain.Increment(5);
+        // Expected: 100 - 30 + 5 = 75
+
+        var valueBeforeDeactivation = await grain.GetValue();
+        var versionBeforeDeactivation = await grain.GetVersion();
+        var eventCountBeforeDeactivation = await grain.GetEventCount();
+
+        // Deactivate to force state recovery via JournaledGrain event replay
+        await grain.Deactivate();
+        await Task.Delay(1000);
+
+        // Reactivate and verify
+        var reactivated = Cluster.GrainFactory.GetGrain<IJournaledCounterGrain>("test-6");
+        Assert.AreEqual(valueBeforeDeactivation, await reactivated.GetValue());
+        Assert.AreEqual(versionBeforeDeactivation, await reactivated.GetVersion());
+        Assert.AreEqual(eventCountBeforeDeactivation, await reactivated.GetEventCount());
+
+        // Continue operations after reactivation — should work seamlessly
+        await reactivated.Increment(25);
+        Assert.AreEqual(100, await reactivated.GetValue()); // 75 + 25
+        Assert.AreEqual(4, await reactivated.GetVersion());
+        Assert.AreEqual(4, await reactivated.GetEventCount());
+    }
+}

--- a/src/Fleans/Fleans.Application/Fleans.Application.csproj
+++ b/src/Fleans/Fleans.Application/Fleans.Application.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Orleans.EventSourcing" Version="10.0.1" />
     <PackageReference Include="Microsoft.Orleans.Reminders" Version="10.0.1" />
     <PackageReference Include="Microsoft.Orleans.Sdk" Version="10.0.1" />
     <PackageReference Include="Microsoft.Orleans.Streaming" Version="10.0.1" />

--- a/src/Fleans/Fleans.Application/Grains/Poc/JournaledCounterGrain.cs
+++ b/src/Fleans/Fleans.Application/Grains/Poc/JournaledCounterGrain.cs
@@ -1,0 +1,69 @@
+using Fleans.Domain.Poc;
+using Orleans.EventSourcing;
+
+namespace Fleans.Application.Grains.Poc;
+
+public class JournaledCounterGrain : JournaledGrain<CounterState, ICounterEvent>, IJournaledCounterGrain
+{
+    private CounterAggregate _aggregate = null!;
+    private bool _draining;
+
+    public override Task OnActivateAsync(CancellationToken cancellationToken)
+    {
+        // State is already recovered via TransitionState replay at this point
+        _aggregate = new CounterAggregate(State);
+        return base.OnActivateAsync(cancellationToken);
+    }
+
+    public async Task Increment(int amount)
+    {
+        _aggregate.Increment(amount);
+        await DrainToJournal();
+    }
+
+    public async Task Decrement(int amount)
+    {
+        _aggregate.Decrement(amount);
+        await DrainToJournal();
+    }
+
+    public async Task Reset()
+    {
+        _aggregate.Reset();
+        await DrainToJournal();
+    }
+
+    public Task<int> GetValue() => Task.FromResult(State.Value);
+
+    public Task<int> GetVersion() => Task.FromResult(Version);
+
+    public Task<int> GetEventCount() => Task.FromResult(State.EventCount);
+
+    public Task Deactivate()
+    {
+        DeactivateOnIdle();
+        return Task.CompletedTask;
+    }
+
+    protected override void TransitionState(CounterState state, ICounterEvent @event)
+    {
+        // During drain, the aggregate has already applied events to State.
+        // Only apply during replay (grain activation) when _draining is false.
+        if (!_draining)
+            state.Apply(@event);
+    }
+
+    private async Task DrainToJournal()
+    {
+        _draining = true;
+        var events = _aggregate.GetUncommittedEvents();
+        foreach (var e in events)
+        {
+            RaiseEvent(e);
+        }
+
+        await ConfirmEvents();
+        _aggregate.ClearUncommittedEvents();
+        _draining = false;
+    }
+}

--- a/src/Fleans/Fleans.Domain/Poc/CounterAggregate.cs
+++ b/src/Fleans/Fleans.Domain/Poc/CounterAggregate.cs
@@ -1,0 +1,44 @@
+namespace Fleans.Domain.Poc;
+
+/// <summary>
+/// Mirrors the WorkflowExecution aggregate's Emit/Apply pattern.
+/// The aggregate owns domain logic, accumulates uncommitted events,
+/// and the grain drains them to JournaledGrain's RaiseEvent/ConfirmEvents.
+/// </summary>
+public class CounterAggregate
+{
+    private readonly CounterState _state;
+    private readonly List<ICounterEvent> _uncommittedEvents = [];
+
+    public CounterAggregate(CounterState state)
+    {
+        _state = state ?? throw new ArgumentNullException(nameof(state));
+    }
+
+    public int Value => _state.Value;
+    public int EventCount => _state.EventCount;
+
+    public void Increment(int amount)
+    {
+        if (amount <= 0) throw new ArgumentOutOfRangeException(nameof(amount));
+        Emit(new CounterIncremented(amount));
+    }
+
+    public void Decrement(int amount)
+    {
+        if (amount <= 0) throw new ArgumentOutOfRangeException(nameof(amount));
+        Emit(new CounterDecremented(amount));
+    }
+
+    public void Reset() => Emit(new CounterReset());
+
+    public IReadOnlyList<ICounterEvent> GetUncommittedEvents() => _uncommittedEvents.AsReadOnly();
+
+    public void ClearUncommittedEvents() => _uncommittedEvents.Clear();
+
+    private void Emit(ICounterEvent @event)
+    {
+        _state.Apply(@event);
+        _uncommittedEvents.Add(@event);
+    }
+}

--- a/src/Fleans/Fleans.Domain/Poc/CounterState.cs
+++ b/src/Fleans/Fleans.Domain/Poc/CounterState.cs
@@ -1,0 +1,29 @@
+namespace Fleans.Domain.Poc;
+
+[GenerateSerializer]
+public class CounterState
+{
+    [Id(0)]
+    public int Value { get; set; }
+
+    [Id(1)]
+    public int EventCount { get; set; }
+
+    public void Apply(ICounterEvent @event)
+    {
+        switch (@event)
+        {
+            case CounterIncremented e:
+                Value += e.Amount;
+                break;
+            case CounterDecremented e:
+                Value -= e.Amount;
+                break;
+            case CounterReset:
+                Value = 0;
+                break;
+        }
+
+        EventCount++;
+    }
+}

--- a/src/Fleans/Fleans.Domain/Poc/ICounterEvent.cs
+++ b/src/Fleans/Fleans.Domain/Poc/ICounterEvent.cs
@@ -1,0 +1,12 @@
+namespace Fleans.Domain.Poc;
+
+public interface ICounterEvent;
+
+[GenerateSerializer]
+public record CounterIncremented([property: Id(0)] int Amount) : ICounterEvent;
+
+[GenerateSerializer]
+public record CounterDecremented([property: Id(0)] int Amount) : ICounterEvent;
+
+[GenerateSerializer]
+public record CounterReset() : ICounterEvent;

--- a/src/Fleans/Fleans.Domain/Poc/IJournaledCounterGrain.cs
+++ b/src/Fleans/Fleans.Domain/Poc/IJournaledCounterGrain.cs
@@ -1,0 +1,12 @@
+namespace Fleans.Domain.Poc;
+
+public interface IJournaledCounterGrain : IGrainWithStringKey
+{
+    Task Increment(int amount);
+    Task Decrement(int amount);
+    Task Reset();
+    Task<int> GetValue();
+    Task<int> GetVersion();
+    Task<int> GetEventCount();
+    Task Deactivate();
+}


### PR DESCRIPTION
## Summary

Closes #140

Adds `Microsoft.Orleans.EventSourcing` v10.0.1 and a standalone PoC grain (`JournaledCounterGrain`) that validates Orleans JournaledGrain integration with our existing aggregate Emit/Apply pattern before committing to the full migration (#135).

### Key findings validated by this PoC:

- **TransitionState delegation works**: `state.Apply(event)` in `TransitionState` correctly replays events on grain activation
- **Drain-and-raise pattern works**: Aggregate accumulates events → grain drains via `RaiseEvent()` → `ConfirmEvents()` persists
- **Double-apply requires a flag**: Since aggregate and JournaledGrain share the same state object, `TransitionState` must be skipped during drain (aggregate already applied). A `_draining` bool flag cleanly resolves this
- **State recovery works**: After `DeactivateOnIdle()`, JournaledGrain replays events via `TransitionState` and produces identical state
- **Version tracking works**: `Version` increments correctly per `RaiseEvent()` call
- **`LogConsistencyProviderAttribute` does not exist in Orleans 10.x**: Must register provider as default via `AddLogStorageBasedLogConsistencyProviderAsDefault()`
- **Package only needed in `Fleans.Application`**: Domain types only need `[GenerateSerializer]` from `Microsoft.Orleans.Sdk` (already referenced)
- **JournaledGrain requires mutable state**: `{ get; set; }` properties needed for `TransitionState` to work (matches existing `WorkflowInstanceState`)

### What was implemented:
- `Microsoft.Orleans.EventSourcing` added to `Fleans.Application.csproj` only
- Domain types in `Fleans.Domain/Poc/`: `ICounterEvent`, `CounterState`, `CounterAggregate`
- `JournaledCounterGrain` in `Fleans.Application/Grains/Poc/`
- Dedicated `JournaledCounterTestBase` with isolated `TestCluster` (no changes to shared test infrastructure)
- 6 integration tests covering: basic events, multiple event types, state recovery after deactivation, batch semantics, version tracking, double-apply sync validation

### No changes to existing production grains.

646 tests pass (301 Domain + 94 Persistence + 88 Infrastructure + 163 Application).

## Test plan
- [x] All 6 PoC integration tests pass
- [x] All 646 existing tests pass (no regressions)
- [x] Build succeeds with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)