### PR TITLE
Fix fire-and-forget CompleteActivity and add API endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ Add it to `Fleans.Api/Controllers/WorkflowController.cs`. DTOs go in `Fleans.Ser
 - Start instance: `POST https://localhost:7140/Workflow/start` — body: `{"WorkflowId":"process-id"}`
 - Send message: `POST https://localhost:7140/Workflow/message` — body: `{"MessageName":"...", "CorrelationKey":"...", "Variables":{}}`
 - Send signal: `POST https://localhost:7140/Workflow/signal` — body: `{"SignalName":"..."}`
+- Complete activity: `POST https://localhost:7140/Workflow/complete-activity` — body: `{"WorkflowInstanceId":"guid", "ActivityId":"activity-id", "Variables":{}}`
 
 ## Things to Know
 

--- a/src/Fleans/Fleans.Api/Controllers/WorkflowController.cs
+++ b/src/Fleans/Fleans.Api/Controllers/WorkflowController.cs
@@ -102,6 +102,40 @@ namespace Fleans.Api.Controllers
         [LoggerMessage(EventId = 8003, Level = LogLevel.Error, Message = "Error broadcasting signal")]
         private partial void LogSignalDeliveryError(Exception exception);
 
+        [HttpPost("complete-activity", Name = "CompleteActivity")]
+        public async Task<IActionResult> CompleteActivity([FromBody] CompleteActivityRequest request)
+        {
+            if (request == null || request.WorkflowInstanceId == Guid.Empty)
+                return BadRequest(new ErrorResponse("WorkflowInstanceId is required"));
+            if (string.IsNullOrWhiteSpace(request.ActivityId))
+                return BadRequest(new ErrorResponse("ActivityId is required"));
+
+            try
+            {
+                // System.Text.Json deserializes ExpandoObject values as JsonElement,
+                // which Orleans cannot serialize. Re-parse via Newtonsoft to get proper .NET primitives.
+                var variables = request.Variables != null
+                    ? JsonConvert.DeserializeObject<ExpandoObject>(
+                        System.Text.Json.JsonSerializer.Serialize(request.Variables))!
+                    : new ExpandoObject();
+
+                await _commandService.CompleteActivity(request.WorkflowInstanceId, request.ActivityId, variables);
+                return Ok();
+            }
+            catch (KeyNotFoundException ex)
+            {
+                return NotFound(new ErrorResponse(ex.Message));
+            }
+            catch (Exception ex)
+            {
+                LogCompleteActivityError(ex);
+                return StatusCode(500, new ErrorResponse("An error occurred while completing the activity"));
+            }
+        }
+
+        [LoggerMessage(EventId = 8007, Level = LogLevel.Error, Message = "Error completing activity")]
+        private partial void LogCompleteActivityError(Exception exception);
+
         [HttpGet("tasks", Name = "GetPendingTasks")]
         public async Task<IActionResult> GetPendingTasks(
             [FromQuery] string? assignee = null,

--- a/src/Fleans/Fleans.Application.Tests/WorkflowCommandServiceTests.cs
+++ b/src/Fleans/Fleans.Application.Tests/WorkflowCommandServiceTests.cs
@@ -71,14 +71,14 @@ namespace Fleans.Application.Tests
                 .Returns(Task.CompletedTask);
 
             // Act
-            _commandService.CompleteActivity(workflowInstanceId, activityId, variables);
+            await _commandService.CompleteActivity(workflowInstanceId, activityId, variables);
 
             // Assert
             await workflowInstance.Received(1).CompleteActivity(activityId, variables);
         }
 
         [TestMethod]
