### PR TITLE
Parallelize start event listener fan-out (#159)

### DIFF
--- a/src/Fleans/Fleans.Application/Grains/MessageStartEventListenerGrain.cs
+++ b/src/Fleans/Fleans.Application/Grains/MessageStartEventListenerGrain.cs
@@ -57,17 +57,16 @@ public partial class MessageStartEventListenerGrain : Grain, IMessageStartEventL
     public async ValueTask<List<Guid>> FireMessageStartEvent(ExpandoObject variables)
     {
         var messageName = this.GetPrimaryKeyString();
-        var createdIds = new List<Guid>();
 
         if (State.ProcessDefinitionKeys.Count == 0)
         {
             LogNoRegisteredProcesses(messageName);
-            return createdIds;
+            return [];
         }
 
         var factory = _grainFactory.GetGrain<IWorkflowInstanceFactoryGrain>(0);
 
-        foreach (var processDefinitionKey in State.ProcessDefinitionKeys)
+        var tasks = State.ProcessDefinitionKeys.Select(async processDefinitionKey =>
         {
             try
             {
@@ -76,7 +75,7 @@ public partial class MessageStartEventListenerGrain : Grain, IMessageStartEventL
                 if (!await factory.IsProcessActive(processDefinitionKey))
                 {
                     LogProcessDisabledSkipped(messageName, processDefinitionKey);
-                    continue;
+                    return (Guid?)null;
                 }
 
                 var instanceId = Guid.NewGuid();
@@ -94,16 +93,18 @@ public partial class MessageStartEventListenerGrain : Grain, IMessageStartEventL
                 await instance.SetInitialVariables(variables);
                 await instance.StartWorkflow();
 
-                createdIds.Add(instanceId);
                 LogMessageStartEventFired(messageName, processDefinitionKey, instanceId);
+                return (Guid?)instanceId;
             }
             catch (Exception ex)
             {
                 LogMessageStartEventFailed(messageName, processDefinitionKey, ex);
+                return (Guid?)null;
             }
-        }
+        });
 
-        return createdIds;
+        var results = await Task.WhenAll(tasks);
+        return results.Where(id => id.HasValue).Select(id => id!.Value).ToList();
     }
 
     private static string? FindMessageStartActivityId(IWorkflowDefinition definition, string messageName)

--- a/src/Fleans/Fleans.Application/Grains/SignalStartEventListenerGrain.cs
+++ b/src/Fleans/Fleans.Application/Grains/SignalStartEventListenerGrain.cs
@@ -56,17 +56,16 @@ public partial class SignalStartEventListenerGrain : Grain, ISignalStartEventLis
     public async ValueTask<List<Guid>> FireSignalStartEvent()
     {
         var signalName = this.GetPrimaryKeyString();
-        var createdIds = new List<Guid>();
 
         if (State.ProcessDefinitionKeys.Count == 0)
         {
             LogNoRegisteredProcesses(signalName);
-            return createdIds;
+            return [];
         }
 
         var factory = _grainFactory.GetGrain<IWorkflowInstanceFactoryGrain>(0);
 
-        foreach (var processDefinitionKey in State.ProcessDefinitionKeys)
+        var tasks = State.ProcessDefinitionKeys.Select(async processDefinitionKey =>
         {
             try
             {
@@ -75,7 +74,7 @@ public partial class SignalStartEventListenerGrain : Grain, ISignalStartEventLis
                 if (!await factory.IsProcessActive(processDefinitionKey))
                 {
                     LogProcessDisabledSkipped(signalName, processDefinitionKey);
-                    continue;
+                    return (Guid?)null;
                 }
 
                 var instanceId = Guid.NewGuid();
@@ -91,16 +90,18 @@ public partial class SignalStartEventListenerGrain : Grain, ISignalStartEventLis
                 await instance.SetWorkflow(definition, signalStartActivityId);
                 await instance.StartWorkflow();
 
-                createdIds.Add(instanceId);
                 LogSignalStartEventFired(signalName, processDefinitionKey, instanceId);
+                return (Guid?)instanceId;
             }
             catch (Exception ex)
             {
                 LogSignalStartEventFailed(signalName, processDefinitionKey, ex);
+                return (Guid?)null;
             }
-        }
+        });
 
-        return createdIds;
+        var results = await Task.WhenAll(tasks);
+        return results.Where(id => id.HasValue).Select(id => id!.Value).ToList();
     }
 
     private static string? FindSignalStartActivityId(IWorkflowDefinition definition, string signalName)


### PR DESCRIPTION
## Summary

Closes #159

- Replaced sequential `foreach` loops in `MessageStartEventListenerGrain.FireMessageStartEvent()` and `SignalStartEventListenerGrain.FireSignalStartEvent()` with `Task.WhenAll` for parallel workflow creation
- Follows the existing pattern from `SignalCorrelationGrain.BroadcastSignal()` which already uses `Task.WhenAll` for the same fan-out pattern
- Reduces latency from O(N×T) to O(T) when multiple processes are registered for the same message/signal start event
- Per-process error isolation preserved — one failure doesn't abort others
- No interface changes, no new types, no new tests needed (existing tests cover behavior)

## Key decisions

- Used `(Guid?)null` for failed/skipped processes and filter with `Where(id => id.HasValue)` — matches the existing behavior where failed processes are silently skipped
- No deviations from the approved design

## Test plan

- [x] All 334 existing tests pass without modification
- [x] Build succeeds with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)