### PR TITLE
Optimize ExpandoObject Combine to in-place merge

### DIFF
--- a/src/Fleans/Fleans.Domain/States/WorkflowVariablesState.cs
+++ b/src/Fleans/Fleans.Domain/States/WorkflowVariablesState.cs
@@ -30,21 +30,10 @@ public class WorkflowVariablesState
 
     internal void Merge(ExpandoObject variables)
     {
-        Variables = Combine(Variables, variables);
-    }
-
-    static ExpandoObject Combine(dynamic item1, dynamic item2)
-    {
-        var dictionary1 = (IDictionary<string, object>)item1;
-        var dictionary2 = (IDictionary<string, object>)item2;
-        var result = new ExpandoObject();
-        var d = result as IDictionary<string, object>;
-
-        foreach (var pair in dictionary1.Concat(dictionary2))
+        var target = (IDictionary<string, object>)Variables;
+        foreach (var kvp in (IDictionary<string, object>)variables)
         {
-            d[pair.Key] = pair.Value;
+            target[kvp.Key] = kvp.Value;
         }
-
-        return result;
     }
 }


### PR DESCRIPTION
## Summary

Closes #169

- Replaced `WorkflowVariablesState.Combine()` (which allocated a new `ExpandoObject` and copied all existing + incoming keys) with an in-place merge that iterates only incoming keys
- Removed the now-unused `Combine()` static method
- Zero allocations per merge, iteration reduced from O(existing + incoming) to O(incoming)

## Key decisions

- In-place mutation is safe: all three call sites (`AddCloneOfVariableState` x2, `MergeState`) are additive merges where no caller holds references to the previous `Variables` object
- Event immutability is already protected by `SnapshotExpandoObject` in `WorkflowExecution.Emit()`

## Test plan

- [x] Build compiles cleanly (0 errors)
- [x] All 735 tests pass (334 Domain + 94 Infrastructure + 109 Persistence + 194 Application + 4 Mcp)
- [x] No behavioral change — same keys merged with same override semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)