### PR TITLE
Add event-sourcing integration tests and performance baseline (#144)

### DIFF
--- a/src/Fleans/Fleans.Application.Tests/EventSourcingIntegrationTests.cs
+++ b/src/Fleans/Fleans.Application.Tests/EventSourcingIntegrationTests.cs
@@ -35,7 +35,7 @@ public class EventSourcingIntegrationTests : WorkflowTestBase
         Assert.IsTrue(preSnapshot.IsCompleted);
 
         // Act — deactivate and reactivate
-        await ForceGrainDeactivation<IWorkflowInstanceGrain>(instanceId);
+        await ForceAllGrainDeactivation();
 
         // Trigger reactivation by calling a method
         var postGrain = Cluster.GrainFactory.GetGrain<IWorkflowInstanceGrain>(instanceId);
@@ -82,7 +82,7 @@ public class EventSourcingIntegrationTests : WorkflowTestBase
         Assert.IsTrue(preSnapshot.IsCompleted);
 
         // Act — deactivate and reactivate
-        await ForceGrainDeactivation<IWorkflowInstanceGrain>(instanceId);
+        await ForceAllGrainDeactivation();
         var postGrain = Cluster.GrainFactory.GetGrain<IWorkflowInstanceGrain>(instanceId);
         await postGrain.GetWorkflowInstanceId();
 
@@ -146,7 +146,7 @@ public class EventSourcingIntegrationTests : WorkflowTestBase
         Assert.IsTrue(midSnapshot.ActiveActivities.Any(a => a.ActivityId == "waitPayment"));
 
         // Act — deactivate grain while waiting for message
-        await ForceGrainDeactivation<IWorkflowInstanceGrain>(instanceId);
+        await ForceAllGrainDeactivation();
 
         // Send message via correlation grain (full correlation path per design review)
         var grainKey = MessageCorrelationKey.Build("paymentReceived", "order-456");
@@ -181,7 +181,7 @@ public class EventSourcingIntegrationTests : WorkflowTestBase
         await grain.CompleteActivity("task2", new ExpandoObject());
 
         // Act — deactivate (triggers OnDeactivateAsync → snapshot write)
-        await ForceGrainDeactivation<IWorkflowInstanceGrain>(instanceId);
+        await ForceAllGrainDeactivation();
 
         // Assert — verify snapshot exists in DB
         var dbFactory = GetSiloService<IDbContextFactory<FleanCommandDbContext>>();
@@ -210,7 +210,7 @@ public class EventSourcingIntegrationTests : WorkflowTestBase
     public async Task VersionTracking_EventCountMatchesExpected()
     {
         // Arrange
-        var workflow = CreateSimpleWorkflow();
+        var workflow = CreateSimpleWorkflow("es-simple-workflow");
         var instanceId = Guid.NewGuid();
         var grain = Cluster.GrainFactory.GetGrain<IWorkflowInstanceGrain>(instanceId);
         var grainIdStr = instanceId.ToString();
@@ -260,7 +260,7 @@ public class EventSourcingIntegrationTests : WorkflowTestBase
     public async Task ExpandoObjectRoundTrip_VariablesSurviveEventStoreReplay()
     {
         // Arrange — workflow with a task that sets diverse variable types
-        var workflow = CreateSimpleWorkflow();
+        var workflow = CreateSimpleWorkflow("es-simple-workflow");
         var instanceId = Guid.NewGuid();
         var grain = Cluster.GrainFactory.GetGrain<IWorkflowInstanceGrain>(instanceId);
         await grain.SetWorkflow(workflow);
@@ -282,7 +282,7 @@ public class EventSourcingIntegrationTests : WorkflowTestBase
         var preVars = preSnapshot.VariableStates.First().Variables;
 
         // Act — deactivate and reactivate
-        await ForceGrainDeactivation<IWorkflowInstanceGrain>(instanceId);
+        await ForceAllGrainDeactivation();
         var postGrain = Cluster.GrainFactory.GetGrain<IWorkflowInstanceGrain>(instanceId);
         await postGrain.GetWorkflowInstanceId();
 
@@ -300,24 +300,6 @@ public class EventSourcingIntegrationTests : WorkflowTestBase
     }
 
     // ── Workflow Builders ────────────────────────────────────────────────
-
-    private static IWorkflowDefinition CreateSimpleWorkflow()
-    {
-        var start = new StartEvent("start");
-        var task = new TaskActivity("task");
-        var end = new EndEvent("end");
-
-        return new WorkflowDefinition
-        {
-            WorkflowId = "es-simple-workflow",
-            Activities = [start, task, end],
-            SequenceFlows =
-            [
-                new SequenceFlow("seq1", start, task),
-                new SequenceFlow("seq2", task, end)
-            ]
-        };
-    }
 
     private static IWorkflowDefinition CreateSequentialWorkflow()
     {

--- a/src/Fleans/Fleans.Application.Tests/EventSourcingPerformanceTests.cs
+++ b/src/Fleans/Fleans.Application.Tests/EventSourcingPerformanceTests.cs
@@ -28,10 +28,10 @@ public class EventSourcingPerformanceTests : WorkflowTestBase
         // Scenario 2: Short workflow (~10-15 events)
         var shortId = Guid.NewGuid();
         var shortGrain = Cluster.GrainFactory.GetGrain<IWorkflowInstanceGrain>(shortId);
-        await shortGrain.SetWorkflow(CreateSimpleWorkflow());
+        await shortGrain.SetWorkflow(CreateSimpleWorkflow("perf-simple"));
         await shortGrain.StartWorkflow();
         await shortGrain.CompleteActivity("task", new ExpandoObject());
-        await ForceGrainDeactivation<IWorkflowInstanceGrain>(shortId);
+        await ForceAllGrainDeactivation();
 
         sw.Restart();
         var reactivatedShort = Cluster.GrainFactory.GetGrain<IWorkflowInstanceGrain>(shortId);
@@ -46,7 +46,7 @@ public class EventSourcingPerformanceTests : WorkflowTestBase
         await medGrain.StartWorkflow();
         for (int i = 1; i <= 10; i++)
             await medGrain.CompleteActivity($"task{i}", new ExpandoObject());
-        await ForceGrainDeactivation<IWorkflowInstanceGrain>(medId);
+        await ForceAllGrainDeactivation();
 
         sw.Restart();
         var reactivatedMed = Cluster.GrainFactory.GetGrain<IWorkflowInstanceGrain>(medId);
@@ -61,7 +61,7 @@ public class EventSourcingPerformanceTests : WorkflowTestBase
         await longGrain.StartWorkflow();
         for (int i = 1; i <= 25; i++)
             await longGrain.CompleteActivity($"task{i}", new ExpandoObject());
-        await ForceGrainDeactivation<IWorkflowInstanceGrain>(longId);
+        await ForceAllGrainDeactivation();
 
         sw.Restart();
         var reactivatedLong = Cluster.GrainFactory.GetGrain<IWorkflowInstanceGrain>(longId);
@@ -77,24 +77,6 @@ public class EventSourcingPerformanceTests : WorkflowTestBase
             Console.WriteLine($"{scenario,-50} {ms,15}");
         Console.WriteLine(new string('-', 67));
         Console.WriteLine("Note: Results are machine-specific. Use as relative baseline only.\n");
-    }
-
-    private static IWorkflowDefinition CreateSimpleWorkflow()
-    {
-        var start = new StartEvent("start");
-        var task = new TaskActivity("task");
-        var end = new EndEvent("end");
-
-        return new WorkflowDefinition
-        {
-            WorkflowId = "perf-simple",
-            Activities = [start, task, end],
-            SequenceFlows =
-            [
-                new SequenceFlow("seq1", start, task),
-                new SequenceFlow("seq2", task, end)
-            ]
-        };
     }
 
     private static IWorkflowDefinition CreateLongSequentialWorkflow(int taskCount)

--- a/src/Fleans/Fleans.Application.Tests/WorkflowTestBase.cs
+++ b/src/Fleans/Fleans.Application.Tests/WorkflowTestBase.cs
@@ -3,8 +3,10 @@ using Fleans.Application.Events;
 using Fleans.Application.Scripts;
 using Fleans.Application.Conditions;
 using Fleans.Domain;
+using Fleans.Domain.Activities;
 using Fleans.Domain.Events;
 using Fleans.Domain.Persistence;
+using Fleans.Domain.Sequences;
 using Fleans.Persistence;
 using Fleans.Persistence.Events;
 using Microsoft.Data.Sqlite;
@@ -52,8 +54,9 @@ public abstract class WorkflowTestBase
     /// and waits for deactivation to complete. After this call, the next
     /// method call on any grain will trigger reactivation from the event store
     /// (snapshot + event replay).
+    /// Note: This deactivates ALL grains globally, not a specific grain.
     /// </summary>
-    protected async Task ForceGrainDeactivation<T>(Guid grainId) where T : IGrainWithGuidKey
+    protected async Task ForceAllGrainDeactivation()
     {
         var managementGrain = Cluster.GrainFactory.GetGrain<IManagementGrain>(0);
         await managementGrain.ForceActivationCollection(TimeSpan.Zero);
@@ -79,6 +82,28 @@ public abstract class WorkflowTestBase
             _sharedConnection?.Dispose();
             _sharedConnection = null;
         }
+    }
+
+    /// <summary>
+    /// Creates a minimal workflow: start → task → end.
+    /// Shared across test classes to avoid duplication.
+    /// </summary>
+    protected static IWorkflowDefinition CreateSimpleWorkflow(string workflowId = "simple-workflow")
+    {
+        var start = new StartEvent("start");
+        var task = new TaskActivity("task");
+        var end = new EndEvent("end");
+
+        return new WorkflowDefinition
+        {
+            WorkflowId = workflowId,
+            Activities = [start, task, end],
+            SequenceFlows =
+            [
+                new SequenceFlow("seq1", start, task),
+                new SequenceFlow("seq2", task, end)
+            ]
+        };
     }
 
     private class SimpleScriptExecutor : IScriptExpressionExecutor


### PR DESCRIPTION
## Summary

Closes #144

Implements the event-sourcing test infrastructure for the JournaledGrain migration:

- **6 integration tests** verifying end-to-end event sourcing behavior:
  - State recovery after grain deactivation (sequential workflow)
  - State recovery with parallel workflow (fork-join, variable merging preserved)
  - Mid-execution recovery via full message correlation path (grain deactivated while waiting for message, then reactivated by message delivery)
  - Snapshot written on graceful deactivation (verified in DB)
  - Event version tracking (contiguous ordering, event count matches)
  - ExpandoObject variable round-trip through event store (int, string, bool, double survive serialize/deserialize cycle)

- **1 performance baseline test** (`[TestCategory("Performance")]`, excludable from CI):
  - Measures grain activation time for fresh grain, short workflow, medium (10 tasks), and long (25 tasks) workflows

- **Test infrastructure additions to `WorkflowTestBase`**:
  - `ForceGrainDeactivation<T>()` — forces all grain activations to deactivate via `IManagementGrain.ForceActivationCollection`
  - `GetSiloService<T>()` — resolves services from silo DI for direct DB queries in tests
  - `EfCoreProcessDefinitionGrainStorage` registered in test DI (enables workflow definition reload after grain reactivation)

## Key decisions

- Used `IManagementGrain.ForceActivationCollection(TimeSpan.Zero)` for grain deactivation — simpler than targeting individual grains, and each test uses independent grain IDs
- Test 3 (mid-execution recovery) deploys workflow via factory to ensure `ProcessDefinitionId` is persisted, enabling the grain to reload its definition on reactivation
- All existing 721 tests continue to pass with no modifications

## Test plan

- [x] All 6 new integration tests pass
- [x] Performance baseline test passes
- [x] All 721 existing tests pass (no regressions)
- [x] Build succeeds with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)