### PR TITLE
Replace stringly-typed RequestContext keys with constants

### DIFF
--- a/src/Fleans/Fleans.Application/Grains/WorkflowInstance.cs
+++ b/src/Fleans/Fleans.Application/Grains/WorkflowInstance.cs
@@ -5,6 +5,7 @@ using Fleans.Domain.Effects;
 using Fleans.Domain.Events;
 using Fleans.Domain.States;
 using Fleans.Application.Adapters;
+using Fleans.Application.Logging;
 using Microsoft.Extensions.Logging;
 using Orleans;
 using Orleans.EventSourcing;
@@ -217,10 +218,10 @@ public partial class WorkflowInstance :
     {
         if (_workflowDefinition is null) return;
 
-        RequestContext.Set("WorkflowId", _workflowDefinition.WorkflowId);
-        RequestContext.Set("WorkflowInstanceId", this.GetPrimaryKey().ToString());
+        RequestContext.Set(WorkflowContextKeys.WorkflowId, _workflowDefinition.WorkflowId);
+        RequestContext.Set(WorkflowContextKeys.WorkflowInstanceId, this.GetPrimaryKey().ToString());
         if (_workflowDefinition.ProcessDefinitionId is not null)
-            RequestContext.Set("ProcessDefinitionId", _workflowDefinition.ProcessDefinitionId);
+            RequestContext.Set(WorkflowContextKeys.ProcessDefinitionId, _workflowDefinition.ProcessDefinitionId);
     }
 
     private IDisposable? BeginWorkflowScope()

--- a/src/Fleans/Fleans.Application/Logging/WorkflowContextKeys.cs
+++ b/src/Fleans/Fleans.Application/Logging/WorkflowContextKeys.cs
@@ -1,0 +1,15 @@
+namespace Fleans.Application.Logging;
+
+/// <summary>
+/// Constants for Orleans RequestContext keys used to propagate
+/// workflow correlation identifiers across grain calls.
+/// </summary>
+internal static class WorkflowContextKeys
+{
+    public const string WorkflowId = "WorkflowId";
+    public const string ProcessDefinitionId = "ProcessDefinitionId";
+    public const string WorkflowInstanceId = "WorkflowInstanceId";
+    public const string ActivityId = "ActivityId";
+    public const string ActivityInstanceId = "ActivityInstanceId";
+    public const string VariablesId = "VariablesId";
+}

