### PR TITLE
Map health check endpoints in all environments and services

### DIFF
--- a/src/Fleans/Fleans.Api/Program.cs
+++ b/src/Fleans/Fleans.Api/Program.cs
@@ -62,5 +62,6 @@ app.UseHttpsRedirection();
 app.UseAuthorization();
 
 app.MapControllers();
+app.MapDefaultEndpoints();
 
 app.Run();

--- a/src/Fleans/Fleans.ServiceDefaults/Extensions.cs
+++ b/src/Fleans/Fleans.ServiceDefaults/Extensions.cs
@@ -103,19 +103,14 @@ namespace Microsoft.Extensions.Hosting
 
         public static WebApplication MapDefaultEndpoints(this WebApplication app)
         {
-            // Adding health checks endpoints to applications in non-development environments has security implications.
-            // See https://aka.ms/dotnet/aspire/healthchecks for details before enabling these endpoints in non-development environments.
-            if (app.Environment.IsDevelopment())
-            {
-                // All health checks must pass for app to be considered ready to accept traffic after starting
-                app.MapHealthChecks("/health");
+            // All health checks must pass for app to be considered ready to accept traffic after starting
+            app.MapHealthChecks("/health");
 
-                // Only health checks tagged with the "live" tag must pass for app to be considered alive
-                app.MapHealthChecks("/alive", new HealthCheckOptions
-                {
-                    Predicate = r => r.Tags.Contains("live")
-                });
-            }
+            // Only health checks tagged with the "live" tag must pass for app to be considered alive
+            app.MapHealthChecks("/alive", new HealthCheckOptions
+            {
+                Predicate = r => r.Tags.Contains("live")
+            });
 
             return app;
         }

--- a/src/Fleans/Fleans.Web/Program.cs
+++ b/src/Fleans/Fleans.Web/Program.cs
@@ -68,5 +68,6 @@ app.MapRazorComponents<App>()
 
 // Orleans Dashboard at /dashboard
 app.MapOrleansDashboard(routePrefix: "/dashboard");
+app.MapDefaultEndpoints();
 
 app.Run();


### PR DESCRIPTION
## Summary

Closes #152

- Removed `IsDevelopment()` guard from `MapDefaultEndpoints()` in `Extensions.cs` so `/health` and `/alive` endpoints are mapped in all environments (not just development)
- Added `app.MapDefaultEndpoints()` to `Fleans.Api/Program.cs` and `Fleans.Web/Program.cs` — previously only `Fleans.Mcp` called it

## Files Changed

| File | Change |
|------|--------|
| `Fleans.ServiceDefaults/Extensions.cs` | Removed environment check wrapping health endpoint mapping |
| `Fleans.Api/Program.cs` | Added `app.MapDefaultEndpoints()` after `app.MapControllers()` |
| `Fleans.Web/Program.cs` | Added `app.MapDefaultEndpoints()` after `app.MapOrleansDashboard()` |

## Test plan

- [x] Solution builds with zero warnings/errors
- [x] All 708 tests pass across all test projects
- [ ] Manual: Start via Aspire, verify `/health` and `/alive` return 200 on Api, Web, and Mcp services

🤖 Generated with [Claude Code](https://claude.com/claude-code)