-        public void CompleteActivity_ShouldGetCorrectGrain_ByInstanceId()
+        public async Task CompleteActivity_ShouldGetCorrectGrain_ByInstanceId()
         {
             // Arrange
             var workflowInstanceId = Guid.NewGuid();
@@ -90,7 +90,7 @@ namespace Fleans.Application.Tests
                 .Returns(workflowInstance);
 
             // Act
-            _commandService.CompleteActivity(workflowInstanceId, activityId, variables);
+            await _commandService.CompleteActivity(workflowInstanceId, activityId, variables);
 
             // Assert
             _grainFactory.Received(1).GetGrain<IWorkflowInstanceGrain>(workflowInstanceId);

--- a/src/Fleans/Fleans.Application/IWorkflowCommandService.cs
+++ b/src/Fleans/Fleans.Application/IWorkflowCommandService.cs
@@ -8,7 +8,7 @@ public interface IWorkflowCommandService
 {
     Task<Guid> StartWorkflow(string workflowId);
     Task<Guid> StartWorkflowByProcessDefinitionId(string processDefinitionId);
-    void CompleteActivity(Guid workflowInstanceId, string activityId, ExpandoObject variables);
+    Task CompleteActivity(Guid workflowInstanceId, string activityId, ExpandoObject variables);
     Task<ProcessDefinitionSummary> DeployWorkflow(WorkflowDefinition workflow, string bpmnXml);
     Task<SendMessageResult> SendMessage(string messageName, string? correlationKey, ExpandoObject variables);
     Task<SendSignalResult> SendSignal(string signalName);

--- a/src/Fleans/Fleans.Application/WorkflowCommandService.cs
+++ b/src/Fleans/Fleans.Application/WorkflowCommandService.cs
@@ -44,11 +44,11 @@ public partial class WorkflowCommandService : IWorkflowCommandService
         return await workflowInstance.GetWorkflowInstanceId();
     }
 
-    public void CompleteActivity(Guid workflowInstanceId, string activityId, ExpandoObject variables)
+    public async Task CompleteActivity(Guid workflowInstanceId, string activityId, ExpandoObject variables)
     {
         LogCompletingActivity(workflowInstanceId, activityId);
 
-        _grainFactory.GetGrain<IWorkflowInstanceGrain>(workflowInstanceId)
+        await _grainFactory.GetGrain<IWorkflowInstanceGrain>(workflowInstanceId)
                      .CompleteActivity(activityId, variables);
     }
 

--- a/src/Fleans/Fleans.ServiceDefaults/DTOs/CompleteActivityRequest.cs
+++ b/src/Fleans/Fleans.ServiceDefaults/DTOs/CompleteActivityRequest.cs
@@ -1,0 +1,6 @@
+namespace Fleans.ServiceDefaults.DTOs;
+
+public record CompleteActivityRequest(
+    Guid WorkflowInstanceId,
+    string ActivityId,
+    Dictionary<string, object>? Variables = null);


### PR DESCRIPTION
## Summary

Closes #156

- **Fixed `CompleteActivity` fire-and-forget bug** — `WorkflowCommandService.CompleteActivity()` was `void` and did not await the grain call, silently swallowing all exceptions. Changed to `async Task` with `await` so errors propagate to callers.
- **Added `POST /Workflow/complete-activity` API endpoint** — enables external clients (test scripts, MCP tools, third-party integrations) to complete activities via HTTP. Follows the same error handling and ExpandoObject re-parse pattern as `SendMessage`/`SendSignal`.
- **Added `CompleteActivityRequest` DTO** in `Fleans.ServiceDefaults/DTOs/`
- **Updated unit tests** to use `async Task` with `await`
- **Updated CLAUDE.md** API endpoints section with the new endpoint

### Files Changed

| File | Change |
|------|--------|
| `IWorkflowCommandService.cs` | `void` → `Task` return type |
| `WorkflowCommandService.cs` | Add `async`/`await` |
| `WorkflowController.cs` | Add `CompleteActivity` endpoint + `[LoggerMessage]` |
| `CompleteActivityRequest.cs` | New DTO |
| `WorkflowCommandServiceTests.cs` | 2 tests updated to async |
| `CLAUDE.md` | Add complete-activity endpoint |

## Test plan

- [x] All 742 existing tests pass (0 failures)
- [x] Build succeeds with 0 errors
- [x] `CompleteActivity` unit tests updated and passing with async/await
- [ ] Manual: `POST /Workflow/complete-activity` with valid workflow instance returns 200
- [ ] Manual: `POST /Workflow/complete-activity` with invalid instance returns 404
- [ ] Manual: `POST /Workflow/complete-activity` with empty body returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)