--- a/src/Fleans/Fleans.Application/Logging/WorkflowLoggingContext.cs
+++ b/src/Fleans/Fleans.Application/Logging/WorkflowLoggingContext.cs
@@ -9,12 +9,12 @@ internal static class WorkflowLoggingContext
         ILogger logger, string workflowId, string? processDefinitionId,
         Guid workflowInstanceId, string? activityId = null)
     {
-        RequestContext.Set("WorkflowId", workflowId);
-        RequestContext.Set("WorkflowInstanceId", workflowInstanceId.ToString());
+        RequestContext.Set(WorkflowContextKeys.WorkflowId, workflowId);
+        RequestContext.Set(WorkflowContextKeys.WorkflowInstanceId, workflowInstanceId.ToString());
         if (processDefinitionId is not null)
-            RequestContext.Set("ProcessDefinitionId", processDefinitionId);
+            RequestContext.Set(WorkflowContextKeys.ProcessDefinitionId, processDefinitionId);
         if (activityId is not null)
-            RequestContext.Set("ActivityId", activityId);
+            RequestContext.Set(WorkflowContextKeys.ActivityId, activityId);
 
         return logger.BeginScope(
             "[{WorkflowId}, {ProcessDefinitionId}, {WorkflowInstanceId}, {ActivityId}]",

--- a/src/Fleans/Fleans.Application/Logging/WorkflowLoggingScopeFilter.cs
+++ b/src/Fleans/Fleans.Application/Logging/WorkflowLoggingScopeFilter.cs
@@ -23,12 +23,12 @@ public class WorkflowLoggingScopeFilter : IIncomingGrainCallFilter
             return;
         }
 
-        var wid = RequestContext.Get("WorkflowId") as string;
-        var pdid = RequestContext.Get("ProcessDefinitionId") as string;
-        var wiid = RequestContext.Get("WorkflowInstanceId") as string;
-        var aid = RequestContext.Get("ActivityId") as string;
-        var aiid = RequestContext.Get("ActivityInstanceId") as string;
-        var vid = RequestContext.Get("VariablesId") as string;
+        var wid = RequestContext.Get(WorkflowContextKeys.WorkflowId) as string;
+        var pdid = RequestContext.Get(WorkflowContextKeys.ProcessDefinitionId) as string;
+        var wiid = RequestContext.Get(WorkflowContextKeys.WorkflowInstanceId) as string;
+        var aid = RequestContext.Get(WorkflowContextKeys.ActivityId) as string;
+        var aiid = RequestContext.Get(WorkflowContextKeys.ActivityInstanceId) as string;
+        var vid = RequestContext.Get(WorkflowContextKeys.VariablesId) as string;
 
         if (wid is not null || wiid is not null)
         {

--- a/src/Fleans/Fleans.Application/WorkflowFactory/WorkflowInstanceFactoryGrain.cs
+++ b/src/Fleans/Fleans.Application/WorkflowFactory/WorkflowInstanceFactoryGrain.cs
@@ -1,4 +1,5 @@
 using Fleans.Application.Grains;
+using Fleans.Application.Logging;
 using Fleans.Application.QueryModels;
 using Fleans.Application.WorkflowFactory;
 using Fleans.Domain;
@@ -58,9 +59,9 @@ public partial class WorkflowInstanceFactoryGrain : Grain, IWorkflowInstanceFact
         var guid = Guid.NewGuid();
         LogCreatingInstance(workflowId, definition.ProcessDefinitionId, guid);
 
-        RequestContext.Set("WorkflowId", workflowId);
-        RequestContext.Set("ProcessDefinitionId", definition.ProcessDefinitionId);
-        RequestContext.Set("WorkflowInstanceId", guid.ToString());
+        RequestContext.Set(WorkflowContextKeys.WorkflowId, workflowId);
+        RequestContext.Set(WorkflowContextKeys.ProcessDefinitionId, definition.ProcessDefinitionId);
+        RequestContext.Set(WorkflowContextKeys.WorkflowInstanceId, guid.ToString());
 
         var workflowInstanceGrain = _grainFactory.GetGrain<IWorkflowInstanceGrain>(guid);
 
@@ -84,9 +85,9 @@ public partial class WorkflowInstanceFactoryGrain : Grain, IWorkflowInstanceFact
         var guid = Guid.NewGuid();
         LogCreatingInstance(definition.ProcessDefinitionKey, processDefinitionId, guid);
 
-        RequestContext.Set("WorkflowId", definition.ProcessDefinitionKey);
-        RequestContext.Set("ProcessDefinitionId", processDefinitionId);
-        RequestContext.Set("WorkflowInstanceId", guid.ToString());
+        RequestContext.Set(WorkflowContextKeys.WorkflowId, definition.ProcessDefinitionKey);
+        RequestContext.Set(WorkflowContextKeys.ProcessDefinitionId, processDefinitionId);
+        RequestContext.Set(WorkflowContextKeys.WorkflowInstanceId, guid.ToString());
 
         var workflowInstanceGrain = _grainFactory.GetGrain<IWorkflowInstanceGrain>(guid);
 


### PR DESCRIPTION
## Summary

Closes #198

- Extract `WorkflowContextKeys` static class in `Fleans.Application/Logging/` with `const string` fields for all 6 Orleans `RequestContext` keys
- Replace all 19 raw string literals (`RequestContext.Set("WorkflowId", ...)` / `RequestContext.Get("WorkflowId")`) across 4 files with constant references
- Pure rename refactoring — zero behavioral change, `const string` inlines at compile time

## Files Changed

| File | Change |
|------|--------|
| `Fleans.Application/Logging/WorkflowContextKeys.cs` | **New** — 6 constant fields |
| `Fleans.Application/Logging/WorkflowLoggingContext.cs` | 4 `Set` calls → constants |
| `Fleans.Application/Logging/WorkflowLoggingScopeFilter.cs` | 6 `Get` calls → constants |
| `Fleans.Application/Grains/WorkflowInstance.cs` | 3 `Set` calls → constants |
| `Fleans.Application/WorkflowFactory/WorkflowInstanceFactoryGrain.cs` | 6 `Set` calls → constants |

## Verification

- `dotnet build` — 0 errors
- `dotnet test` — 728 passed, 0 failed
- Grep confirms no raw string `RequestContext.Set/Get("...")` calls remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)