### PR TITLE
Parallelize independent grain calls in start event listener registration

### DIFF
--- a/src/Fleans/Fleans.Application/WorkflowFactory/WorkflowInstanceFactoryGrain.cs
+++ b/src/Fleans/Fleans.Application/WorkflowFactory/WorkflowInstanceFactoryGrain.cs
@@ -167,12 +167,13 @@ public partial class WorkflowInstanceFactoryGrain : Grain, IWorkflowInstanceFact
         if (versions.Count > 1)
         {
             IWorkflowDefinition previousWorkflow = versions[^2].Workflow;
+            var unregisterTasks = new List<Task>();
 
             // Timer: if previous had timer but new doesn't, deactivate
             if (!scope.HasTimerStartEvent() && previousWorkflow.HasTimerStartEvent())
             {
                 var scheduler = _grainFactory.GetGrain<ITimerStartEventSchedulerGrain>(processDefinitionKey);
-                await scheduler.DeactivateScheduler();
+                unregisterTasks.Add(scheduler.DeactivateScheduler());
             }
 
             // Messages: unregister removed message names
@@ -180,7 +181,7 @@ public partial class WorkflowInstanceFactoryGrain : Grain, IWorkflowInstanceFact
             foreach (var removedName in previousWorkflow.GetMessageStartEventNames().Except(newMessageNames))
             {
                 var listener = _grainFactory.GetGrain<IMessageStartEventListenerGrain>(removedName);
-                await listener.UnregisterProcess(processDefinitionKey);
+                unregisterTasks.Add(listener.UnregisterProcess(processDefinitionKey).AsTask());
             }
 
             // Signals: unregister removed signal names
@@ -188,8 +189,10 @@ public partial class WorkflowInstanceFactoryGrain : Grain, IWorkflowInstanceFact
             foreach (var removedName in previousWorkflow.GetSignalStartEventNames().Except(newSignalNames))
             {
                 var listener = _grainFactory.GetGrain<ISignalStartEventListenerGrain>(removedName);
-                await listener.UnregisterProcess(processDefinitionKey);
+                unregisterTasks.Add(listener.UnregisterProcess(processDefinitionKey).AsTask());
             }
+
+            await Task.WhenAll(unregisterTasks);
         }
 
         return ToSummary(definition);
@@ -286,10 +289,12 @@ public partial class WorkflowInstanceFactoryGrain : Grain, IWorkflowInstanceFact
 
     private async Task UnregisterAllStartEventListeners(IWorkflowDefinition workflow, string processDefinitionKey)
     {
+        var tasks = new List<Task>();
+
         if (workflow.Activities.OfType<TimerStartEvent>().Any())
         {
             var scheduler = _grainFactory.GetGrain<ITimerStartEventSchedulerGrain>(processDefinitionKey);
-            await scheduler.DeactivateScheduler();
+            tasks.Add(scheduler.DeactivateScheduler());
         }
 
         foreach (var messageStart in workflow.Activities.OfType<MessageStartEvent>())
@@ -298,7 +303,7 @@ public partial class WorkflowInstanceFactoryGrain : Grain, IWorkflowInstanceFact
             if (msgDef != null)
             {
                 var listener = _grainFactory.GetGrain<IMessageStartEventListenerGrain>(msgDef.Name);
-                await listener.UnregisterProcess(processDefinitionKey);
+                tasks.Add(listener.UnregisterProcess(processDefinitionKey).AsTask());
             }
         }
 
@@ -308,17 +313,21 @@ public partial class WorkflowInstanceFactoryGrain : Grain, IWorkflowInstanceFact
             if (sigDef != null)
             {
                 var listener = _grainFactory.GetGrain<ISignalStartEventListenerGrain>(sigDef.Name);
-                await listener.UnregisterProcess(processDefinitionKey);
+                tasks.Add(listener.UnregisterProcess(processDefinitionKey).AsTask());
             }
         }
+
+        await Task.WhenAll(tasks);
     }
 
     private async Task RegisterAllStartEventListeners(IWorkflowDefinition workflow, string processDefinitionKey, string processDefinitionId)
     {
+        var tasks = new List<Task>();
+
         if (workflow.Activities.OfType<TimerStartEvent>().Any())
         {
             var scheduler = _grainFactory.GetGrain<ITimerStartEventSchedulerGrain>(processDefinitionKey);
-            await scheduler.ActivateScheduler(processDefinitionId);
+            tasks.Add(scheduler.ActivateScheduler(processDefinitionId));
         }
 
         foreach (var messageStart in workflow.Activities.OfType<MessageStartEvent>())
@@ -327,7 +336,7 @@ public partial class WorkflowInstanceFactoryGrain : Grain, IWorkflowInstanceFact
             if (msgDef != null)
             {
                 var listener = _grainFactory.GetGrain<IMessageStartEventListenerGrain>(msgDef.Name);
-                await listener.RegisterProcess(processDefinitionKey);
+                tasks.Add(listener.RegisterProcess(processDefinitionKey).AsTask());
             }
         }
 
@@ -337,9 +346,11 @@ public partial class WorkflowInstanceFactoryGrain : Grain, IWorkflowInstanceFact
             if (sigDef != null)
             {
                 var listener = _grainFactory.GetGrain<ISignalStartEventListenerGrain>(sigDef.Name);
-                await listener.RegisterProcess(processDefinitionKey);
+                tasks.Add(listener.RegisterProcess(processDefinitionKey).AsTask());
             }
         }
+
+        await Task.WhenAll(tasks);
     }
 
     private string GenerateProcessDefinitionId(string key, int version, DateTimeOffset deployedAt)


### PR DESCRIPTION
Closes #200

## Summary

- Refactored `RegisterAllStartEventListeners`, `UnregisterAllStartEventListeners`, and the `DeployWorkflow` unregistration block to collect independent grain calls into a `List<Task>` and await them with `Task.WhenAll`
- Each grain call targets a distinct grain (timer scheduler keyed by process definition key, message/signal listeners keyed by event name), so there are no ordering dependencies
- For workflows with N message + M signal start events, deployment latency drops from O(N+M+1) sequential grain round-trips to O(1) — the single slowest call

## Key decisions

- Used `List<Task>` + `Task.WhenAll` (standard C# pattern) over LINQ `.Select()` or `Parallel.ForEachAsync` — simpler and more readable for mixed conditional logic
- Added `.AsTask()` for `ValueTask`-returning grain methods (`RegisterProcess`, `UnregisterProcess`) since `Task.WhenAll` requires `Task`
- Timer scheduler methods already return `Task`, so no conversion needed there

## How to test

All 735 existing tests pass — this is a pure performance refactoring with no behavioral change. The same grain calls are made to the same targets; only the scheduling changes from sequential to concurrent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)