### PR TITLE
Refactor: Extract shared base for start event listener grains (#196)

### DIFF
--- a/src/Fleans/Fleans.Application/Grains/MessageStartEventListenerGrain.cs
+++ b/src/Fleans/Fleans.Application/Grains/MessageStartEventListenerGrain.cs
@@ -1,5 +1,4 @@
 using System.Dynamic;
-using Fleans.Application.WorkflowFactory;
 using Fleans.Domain;
 using Fleans.Domain.Activities;
 using Fleans.Domain.States;
@@ -8,115 +7,50 @@ using Orleans.Runtime;
 
 namespace Fleans.Application.Grains;
 
-public partial class MessageStartEventListenerGrain : Grain, IMessageStartEventListenerGrain
+public partial class MessageStartEventListenerGrain :
+    StartEventListenerGrainBase<MessageStartEventListenerState>, IMessageStartEventListenerGrain
 {
-    private readonly IGrainFactory _grainFactory;
     private readonly ILogger<MessageStartEventListenerGrain> _logger;
-    private readonly IPersistentState<MessageStartEventListenerState> _state;
-
-    private MessageStartEventListenerState State => _state.State;
 
     public MessageStartEventListenerGrain(
         [PersistentState("state", GrainStorageNames.MessageStartEventListeners)] IPersistentState<MessageStartEventListenerState> state,
         IGrainFactory grainFactory,
         ILogger<MessageStartEventListenerGrain> logger)
+        : base(state, grainFactory)
     {
-        _state = state;
-        _grainFactory = grainFactory;
         _logger = logger;
     }
 
-    public async ValueTask RegisterProcess(string processDefinitionKey)
-    {
-        if (!State.AddProcess(processDefinitionKey))
-        {
-            LogProcessAlreadyRegistered(this.GetPrimaryKeyString(), processDefinitionKey);
-            return;
-        }
-
-        await _state.WriteStateAsync();
-        LogProcessRegistered(this.GetPrimaryKeyString(), processDefinitionKey);
-    }
-
-    public async ValueTask UnregisterProcess(string processDefinitionKey)
-    {
-        if (!State.RemoveProcess(processDefinitionKey))
-        {
-            LogProcessNotFound(this.GetPrimaryKeyString(), processDefinitionKey);
-            return;
-        }
-
-        if (State.IsEmpty)
-            await _state.ClearStateAsync();
-        else
-            await _state.WriteStateAsync();
-
-        LogProcessUnregistered(this.GetPrimaryKeyString(), processDefinitionKey);
-    }
-
     public async ValueTask<List<Guid>> FireMessageStartEvent(ExpandoObject variables)
-    {
-        var messageName = this.GetPrimaryKeyString();
+        => await FireStartEventCore(variables);
 
-        if (State.ProcessDefinitionKeys.Count == 0)
-        {
-            LogNoRegisteredProcesses(messageName);
-            return [];
-        }
-
-        var factory = _grainFactory.GetGrain<IWorkflowInstanceFactoryGrain>(0);
-
-        var tasks = State.ProcessDefinitionKeys.Select(async processDefinitionKey =>
-        {
-            try
-            {
-                // Guard: skip disabled processes to prevent race condition
-                // between DisableProcess persisting IsActive=false and unregistering listeners
-                if (!await factory.IsProcessActive(processDefinitionKey))
-                {
-                    LogProcessDisabledSkipped(messageName, processDefinitionKey);
-                    return (Guid?)null;
-                }
-
-                var instanceId = Guid.NewGuid();
-                var instance = _grainFactory.GetGrain<IWorkflowInstanceGrain>(instanceId);
-
-                var definition = await factory.GetLatestWorkflowDefinition(processDefinitionKey);
-
-                // Find the MessageStartEvent that matches this message name
-                var messageStartActivityId = FindMessageStartActivityId(definition, messageName)
-                    ?? throw new InvalidOperationException(
-                        $"Message start activity for message '{messageName}' not found in process '{processDefinitionKey}'. " +
-                        "The message definition may have been removed during a redeployment.");
-
-                await instance.SetWorkflow(definition, messageStartActivityId);
-                await instance.SetInitialVariables(variables);
-                await instance.StartWorkflow();
-
-                LogMessageStartEventFired(messageName, processDefinitionKey, instanceId);
-                return (Guid?)instanceId;
-            }
-            catch (Exception ex)
-            {
-                LogMessageStartEventFailed(messageName, processDefinitionKey, ex);
-                return (Guid?)null;
-            }
-        });
-
-        var results = await Task.WhenAll(tasks);
-        return results.Where(id => id.HasValue).Select(id => id!.Value).ToList();
-    }
-
-    private static string? FindMessageStartActivityId(IWorkflowDefinition definition, string messageName)
+    protected override string? FindStartActivityId(IWorkflowDefinition definition, string eventName)
     {
         foreach (var activity in definition.Activities.OfType<MessageStartEvent>())
         {
             var msgDef = definition.FindMessageDefinition(activity.MessageDefinitionId);
-            if (msgDef?.Name == messageName)
+            if (msgDef?.Name == eventName)
                 return activity.ActivityId;
         }
         return null;
     }
+
+    protected override void OnProcessRegistered(string eventName, string processDefinitionKey)
+        => LogProcessRegistered(eventName, processDefinitionKey);
+    protected override void OnProcessUnregistered(string eventName, string processDefinitionKey)
+        => LogProcessUnregistered(eventName, processDefinitionKey);
+    protected override void OnProcessAlreadyRegistered(string eventName, string processDefinitionKey)
+        => LogProcessAlreadyRegistered(eventName, processDefinitionKey);
+    protected override void OnProcessNotFound(string eventName, string processDefinitionKey)
+        => LogProcessNotFound(eventName, processDefinitionKey);
+    protected override void OnNoRegisteredProcesses(string eventName)
+        => LogNoRegisteredProcesses(eventName);
+    protected override void OnProcessDisabledSkipped(string eventName, string processDefinitionKey)
+        => LogProcessDisabledSkipped(eventName, processDefinitionKey);
+    protected override void OnStartEventFired(string eventName, string processDefinitionKey, Guid instanceId)
+        => LogMessageStartEventFired(eventName, processDefinitionKey, instanceId);
+    protected override void OnStartEventFailed(string eventName, string processDefinitionKey, Exception ex)
+        => LogMessageStartEventFailed(eventName, processDefinitionKey, ex);
 
     [LoggerMessage(EventId = 9100, Level = LogLevel.Information, Message = "Registered process {ProcessDefinitionKey} for message start event '{MessageName}'")]
     private partial void LogProcessRegistered(string messageName, string processDefinitionKey);

--- a/src/Fleans/Fleans.Application/Grains/SignalStartEventListenerGrain.cs
+++ b/src/Fleans/Fleans.Application/Grains/SignalStartEventListenerGrain.cs
@@ -1,4 +1,3 @@
-using Fleans.Application.WorkflowFactory;
 using Fleans.Domain;
 using Fleans.Domain.Activities;
 using Fleans.Domain.States;
@@ -7,113 +6,50 @@ using Orleans.Runtime;
 
 namespace Fleans.Application.Grains;
 
-public partial class SignalStartEventListenerGrain : Grain, ISignalStartEventListenerGrain
+public partial class SignalStartEventListenerGrain :
+    StartEventListenerGrainBase<SignalStartEventListenerState>, ISignalStartEventListenerGrain
 {
-    private readonly IGrainFactory _grainFactory;
     private readonly ILogger<SignalStartEventListenerGrain> _logger;
-    private readonly IPersistentState<SignalStartEventListenerState> _state;
-
-    private SignalStartEventListenerState State => _state.State;
 
     public SignalStartEventListenerGrain(
         [PersistentState("state", GrainStorageNames.SignalStartEventListeners)] IPersistentState<SignalStartEventListenerState> state,
         IGrainFactory grainFactory,
         ILogger<SignalStartEventListenerGrain> logger)
+        : base(state, grainFactory)
     {
-        _state = state;
-        _grainFactory = grainFactory;
         _logger = logger;
     }
 
-    public async ValueTask RegisterProcess(string processDefinitionKey)
-    {
-        if (!State.AddProcess(processDefinitionKey))
-        {
-            LogProcessAlreadyRegistered(this.GetPrimaryKeyString(), processDefinitionKey);
-            return;
-        }
-
-        await _state.WriteStateAsync();
-        LogProcessRegistered(this.GetPrimaryKeyString(), processDefinitionKey);
-    }
-
-    public async ValueTask UnregisterProcess(string processDefinitionKey)
-    {
-        if (!State.RemoveProcess(processDefinitionKey))
-        {
-            LogProcessNotFound(this.GetPrimaryKeyString(), processDefinitionKey);
-            return;
-        }
-
-        if (State.IsEmpty)
-            await _state.ClearStateAsync();
-        else
-            await _state.WriteStateAsync();
-
-        LogProcessUnregistered(this.GetPrimaryKeyString(), processDefinitionKey);
-    }
-
     public async ValueTask<List<Guid>> FireSignalStartEvent()
-    {
-        var signalName = this.GetPrimaryKeyString();
+        => await FireStartEventCore(null);
 
-        if (State.ProcessDefinitionKeys.Count == 0)
-        {
-            LogNoRegisteredProcesses(signalName);
-            return [];
-        }
-
-        var factory = _grainFactory.GetGrain<IWorkflowInstanceFactoryGrain>(0);
-
-        var tasks = State.ProcessDefinitionKeys.Select(async processDefinitionKey =>
-        {
-            try
-            {
-                // Guard: skip disabled processes to prevent race condition
-                // between DisableProcess persisting IsActive=false and unregistering listeners
-                if (!await factory.IsProcessActive(processDefinitionKey))
-                {
-                    LogProcessDisabledSkipped(signalName, processDefinitionKey);
-                    return (Guid?)null;
-                }
-
-                var instanceId = Guid.NewGuid();
-                var instance = _grainFactory.GetGrain<IWorkflowInstanceGrain>(instanceId);
-
-                var definition = await factory.GetLatestWorkflowDefinition(processDefinitionKey);
-
-                var signalStartActivityId = FindSignalStartActivityId(definition, signalName)
-                    ?? throw new InvalidOperationException(
-                        $"Signal start activity for signal '{signalName}' not found in process '{processDefinitionKey}'. " +
-                        "The signal definition may have been removed during a redeployment.");
-
-                await instance.SetWorkflow(definition, signalStartActivityId);
-                await instance.StartWorkflow();
-
-                LogSignalStartEventFired(signalName, processDefinitionKey, instanceId);
-                return (Guid?)instanceId;
-            }
-            catch (Exception ex)
-            {
-                LogSignalStartEventFailed(signalName, processDefinitionKey, ex);
-                return (Guid?)null;
-            }
-        });
-
-        var results = await Task.WhenAll(tasks);
-        return results.Where(id => id.HasValue).Select(id => id!.Value).ToList();
-    }
-
-    private static string? FindSignalStartActivityId(IWorkflowDefinition definition, string signalName)
+    protected override string? FindStartActivityId(IWorkflowDefinition definition, string eventName)
     {
         foreach (var activity in definition.Activities.OfType<SignalStartEvent>())
         {
             var sigDef = definition.FindSignalDefinition(activity.SignalDefinitionId);
-            if (sigDef?.Name == signalName)
+            if (sigDef?.Name == eventName)
                 return activity.ActivityId;
         }
         return null;
     }
+
+    protected override void OnProcessRegistered(string eventName, string processDefinitionKey)
+        => LogProcessRegistered(eventName, processDefinitionKey);
+    protected override void OnProcessUnregistered(string eventName, string processDefinitionKey)
+        => LogProcessUnregistered(eventName, processDefinitionKey);
+    protected override void OnProcessAlreadyRegistered(string eventName, string processDefinitionKey)
+        => LogProcessAlreadyRegistered(eventName, processDefinitionKey);
+    protected override void OnProcessNotFound(string eventName, string processDefinitionKey)
+        => LogProcessNotFound(eventName, processDefinitionKey);
+    protected override void OnNoRegisteredProcesses(string eventName)
+        => LogNoRegisteredProcesses(eventName);
+    protected override void OnProcessDisabledSkipped(string eventName, string processDefinitionKey)
+        => LogProcessDisabledSkipped(eventName, processDefinitionKey);
+    protected override void OnStartEventFired(string eventName, string processDefinitionKey, Guid instanceId)
+        => LogSignalStartEventFired(eventName, processDefinitionKey, instanceId);
+    protected override void OnStartEventFailed(string eventName, string processDefinitionKey, Exception ex)
+        => LogSignalStartEventFailed(eventName, processDefinitionKey, ex);
 
     [LoggerMessage(EventId = 9200, Level = LogLevel.Information, Message = "Registered process {ProcessDefinitionKey} for signal start event '{SignalName}'")]
     private partial void LogProcessRegistered(string signalName, string processDefinitionKey);

--- a/src/Fleans/Fleans.Application/Grains/StartEventListenerGrainBase.cs
+++ b/src/Fleans/Fleans.Application/Grains/StartEventListenerGrainBase.cs
@@ -1,0 +1,120 @@
+using System.Dynamic;
+using Fleans.Application.WorkflowFactory;
+using Fleans.Domain;
+using Fleans.Domain.States;
+using Orleans.Runtime;
+
+namespace Fleans.Application.Grains;
+
+public abstract class StartEventListenerGrainBase<TState> : Grain
+    where TState : class, IStartEventListenerState
+{
+    private readonly IGrainFactory _grainFactory;
+    private readonly IPersistentState<TState> _state;
+
+    protected TState State => _state.State;
+
+    protected StartEventListenerGrainBase(
+        IPersistentState<TState> state,
+        IGrainFactory grainFactory)
+    {
+        _state = state;
+        _grainFactory = grainFactory;
+    }
+
+    public async ValueTask RegisterProcess(string processDefinitionKey)
+    {
+        var eventName = this.GetPrimaryKeyString();
+
+        if (!State.AddProcess(processDefinitionKey))
+        {
+            OnProcessAlreadyRegistered(eventName, processDefinitionKey);
+            return;
+        }
+
+        await _state.WriteStateAsync();
+        OnProcessRegistered(eventName, processDefinitionKey);
+    }
+
+    public async ValueTask UnregisterProcess(string processDefinitionKey)
+    {
+        var eventName = this.GetPrimaryKeyString();
+
+        if (!State.RemoveProcess(processDefinitionKey))
+        {
+            OnProcessNotFound(eventName, processDefinitionKey);
+            return;
+        }
+
+        if (State.IsEmpty)
+            await _state.ClearStateAsync();
+        else
+            await _state.WriteStateAsync();
+
+        OnProcessUnregistered(eventName, processDefinitionKey);
+    }
+
+    protected async ValueTask<List<Guid>> FireStartEventCore(ExpandoObject? variables)
+    {
+        var eventName = this.GetPrimaryKeyString();
+
+        if (State.ProcessDefinitionKeys.Count == 0)
+        {
+            OnNoRegisteredProcesses(eventName);
+            return [];
+        }
+
+        var factory = _grainFactory.GetGrain<IWorkflowInstanceFactoryGrain>(0);
+
+        var tasks = State.ProcessDefinitionKeys.Select(async processDefinitionKey =>
+        {
+            try
+            {
+                if (!await factory.IsProcessActive(processDefinitionKey))
+                {
+                    OnProcessDisabledSkipped(eventName, processDefinitionKey);
+                    return (Guid?)null;
+                }
+
+                var instanceId = Guid.NewGuid();
+                var instance = _grainFactory.GetGrain<IWorkflowInstanceGrain>(instanceId);
+
+                var definition = await factory.GetLatestWorkflowDefinition(processDefinitionKey);
+
+                var startActivityId = FindStartActivityId(definition, eventName)
+                    ?? throw new InvalidOperationException(
+                        $"Start activity for '{eventName}' not found in process '{processDefinitionKey}'. " +
+                        "The definition may have been removed during a redeployment.");
+
+                await instance.SetWorkflow(definition, startActivityId);
+
+                if (variables is not null)
+                    await instance.SetInitialVariables(variables);
+
+                await instance.StartWorkflow();
+
+                OnStartEventFired(eventName, processDefinitionKey, instanceId);
+                return (Guid?)instanceId;
+            }
+            catch (Exception ex)
+            {
+                OnStartEventFailed(eventName, processDefinitionKey, ex);
+                return (Guid?)null;
+            }
+        });
+
+        var results = await Task.WhenAll(tasks);
+        return results.Where(id => id.HasValue).Select(id => id!.Value).ToList();
+    }
+
+    protected abstract string? FindStartActivityId(IWorkflowDefinition definition, string eventName);
+
+    protected abstract void OnProcessRegistered(string eventName, string processDefinitionKey);
+    protected abstract void OnProcessUnregistered(string eventName, string processDefinitionKey);
+    protected abstract void OnProcessAlreadyRegistered(string eventName, string processDefinitionKey);
+    protected abstract void OnProcessNotFound(string eventName, string processDefinitionKey);
+    protected abstract void OnNoRegisteredProcesses(string eventName);
+    protected abstract void OnProcessDisabledSkipped(string eventName, string processDefinitionKey);
+    protected abstract void OnStartEventFired(string eventName, string processDefinitionKey, Guid instanceId);
+    protected abstract void OnStartEventFailed(string eventName, string processDefinitionKey, Exception ex);
+}

--- a/src/Fleans/Fleans.Domain/States/IStartEventListenerState.cs
+++ b/src/Fleans/Fleans.Domain/States/IStartEventListenerState.cs
@@ -1,0 +1,9 @@
+namespace Fleans.Domain.States;
+
+public interface IStartEventListenerState
+{
+    List<string> ProcessDefinitionKeys { get; }
+    bool AddProcess(string processDefinitionKey);
+    bool RemoveProcess(string processDefinitionKey);
+    bool IsEmpty { get; }
+}

--- a/src/Fleans/Fleans.Domain/States/MessageStartEventListenerState.cs
+++ b/src/Fleans/Fleans.Domain/States/MessageStartEventListenerState.cs
@@ -1,7 +1,7 @@
 namespace Fleans.Domain.States;
 
 [GenerateSerializer]
-public class MessageStartEventListenerState
+public class MessageStartEventListenerState : IStartEventListenerState
 {
     [Id(0)] public string Key { get; set; } = string.Empty;
     [Id(1)] public string? ETag { get; set; }

--- a/src/Fleans/Fleans.Domain/States/SignalStartEventListenerState.cs
+++ b/src/Fleans/Fleans.Domain/States/SignalStartEventListenerState.cs
@@ -1,7 +1,7 @@
 namespace Fleans.Domain.States;
 
 [GenerateSerializer]
-public class SignalStartEventListenerState
+public class SignalStartEventListenerState : IStartEventListenerState
 {
     [Id(0)] public string Key { get; set; } = string.Empty;
     [Id(1)] public string? ETag { get; set; }


### PR DESCRIPTION
## Summary

Closes #196

- Extracted `StartEventListenerGrainBase<TState>` abstract class that encapsulates the shared `RegisterProcess`, `UnregisterProcess`, and `FireStartEventCore` logic
- Added `IStartEventListenerState` interface implemented by both `MessageStartEventListenerState` and `SignalStartEventListenerState`
- Refactored `MessageStartEventListenerGrain` and `SignalStartEventListenerGrain` to extend the base class
- `[LoggerMessage]` declarations remain on concrete classes per CLAUDE.md convention, bridged via abstract log callbacks
- Storage classes and EF Core DbContext are unchanged (out of scope per design)

## Key Decisions

- **Abstract base class over composition** — natural Orleans grain pattern; avoids passing grain context to external services
- **`FireStartEventCore(ExpandoObject? variables)`** — null check on variables cleanly handles signal (no variables) vs message (has variables)
- **Error message uses event name + process key** — addresses the minor finding from design review about lost specificity

## Impact

- **Net change:** ~0 lines (177 added, 178 removed) — duplication eliminated, code redistributed to base class
- **No behavioral changes** — grain interfaces unchanged, persistence unchanged
- **No new tests needed** — pure refactoring validated by all 735 existing tests passing

## Test plan

- [x] `dotnet build` — zero errors
- [x] `dotnet test` — all 735 tests pass (334 Domain + 194 Application + 94 Infrastructure + 109 Persistence + 4 Mcp)
- [x] No interface changes — consumers unaffected


🤖 Generated with [Claude Code](https://claude.com/claude-code)