### PR TITLE
Cache compiled DynamicExpresso expressions and pool interpreters

### DIFF
--- a/src/Fleans/Fleans.Infrastructure.Tests/DynamicExpressoConditionExpressionEvaluatorTests.cs
+++ b/src/Fleans/Fleans.Infrastructure.Tests/DynamicExpressoConditionExpressionEvaluatorTests.cs
@@ -23,5 +23,52 @@ namespace Fleans.Infrastructure.Tests
             // Assert
             Assert.IsTrue(result);
         }
+
+        [TestMethod]
+        public async Task Evaluate_SameExpression_DifferentVariables_ReturnsDifferentResults()
+        {
+            // Arrange
+            var evaluator = new DynamicExpressoConditionExpressionEvaluator();
+            const string expression = "_context.x > 5";
+
+            dynamic vars1 = new ExpandoObject();
+            vars1.x = 10;
+
+            dynamic vars2 = new ExpandoObject();
+            vars2.x = 3;
+
+            // Act
+            var result1 = await evaluator.Evaluate(expression, vars1);
+            var result2 = await evaluator.Evaluate(expression, vars2);
+
+            // Assert
+            Assert.IsTrue(result1);
+            Assert.IsFalse(result2);
+        }
+
+        [TestMethod]
+        public async Task Evaluate_ConcurrentCalls_SameExpression_AllReturnCorrectResults()
+        {
+            // Arrange
+            var evaluator = new DynamicExpressoConditionExpressionEvaluator();
+            const string expression = "_context.value > 25";
+            const int concurrency = 50;
+
+            // Act
+            var tasks = Enumerable.Range(0, concurrency).Select(i =>
+            {
+                dynamic vars = new ExpandoObject();
+                ((IDictionary<string, object>)vars)["value"] = i;
+                return evaluator.Evaluate(expression, (ExpandoObject)vars);
+            }).ToArray();
+
+            var results = await Task.WhenAll(tasks);
+
+            // Assert — values 26..49 should be true, 0..25 should be false
+            for (int i = 0; i < concurrency; i++)
+            {
+                Assert.AreEqual(i > 25, results[i], $"Failed for value {i}");
+            }
+        }
     }
 }

--- a/src/Fleans/Fleans.Infrastructure.Tests/DynamicExpressoScriptExpressionExecutorTests.cs
+++ b/src/Fleans/Fleans.Infrastructure.Tests/DynamicExpressoScriptExpressionExecutorTests.cs
@@ -169,4 +169,54 @@ public class DynamicExpressoScriptExpressionExecutorTests
         Assert.AreEqual("_context.path = \"C:\\\\\"", statements[0]);
         Assert.AreEqual("_context.x = 1", statements[1]);
     }
+
+    [TestMethod]
+    public async Task Execute_SequentialScripts_NoStateLeak()
+    {
+        // Arrange — run script A that sets _context.x, then script B with fresh variables
+        // that does NOT set _context.x. Pooled Interpreter must not leak _context.x.
+        dynamic varsA = new ExpandoObject();
+        varsA.x = 1;
+        await _executor.Execute("_context.x = _context.x + 100", varsA, "csharp");
+
+        dynamic varsB = new ExpandoObject();
+        varsB.y = 42;
+
+        // Act
+        var result = await _executor.Execute("_context.y = _context.y * 2", varsB, "csharp");
+
+        // Assert — varsB should only have 'y', not 'x' from the previous execution
+        var dict = (IDictionary<string, object>)result;
+        Assert.AreEqual(84, dict["y"]);
+        Assert.IsFalse(dict.ContainsKey("x"), "Pooled interpreter leaked variable 'x' from previous execution");
+    }
+
+    [TestMethod]
+    public async Task Execute_ConcurrentScripts_NoInterference()
+    {
+        // Arrange — 20 concurrent script executions with unique variable names
+        const int concurrency = 20;
+
+        var tasks = Enumerable.Range(0, concurrency).Select(async i =>
+        {
+            dynamic vars = new ExpandoObject();
+            ((IDictionary<string, object>)vars)["input"] = i;
+
+            var result = await _executor.Execute(
+                "_context.output = _context.input * 3",
+                (ExpandoObject)vars, "csharp");
+
+            var dict = (IDictionary<string, object>)result;
+            return (Input: i, Output: dict["output"]);
+        }).ToArray();
+
+        // Act
+        var results = await Task.WhenAll(tasks);
+
+        // Assert — each execution should produce its own correct result
+        foreach (var (input, output) in results)
+        {
+            Assert.AreEqual(input * 3, output, $"Interference detected for input {input}");
+        }
+    }
 }

