### PR TITLE
Fix non-interrupting boundary event prematurely completing workflow

### DIFF
--- a/src/Fleans/Fleans.Application.Tests/BoundaryEventTestBase.cs
+++ b/src/Fleans/Fleans.Application.Tests/BoundaryEventTestBase.cs
@@ -158,9 +158,129 @@ public abstract class BoundaryEventTestBase : WorkflowTestBase
 
         await instance.CompleteActivity("task1", new ExpandoObject());
 
+        // After completing task1, the main path reaches end1 which issues CompleteWorkflowCommand.
+        // The guard defers completion because afterBoundary is still active.
+        var afterTask1Snapshot = await QueryService.GetStateSnapshot(instanceId);
+        Assert.IsFalse(afterTask1Snapshot!.IsCompleted,
+            "Workflow should NOT be completed — afterBoundary is still active");
+        Assert.IsTrue(afterTask1Snapshot.ActiveActivities.Any(a => a.ActivityId == "afterBoundary"),
+            "afterBoundary should still be active");
+
+        await instance.CompleteActivity("afterBoundary", new ExpandoObject());
+
         var finalSnapshot = await QueryService.GetStateSnapshot(instanceId);
-        Assert.IsTrue(finalSnapshot!.IsCompleted, "Workflow should be completed");
+        Assert.IsTrue(finalSnapshot!.IsCompleted, "Workflow should be completed after all paths finish");
         var task1Entry = finalSnapshot.CompletedActivities.First(a => a.ActivityId == "task1");
         Assert.IsFalse(task1Entry.IsCancelled, "task1 should NOT be cancelled");
+    }
+
+    /// <summary>
+    /// Regression test for #191: boundary path auto-completes (goes directly to EndEvent)
+    /// while the main task is still active — workflow must NOT complete prematurely.
+    /// </summary>
+    [TestMethod]
+    public async Task NonInterruptingBoundary_AutoCompleteBoundaryPath_DoesNotPrematurelyComplete()
+    {
+        var start = new StartEvent("start");
+        var task = new TaskActivity("task1");
+        var boundary = CreateBoundaryEvent("boundary1", "task1", isInterrupting: false);
+        var end1 = new EndEvent("end1");
+        var boundaryEnd = new EndEvent("boundaryEnd");
+
+        var workflow = new WorkflowDefinition
+        {
+            WorkflowId = "ni-boundary-auto-complete",
+            Activities = [start, task, boundary, end1, boundaryEnd],
+            SequenceFlows =
+            [
+                new SequenceFlow("f1", start, task),
+                new SequenceFlow("f2", task, end1),
+                new SequenceFlow("f3", boundary, boundaryEnd)
+            ],
+            Messages = GetMessageDefinitions(),
+            Signals = GetSignalDefinitions()
+        };
+
+        var instance = Cluster.GrainFactory.GetGrain<IWorkflowInstanceGrain>(Guid.NewGuid());
+        await instance.SetWorkflow(workflow);
+        await SetupInitialState(instance);
+        await instance.StartWorkflow();
+
+        var instanceId = instance.GetPrimaryKey();
+        var preSnapshot = await QueryService.GetStateSnapshot(instanceId);
+        var hostInstanceId = preSnapshot!.ActiveActivities
+            .First(a => a.ActivityId == "task1").ActivityInstanceId;
+
+        // Fire boundary — boundaryEnd auto-completes immediately, issuing CompleteWorkflowCommand
+        await TriggerBoundaryEvent(instance, hostInstanceId);
+
+        var midSnapshot = await QueryService.GetStateSnapshot(instanceId);
+        Assert.IsFalse(midSnapshot!.IsCompleted,
+            "Workflow should NOT be completed — task1 is still active");
+        Assert.IsTrue(midSnapshot.ActiveActivities.Any(a => a.ActivityId == "task1"),
+            "task1 should still be active");
+
+        // Now complete the main task — workflow should complete
+        await instance.CompleteActivity("task1", new ExpandoObject());
+
+        var finalSnapshot = await QueryService.GetStateSnapshot(instanceId);
+        Assert.IsTrue(finalSnapshot!.IsCompleted,
+            "Workflow should be completed after all paths finish");
+    }
+
+    /// <summary>
+    /// Verifies that when main path completes first and boundary path is still running,
+    /// workflow waits for the boundary path to finish.
+    /// </summary>
+    [TestMethod]
+    public async Task NonInterruptingBoundary_MainPathCompletesFirst_WorkflowCompletesWhenBoundaryDone()
+    {
+        var start = new StartEvent("start");
+        var task = new TaskActivity("task1");
+        var boundary = CreateBoundaryEvent("boundary1", "task1", isInterrupting: false);
+        var afterBoundary = new TaskActivity("afterBoundary");
+        var end1 = new EndEvent("end1");
+        var end2 = new EndEvent("end2");
+
+        var workflow = new WorkflowDefinition
+        {
+            WorkflowId = "ni-boundary-main-first",
+            Activities = [start, task, boundary, afterBoundary, end1, end2],
+            SequenceFlows =
+            [
+                new SequenceFlow("f1", start, task),
+                new SequenceFlow("f2", task, end1),
+                new SequenceFlow("f3", boundary, afterBoundary),
+                new SequenceFlow("f4", afterBoundary, end2)
+            ],
+            Messages = GetMessageDefinitions(),
+            Signals = GetSignalDefinitions()
+        };
+
+        var instance = Cluster.GrainFactory.GetGrain<IWorkflowInstanceGrain>(Guid.NewGuid());
+        await instance.SetWorkflow(workflow);
+        await SetupInitialState(instance);
+        await instance.StartWorkflow();
+
+        var instanceId = instance.GetPrimaryKey();
+        var preSnapshot = await QueryService.GetStateSnapshot(instanceId);
+        var hostInstanceId = preSnapshot!.ActiveActivities
+            .First(a => a.ActivityId == "task1").ActivityInstanceId;
+
+        await TriggerBoundaryEvent(instance, hostInstanceId);
+
+        // Complete main path first — task1 → end1
+        await instance.CompleteActivity("task1", new ExpandoObject());
+
+        var midSnapshot = await QueryService.GetStateSnapshot(instanceId);
+        Assert.IsFalse(midSnapshot!.IsCompleted,
+            "Workflow should NOT be completed — afterBoundary still active");
+
+        // Now complete boundary path — afterBoundary → end2
+        await instance.CompleteActivity("afterBoundary", new ExpandoObject());
+
+        var finalSnapshot = await QueryService.GetStateSnapshot(instanceId);
+        Assert.IsTrue(finalSnapshot!.IsCompleted,
+            "Workflow should be completed after both paths finish");
     }
 }

