### PR TITLE
Fix User Task API serialization error on CompleteTask (#192)

### DIFF
--- a/src/Fleans/Fleans.Api/Controllers/WorkflowController.cs
+++ b/src/Fleans/Fleans.Api/Controllers/WorkflowController.cs
@@ -205,13 +205,12 @@ namespace Fleans.Api.Controllers
             if (task == null)
                 return NotFound(new ErrorResponse($"User task '{activityInstanceId}' not found"));
 
-            var variables = new ExpandoObject();
-            if (request.Variables is { Count: > 0 })
-            {
-                var dict = (IDictionary<string, object?>)variables;
-                foreach (var kvp in request.Variables)
-                    dict[kvp.Key] = kvp.Value;
-            }
+            // System.Text.Json deserializes ExpandoObject values as JsonElement,
+            // which Orleans cannot serialize. Re-parse via Newtonsoft to get proper .NET primitives.
+            var variables = request.Variables is { Count: > 0 }
+                ? JsonConvert.DeserializeObject<ExpandoObject>(
+                    System.Text.Json.JsonSerializer.Serialize(request.Variables))!
+                : new ExpandoObject();
 
             LogUserTaskComplete(activityInstanceId, request.UserId);
             await _commandService.CompleteUserTask(


### PR DESCRIPTION
## Summary

Closes #192
Also fixes #181 (duplicate)

- **Serialization fix**: CompleteTask endpoint manually copied `Dictionary<string, object?>` values into `ExpandoObject`, passing through `JsonElement` values that Orleans cannot serialize (`CodecNotFoundException`). Applied the same Newtonsoft re-parsing pattern already used by `SendMessage` and `CompleteActivity` endpoints.
- **Status code fix**: Already resolved by `GlobalExceptionHandler` (added in prior PR) — `BadRequestActivityException` now maps to 400, `InvalidOperationException` to 409. No controller changes needed.

## Changes

| File | Change |
|------|--------|
| `WorkflowController.cs` | Replace manual dict iteration with Newtonsoft dual-serializer pattern in `CompleteTask` |

## Test plan

- [x] All 728 tests pass
- [x] Build compiles cleanly
- [ ] Manual: `POST /tasks/{id}/complete` with `{"variables": {"approved": true, "count": 5}}` returns 200 (not `CodecNotFoundException`)
- [ ] Manual: Attempt complete with wrong user → returns 400 (not 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)