--- a/src/Fleans/Fleans.Infrastructure/Conditions/DynamicExpressoConditionExpressionEvaluator.cs
+++ b/src/Fleans/Fleans.Infrastructure/Conditions/DynamicExpressoConditionExpressionEvaluator.cs
@@ -1,4 +1,5 @@
-﻿using System.Dynamic;
+using System.Collections.Concurrent;
+using System.Dynamic;
 using DynamicExpresso;
 using Fleans.Application.Conditions;
 
@@ -6,11 +7,17 @@ namespace Fleans.Infrastructure.Conditions;
 
 public class DynamicExpressoConditionExpressionEvaluator : IConditionExpressionEvaluator
 {
+    private readonly ConcurrentDictionary<string, Lambda> _cache = new();
+
     public Task<bool> Evaluate(string expression, ExpandoObject variables)
     {
-        var interpreter = new Interpreter().SetVariable("_context", variables);
-        var result = interpreter.Eval<bool>(expression);
+        var lambda = _cache.GetOrAdd(expression, expr =>
+        {
+            var interpreter = new Interpreter();
+            return interpreter.Parse(expr, new Parameter("_context", typeof(ExpandoObject)));
+        });
 
+        var result = (bool)lambda.Invoke(variables);
         return Task.FromResult(result);
     }
 }

--- a/src/Fleans/Fleans.Infrastructure/Scripts/DynamicExpressoScriptExpressionExecutor.cs
+++ b/src/Fleans/Fleans.Infrastructure/Scripts/DynamicExpressoScriptExpressionExecutor.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Dynamic;
 using DynamicExpresso;
 using Fleans.Application.Scripts;
@@ -7,6 +8,8 @@ namespace Fleans.Infrastructure.Scripts;
 public class DynamicExpressoScriptExpressionExecutor : IScriptExpressionExecutor
 {
     private readonly TimeSpan _scriptTimeout;
+    private readonly ConcurrentBag<Interpreter> _interpreterPool = new();
+    private const int MaxPoolSize = 16;
 
     private static readonly HashSet<string> SupportedFormats = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -37,18 +40,41 @@ public class DynamicExpressoScriptExpressionExecutor : IScriptExpressionExecutor
         // would require running scripts in a separate process.
         var task = Task.Run(() =>
         {
-            var interpreter = new Interpreter().SetVariable("_context", variables);
-            interpreter.Reference(typeof(List<>));
-
-            foreach (var statement in SplitStatements(script))
+            var interpreter = RentInterpreter();
+            try
             {
-                interpreter.Eval(statement);
+                interpreter.SetVariable("_context", variables);
+
+                foreach (var statement in SplitStatements(script))
+                {
+                    interpreter.Eval(statement);
+                }
+            }
+            finally
+            {
+                ReturnInterpreter(interpreter);
             }
         });
 
         await task.WaitAsync(_scriptTimeout);
 
         return variables;
+    }
+
+    private Interpreter RentInterpreter()
+    {
+        if (_interpreterPool.TryTake(out var interpreter))
+            return interpreter;
+
+        var newInterpreter = new Interpreter();
+        newInterpreter.Reference(typeof(List<>));
+        return newInterpreter;
+    }
+
+    private void ReturnInterpreter(Interpreter interpreter)
+    {
+        if (_interpreterPool.Count < MaxPoolSize)
+            _interpreterPool.Add(interpreter);
     }
 
     internal static IEnumerable<string> SplitStatements(string script)


### PR DESCRIPTION
Closes #171

## Summary

- **Condition evaluator**: Added `ConcurrentDictionary<string, Lambda>` cache so each expression string is parsed once via `Interpreter.Parse()` and reused via `Lambda.Invoke()`. Eliminates repeated IL compilation for the same expressions across workflow instances.
- **Script executor**: Added `ConcurrentBag<Interpreter>` pool (capped at 16) to reuse `Interpreter` instances across executions, avoiding the cost of `new Interpreter()` + `Reference(typeof(List<>))` per call.
- **4 new tests**: Cache correctness with different variables, concurrent condition evaluation (50 threads), no state leakage between pooled script executions, concurrent script execution (20 threads).

## Key decisions

- Followed the approved design exactly — `Lambda` caching for conditions (Approach A), `Interpreter` pooling for scripts
- Pool cap of 16 matches typical thread pool concurrency for a silo
- `SetVariable("_context", variables)` replaces the binding on each execution, preventing cross-execution state leakage

## How to test

All existing tests pass unchanged. 4 new tests verify correctness, thread safety, and no state leakage.

```bash
dotnet test --filter "FullyQualifiedName~DynamicExpresso"
```