### PR TITLE
Fix N+1 query pattern in GetInstancesByKey (#155)

### DIFF
--- a/src/Fleans/Fleans.Persistence/WorkflowQueryService.cs
+++ b/src/Fleans/Fleans.Persistence/WorkflowQueryService.cs
@@ -109,10 +109,9 @@ public class WorkflowQueryService : IWorkflowQueryService
     {
         await using var db = await _dbContextFactory.CreateDbContextAsync();
 
-        var definitionIds = await db.ProcessDefinitions
+        var definitionIds = db.ProcessDefinitions
             .Where(p => p.ProcessDefinitionKey == processDefinitionKey)
-            .Select(p => p.ProcessDefinitionId)
-            .ToListAsync();
+            .Select(p => p.ProcessDefinitionId);
 
         var instances = await db.WorkflowInstances
             .Where(w => w.ProcessDefinitionId != null && definitionIds.Contains(w.ProcessDefinitionId))
@@ -127,16 +126,12 @@ public class WorkflowQueryService : IWorkflowQueryService
     {
         await using var db = await _dbContextFactory.CreateDbContextAsync();
 
-        var definitionId = await db.ProcessDefinitions
+        var definitionIds = db.ProcessDefinitions
             .Where(p => p.ProcessDefinitionKey == key && p.Version == version)
-            .Select(p => p.ProcessDefinitionId)
-            .FirstOrDefaultAsync();
-
-        if (definitionId is null)
-            return [];
+            .Select(p => p.ProcessDefinitionId);
 
         var instances = await db.WorkflowInstances
-            .Where(w => w.ProcessDefinitionId == definitionId)
+            .Where(w => definitionIds.Contains(w.ProcessDefinitionId))
             .ToListAsync();
 
         return instances.Select(w => new WorkflowInstanceInfo(
@@ -150,10 +145,9 @@ public class WorkflowQueryService : IWorkflowQueryService
         page = page.Normalize();
         await using var db = await _dbContextFactory.CreateDbContextAsync();
 
-        var definitionIds = await db.ProcessDefinitions
+        var definitionIds = db.ProcessDefinitions
             .Where(p => p.ProcessDefinitionKey == processDefinitionKey)
-            .Select(p => p.ProcessDefinitionId)
-            .ToListAsync();
+            .Select(p => p.ProcessDefinitionId);
 
         var baseQuery = db.WorkflowInstances
             .Where(w => w.ProcessDefinitionId != null
@@ -168,16 +162,12 @@ public class WorkflowQueryService : IWorkflowQueryService
         page = page.Normalize();
         await using var db = await _dbContextFactory.CreateDbContextAsync();
 
-        var definitionId = await db.ProcessDefinitions
+        var definitionIds = db.ProcessDefinitions
             .Where(p => p.ProcessDefinitionKey == key && p.Version == version)
-            .Select(p => p.ProcessDefinitionId)
-            .FirstOrDefaultAsync();
-
-        if (definitionId is null)
-            return new PagedResult<WorkflowInstanceInfo>([], 0, page.Page, page.PageSize);
+            .Select(p => p.ProcessDefinitionId);
 
         var baseQuery = db.WorkflowInstances
-            .Where(w => w.ProcessDefinitionId == definitionId);
+            .Where(w => definitionIds.Contains(w.ProcessDefinitionId));
 
         return await ApplySieveAndProject(baseQuery, page);
     }


### PR DESCRIPTION
## Summary

Closes #155

- Replaced two-step query pattern (materialize definition IDs into memory → filter instances with `Contains`) with single SQL queries using unmaterialized `IQueryable` subqueries
- EF Core composes these into efficient `WHERE ... IN (SELECT ...)` SQL, eliminating the intermediate materialization
- Applied the fix to all 4 affected methods: both non-paginated and paginated overloads of `GetInstancesByKey` and `GetInstancesByKeyAndVersion`

## Changes

**`WorkflowQueryService.cs`** — the only file changed:

| Method | Before | After |
|--------|--------|-------|
| `GetInstancesByKey` (non-paginated) | `ToListAsync()` on definition IDs → `Contains` | `IQueryable` subquery → `Contains` |
| `GetInstancesByKeyAndVersion` (non-paginated) | `FirstOrDefaultAsync()` + null check → separate query | `IQueryable` subquery → `Contains` |
| `GetInstancesByKey` (paginated) | `ToListAsync()` on definition IDs → `Contains` | `IQueryable` subquery → `Contains` |
| `GetInstancesByKeyAndVersion` (paginated) | `FirstOrDefaultAsync()` + null check → separate query | `IQueryable` subquery → `Contains` |

## Test plan

- [x] All 717 existing tests pass (334 Domain + 4 Mcp + 104 Persistence + 94 Infrastructure + 181 Application)
- [x] No interface changes — fully backward compatible
- [x] No new types or files — minimal change (10 insertions, 20 deletions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)