--- a/src/Fleans/Fleans.Application.Tests/MessageBoundaryEventTests.cs
+++ b/src/Fleans/Fleans.Application.Tests/MessageBoundaryEventTests.cs
@@ -88,9 +88,15 @@ public class MessageBoundaryEventTests : BoundaryEventTestBase
         // Complete the attached activity normally
         await workflowInstance.CompleteActivity("task1", new ExpandoObject());
 
-        // Workflow may now be completed (task1 → end)
+        // After completing task1, workflow should NOT yet be completed — afterMsg is still active
+        var afterTask1Snapshot = await QueryService.GetStateSnapshot(instanceId);
+        Assert.IsFalse(afterTask1Snapshot!.IsCompleted,
+            "Workflow should NOT be completed — afterMsg is still active");
+
+        await workflowInstance.CompleteActivity("afterMsg", new ExpandoObject());
+
         var finalSnapshot = await QueryService.GetStateSnapshot(instanceId);
-        Assert.IsTrue(finalSnapshot!.IsCompleted, "Workflow should be completed");
+        Assert.IsTrue(finalSnapshot!.IsCompleted, "Workflow should be completed after all paths finish");
         var task1Entry = finalSnapshot.CompletedActivities.First(a => a.ActivityId == "task1");
         Assert.IsFalse(task1Entry.IsCancelled, "task1 should NOT be cancelled");
     }

--- a/src/Fleans/Fleans.Domain/Aggregates/WorkflowExecution.cs
+++ b/src/Fleans/Fleans.Domain/Aggregates/WorkflowExecution.cs
@@ -270,6 +270,14 @@ public class WorkflowExecution
             switch (command)
             {
                 case CompleteWorkflowCommand:
+                    // Guard: only complete workflow when no other activities are active.
+                    // The current EndEvent (identified by activityInstanceId) hasn't been
+                    // marked completed yet — exclude it from the check.
+                    var otherActive = _state.GetActiveActivities()
+                        .Any(e => e.ActivityInstanceId != activityInstanceId);
+                    if (otherActive)
+                        break; // Defer — workflow will complete when last EndEvent fires
+
                     Emit(new WorkflowCompleted());
                     // If this is a child workflow, notify parent of completion
                     if (_state.ParentWorkflowInstanceId.HasValue)


### PR DESCRIPTION
## Summary

Closes #191

- **Added guard in `WorkflowExecution.ProcessCommands`** for `CompleteWorkflowCommand` — checks if any other activities are still active (excluding the current EndEvent) before completing the workflow. If other activities remain, completion is deferred until the last EndEvent fires.
- **Updated existing non-interrupting boundary tests** to expect correct BPMN semantics (workflow waits for all paths to complete)
- **Added 2 new test scenarios per boundary type** (timer/message/signal = 6 total):
  - `NonInterruptingBoundary_AutoCompleteBoundaryPath_DoesNotPrematurelyComplete` — boundary path goes directly to EndEvent while main task is active
  - `NonInterruptingBoundary_MainPathCompletesFirst_WorkflowCompletesWhenBoundaryDone` — main path completes first, boundary path finishes later

## Root Cause

EndEvent unconditionally issues `CompleteWorkflowCommand` when in root scope. When a non-interrupting boundary path reaches its EndEvent while the main task is still active, the workflow was completed prematurely.

## Fix

Single guard clause in `ProcessCommands` — check `GetActiveActivities()` for any entries besides the current EndEvent. This is correct BPMN semantics: a process instance completes when all tokens are consumed.

## Test Plan

- [x] All 734 existing tests pass (334 domain + 194 application + 108 persistence + 94 infrastructure + 4 MCP)
- [x] 6 new tests added across timer/message/signal boundary event test classes
- [ ] Manual test: `tests/manual/15-non-interrupting-boundaries` scenarios 15.1 and 15.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)