### PR TITLE
Add infrastructure health checks for database (#157)

### DIFF
--- a/src/Fleans/Fleans.Api/Fleans.Api.csproj
+++ b/src/Fleans/Fleans.Api/Fleans.Api.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Aspire.StackExchange.Redis" Version="13.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
     <PackageReference Include="Microsoft.Orleans.Clustering.Redis" Version="10.0.1" />
     <PackageReference Include="Microsoft.Orleans.Dashboard" Version="10.0.1" />
     <PackageReference Include="Microsoft.Orleans.GrainDirectory.Redis" Version="10.0.1" />

--- a/src/Fleans/Fleans.Application.Tests/Fleans.Application.Tests.csproj
+++ b/src/Fleans/Fleans.Application.Tests/Fleans.Application.Tests.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
     <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Fleans/Fleans.Infrastructure.Tests/Fleans.Infrastructure.Tests.csproj
+++ b/src/Fleans/Fleans.Infrastructure.Tests/Fleans.Infrastructure.Tests.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.Orleans.TestingHost" Version="10.0.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
     <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Fleans/Fleans.Mcp/Fleans.Mcp.csproj
+++ b/src/Fleans/Fleans.Mcp/Fleans.Mcp.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.StackExchange.Redis" Version="13.1.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
     <PackageReference Include="Microsoft.Orleans.Client" Version="10.0.1" />
     <PackageReference Include="Microsoft.Orleans.Clustering.Redis" Version="10.0.1" />
     <PackageReference Include="Microsoft.Orleans.Sdk" Version="10.0.1" />

--- a/src/Fleans/Fleans.Persistence.Tests/Fleans.Persistence.Tests.csproj
+++ b/src/Fleans/Fleans.Persistence.Tests/Fleans.Persistence.Tests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="MSTest" Version="4.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Fleans/Fleans.Persistence/DependencyInjection.cs
+++ b/src/Fleans/Fleans.Persistence/DependencyInjection.cs
@@ -63,5 +63,8 @@ public static class EfCorePersistenceDependencyInjection
         services.AddSingleton<IWorkflowQueryService, WorkflowQueryService>();
         services.AddSingleton<IWorkflowStateProjection, EfCoreWorkflowStateProjection>();
         services.AddSingleton<EfCoreEventStore>();
+
+        services.AddHealthChecks()
+            .AddDbContextCheck<FleanCommandDbContext>("database");
     }
 }

--- a/src/Fleans/Fleans.Persistence/Fleans.Persistence.csproj
+++ b/src/Fleans/Fleans.Persistence/Fleans.Persistence.csproj
@@ -12,7 +12,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.5" />
     <PackageReference Include="Microsoft.Orleans.EventSourcing" Version="10.0.1" />
     <PackageReference Include="Microsoft.Orleans.Sdk" Version="10.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/src/Fleans/Fleans.Web/Fleans.Web.csproj
+++ b/src/Fleans/Fleans.Web/Fleans.Web.csproj
@@ -16,7 +16,7 @@
 
     <ItemGroup>
       <PackageReference Include="Aspire.StackExchange.Redis" Version="13.1.1" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.1" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
       <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.14.0" />
       <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Emoji" Version="4.14.0" />
       <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.14.0" />


### PR DESCRIPTION
## Summary

- Adds EF Core database health check (`AddDbContextCheck<FleanCommandDbContext>`) registered automatically via `AddEfCorePersistence`, so all consumers (Api, Web, Mcp) get a real database connectivity check on `/health`
- Updates all `Microsoft.EntityFrameworkCore.*` packages from 10.0.1 to 10.0.5 for version consistency with the new health check package
- Redis health checks are already provided by Aspire's `AddKeyedRedisClient` — no additional work needed
- Health endpoints (`/health`, `/alive`) are already mapped in all three projects (Api, Web, Mcp)

Closes #157

## Design Decisions

- **Approach A from the design plan**: Leverage existing Aspire Redis health checks + add EF Core database check. No custom Orleans health check (if the API responds to `/health`, the silo is alive).
- Health check registered in `AddEfCorePersistence` (Persistence layer) rather than in each `Program.cs` — single registration point, DRY.

## Test Plan

- [ ] All 742 existing tests pass (verified locally)
- [ ] Build succeeds with 0 errors
- [ ] Deploy via Aspire, verify `/health` returns `Healthy` on Api
- [ ] Stop SQLite access, verify `/health` returns `Unhealthy`
- [ ] Verify `/alive` returns `Healthy` (liveness only, no DB check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)