### PR TITLE
Rate-limit signal/message broadcast fan-out with batched delivery (#162)

### DIFF
--- a/src/Fleans/Fleans.Application.Tests/SignalIntermediateCatchEventTests.cs
+++ b/src/Fleans/Fleans.Application.Tests/SignalIntermediateCatchEventTests.cs
@@ -125,4 +125,64 @@ public class SignalIntermediateCatchEventTests : WorkflowTestBase
         // Assert
         Assert.AreEqual(0, deliveredCount, "Should return 0 when no subscribers exist");
     }
+
+    [TestMethod]
+    public async Task SignalBroadcast_ManySubscribers_ShouldDeliverInBatchesAndCompleteAll()
+    {
+        // Arrange — 55 workflows all waiting for the same signal (exceeds batch size of 20)
+        const int subscriberCount = 55;
+        var signalDef = new SignalDefinition("sig1", "batchTest");
+
+        WorkflowDefinition CreateWorkflow(string id) => new()
+        {
+            WorkflowId = id,
+            Activities =
+            [
+                new StartEvent("start"),
+                new TaskActivity("task1"),
+                new SignalIntermediateCatchEvent("waitSignal", "sig1"),
+                new EndEvent("end")
+            ],
+            SequenceFlows =
+            [
+                new SequenceFlow("f1", new StartEvent("start"), new TaskActivity("task1")),
+                new SequenceFlow("f2", new TaskActivity("task1"), new SignalIntermediateCatchEvent("waitSignal", "sig1")),
+                new SequenceFlow("f3", new SignalIntermediateCatchEvent("waitSignal", "sig1"), new EndEvent("end"))
+            ],
+            Signals = [signalDef]
+        };
+
+        var instances = new List<IWorkflowInstanceGrain>();
+        for (var i = 0; i < subscriberCount; i++)
+        {
+            var instance = Cluster.GrainFactory.GetGrain<IWorkflowInstanceGrain>(Guid.NewGuid());
+            await instance.SetWorkflow(CreateWorkflow($"batch-signal-{i}"));
+            await instance.StartWorkflow();
+            await instance.CompleteActivity("task1", new ExpandoObject());
+            instances.Add(instance);
+        }
+
+        // Verify all are suspended at signal catch
+        foreach (var instance in instances)
+        {
+            var snap = await QueryService.GetStateSnapshot(instance.GetPrimaryKey());
+            Assert.IsTrue(snap!.ActiveActivities.Any(a => a.ActivityId == "waitSignal"),
+                $"Instance {instance.GetPrimaryKey()} should be waiting at signal catch");
+        }
+
+        // Act — broadcast signal (should deliver in batches of 20)
+        var signalGrain = Cluster.GrainFactory.GetGrain<ISignalCorrelationGrain>("batchTest");
+        var deliveredCount = await signalGrain.BroadcastSignal();
+
+        // Assert — all 55 subscribers received the signal and completed
+        Assert.AreEqual(subscriberCount, deliveredCount,
+            $"Signal should be delivered to all {subscriberCount} subscribers");
+
+        foreach (var instance in instances)
+        {
+            var finalSnap = await QueryService.GetStateSnapshot(instance.GetPrimaryKey());
+            Assert.IsTrue(finalSnap!.IsCompleted,
+                $"Instance {instance.GetPrimaryKey()} should be completed after signal broadcast");
+        }
+    }
 }

--- a/src/Fleans/Fleans.Application/Grains/MessageStartEventListenerGrain.cs
+++ b/src/Fleans/Fleans.Application/Grains/MessageStartEventListenerGrain.cs
@@ -51,6 +51,8 @@ public partial class MessageStartEventListenerGrain :
         => LogMessageStartEventFired(eventName, processDefinitionKey, instanceId);
     protected override void OnStartEventFailed(string eventName, string processDefinitionKey, Exception ex)
         => LogMessageStartEventFailed(eventName, processDefinitionKey, ex);
+    protected override void OnHighProcessCount(string eventName, int processCount, int threshold)
+        => LogHighProcessCount(eventName, processCount, threshold);
 
     [LoggerMessage(EventId = 9100, Level = LogLevel.Information, Message = "Registered process {ProcessDefinitionKey} for message start event '{MessageName}'")]
     private partial void LogProcessRegistered(string messageName, string processDefinitionKey);
@@ -75,4 +77,7 @@ public partial class MessageStartEventListenerGrain :
 
     [LoggerMessage(EventId = 9107, Level = LogLevel.Warning, Message = "Skipping disabled process {ProcessDefinitionKey} for message '{MessageName}'")]
     private partial void LogProcessDisabledSkipped(string messageName, string processDefinitionKey);
+
+    [LoggerMessage(EventId = 9108, Level = LogLevel.Warning, Message = "Message start event '{MessageName}' has {ProcessCount} registered processes (threshold: {Threshold}) — delivering in batches")]
+    private partial void LogHighProcessCount(string messageName, int processCount, int threshold);
 }

--- a/src/Fleans/Fleans.Application/Grains/SignalCorrelationGrain.cs
+++ b/src/Fleans/Fleans.Application/Grains/SignalCorrelationGrain.cs
@@ -53,6 +53,9 @@ public partial class SignalCorrelationGrain : Grain, ISignalCorrelationGrain
         }
     }
 
+    private const int DeliveryBatchSize = 20;
+    private const int HighSubscriberCountThreshold = 50;
+
     public async ValueTask<int> BroadcastSignal()
     {
         var signalName = this.GetPrimaryKeyString();
@@ -67,25 +70,34 @@ public partial class SignalCorrelationGrain : Grain, ISignalCorrelationGrain
         _state.State.Subscriptions.Clear();
         await _state.WriteStateAsync();
 
+        if (subscribers.Count > HighSubscriberCountThreshold)
+            LogBroadcastHighSubscriberCount(signalName, subscribers.Count, HighSubscriberCountThreshold);
+
         LogBroadcastStarted(signalName, subscribers.Count);
 
-        var deliveryTasks = subscribers.Select(async sub =>
-        {
-            try
-            {
-                var workflowInstance = _grainFactory.GetGrain<IWorkflowInstanceGrain>(sub.WorkflowInstanceId);
-                await workflowInstance.HandleSignalDelivery(sub.ActivityId, sub.HostActivityInstanceId);
-                return true;
-            }
-            catch (Exception ex)
-            {
-                LogDeliveryFailed(signalName, sub.WorkflowInstanceId, sub.ActivityId, ex);
-                return false;
-            }
-        });
+        var deliveredCount = 0;
 
-        var results = await Task.WhenAll(deliveryTasks);
-        var deliveredCount = results.Count(r => r);
+        foreach (var batch in subscribers.Chunk(DeliveryBatchSize))
+        {
+            var batchTasks = batch.Select(async sub =>
+            {
+                try
+                {
+                    var workflowInstance = _grainFactory.GetGrain<IWorkflowInstanceGrain>(sub.WorkflowInstanceId);
+                    await workflowInstance.HandleSignalDelivery(sub.ActivityId, sub.HostActivityInstanceId);
+                    return true;
+                }
+                catch (Exception ex)
+                {
+                    LogDeliveryFailed(signalName, sub.WorkflowInstanceId, sub.ActivityId, ex);
+                    return false;
+                }
+            });
+
+            var results = await Task.WhenAll(batchTasks);
+            deliveredCount += results.Count(r => r);
+        }
+
         LogBroadcastCompleted(signalName, deliveredCount, subscribers.Count);
 
         return deliveredCount;
@@ -118,4 +130,8 @@ public partial class SignalCorrelationGrain : Grain, ISignalCorrelationGrain
     [LoggerMessage(EventId = 9106, Level = LogLevel.Debug,
         Message = "Signal '{SignalName}' duplicate subscription ignored: workflowInstanceId={WorkflowInstanceId}, activityId={ActivityId}")]
     private partial void LogDuplicateSubscription(string signalName, Guid workflowInstanceId, string activityId);
+
+    [LoggerMessage(EventId = 9107, Level = LogLevel.Warning,
+        Message = "Signal '{SignalName}' broadcast has {SubscriberCount} subscribers (threshold: {Threshold}) — delivering in batches")]
+    private partial void LogBroadcastHighSubscriberCount(string signalName, int subscriberCount, int threshold);
 }

--- a/src/Fleans/Fleans.Application/Grains/SignalStartEventListenerGrain.cs
+++ b/src/Fleans/Fleans.Application/Grains/SignalStartEventListenerGrain.cs
@@ -50,6 +50,8 @@ public partial class SignalStartEventListenerGrain :
         => LogSignalStartEventFired(eventName, processDefinitionKey, instanceId);
     protected override void OnStartEventFailed(string eventName, string processDefinitionKey, Exception ex)
         => LogSignalStartEventFailed(eventName, processDefinitionKey, ex);
+    protected override void OnHighProcessCount(string eventName, int processCount, int threshold)
+        => LogHighProcessCount(eventName, processCount, threshold);
 
     [LoggerMessage(EventId = 9200, Level = LogLevel.Information, Message = "Registered process {ProcessDefinitionKey} for signal start event '{SignalName}'")]
     private partial void LogProcessRegistered(string signalName, string processDefinitionKey);
@@ -74,4 +76,7 @@ public partial class SignalStartEventListenerGrain :
 
     [LoggerMessage(EventId = 9207, Level = LogLevel.Debug, Message = "Process {ProcessDefinitionKey} not found for signal start event '{SignalName}', skipping unregister")]
     private partial void LogProcessNotFound(string signalName, string processDefinitionKey);
+
+    [LoggerMessage(EventId = 9208, Level = LogLevel.Warning, Message = "Signal start event '{SignalName}' has {ProcessCount} registered processes (threshold: {Threshold}) — delivering in batches")]
+    private partial void LogHighProcessCount(string signalName, int processCount, int threshold);
 }

--- a/src/Fleans/Fleans.Application/Grains/StartEventListenerGrainBase.cs
+++ b/src/Fleans/Fleans.Application/Grains/StartEventListenerGrainBase.cs
@@ -8,6 +8,9 @@ namespace Fleans.Application.Grains;
 public abstract class StartEventListenerGrainBase<TState> : Grain
     where TState : class, IStartEventListenerState
 {
+    private const int DeliveryBatchSize = 20;
+    private const int HighProcessCountThreshold = 50;
+
     private readonly IGrainFactory _grainFactory;
     private readonly IPersistentState<TState> _state;
 
@@ -63,47 +66,59 @@ public abstract class StartEventListenerGrainBase<TState> : Grain
             return [];
         }
 
-        var tasks = State.ProcessDefinitionKeys.Select(async processDefinitionKey =>
-        {
-            try
-            {
-                var processGrain = _grainFactory.GetGrain<IProcessDefinitionGrain>(processDefinitionKey);
+        var processKeys = State.ProcessDefinitionKeys.ToList();
 
-                if (!await processGrain.IsActive())
+        if (processKeys.Count > HighProcessCountThreshold)
+            OnHighProcessCount(eventName, processKeys.Count, HighProcessCountThreshold);
+
+        var createdInstances = new List<Guid>();
+
+        foreach (var batch in processKeys.Chunk(DeliveryBatchSize))
+        {
+            var batchTasks = batch.Select(async processDefinitionKey =>
+            {
+                try
                 {
-                    OnProcessDisabledSkipped(eventName, processDefinitionKey);
+                    var processGrain = _grainFactory.GetGrain<IProcessDefinitionGrain>(processDefinitionKey);
+
+                    if (!await processGrain.IsActive())
+                    {
+                        OnProcessDisabledSkipped(eventName, processDefinitionKey);
+                        return (Guid?)null;
+                    }
+
+                    var instanceId = Guid.NewGuid();
+                    var instance = _grainFactory.GetGrain<IWorkflowInstanceGrain>(instanceId);
+
+                    var definition = await processGrain.GetLatestDefinition();
+
+                    var startActivityId = FindStartActivityId(definition, eventName)
+                        ?? throw new InvalidOperationException(
+                            $"Start activity for '{eventName}' not found in process '{processDefinitionKey}'. " +
+                            "The definition may have been removed during a redeployment.");
+
+                    await instance.SetWorkflow(definition, startActivityId);
+
+                    if (variables is not null)
+                        await instance.SetInitialVariables(variables);
+
+                    await instance.StartWorkflow();
+
+                    OnStartEventFired(eventName, processDefinitionKey, instanceId);
+                    return (Guid?)instanceId;
+                }
+                catch (Exception ex)
+                {
+                    OnStartEventFailed(eventName, processDefinitionKey, ex);
                     return (Guid?)null;
                 }
+            });
 
-                var instanceId = Guid.NewGuid();
-                var instance = _grainFactory.GetGrain<IWorkflowInstanceGrain>(instanceId);
+            var results = await Task.WhenAll(batchTasks);
+            createdInstances.AddRange(results.Where(id => id.HasValue).Select(id => id!.Value));
+        }
 
-                var definition = await processGrain.GetLatestDefinition();
-
-                var startActivityId = FindStartActivityId(definition, eventName)
-                    ?? throw new InvalidOperationException(
-                        $"Start activity for '{eventName}' not found in process '{processDefinitionKey}'. " +
-                        "The definition may have been removed during a redeployment.");
-
-                await instance.SetWorkflow(definition, startActivityId);
-
-                if (variables is not null)
-                    await instance.SetInitialVariables(variables);
-
-                await instance.StartWorkflow();
-
-                OnStartEventFired(eventName, processDefinitionKey, instanceId);
-                return (Guid?)instanceId;
-            }
-            catch (Exception ex)
-            {
-                OnStartEventFailed(eventName, processDefinitionKey, ex);
-                return (Guid?)null;
-            }
-        });
-
-        var results = await Task.WhenAll(tasks);
-        return results.Where(id => id.HasValue).Select(id => id!.Value).ToList();
+        return createdInstances;
     }
 
     protected abstract string? FindStartActivityId(IWorkflowDefinition definition, string eventName);
@@ -116,4 +131,5 @@ public abstract class StartEventListenerGrainBase<TState> : Grain
     protected abstract void OnProcessDisabledSkipped(string eventName, string processDefinitionKey);
     protected abstract void OnStartEventFired(string eventName, string processDefinitionKey, Guid instanceId);
     protected abstract void OnStartEventFailed(string eventName, string processDefinitionKey, Exception ex);
+    protected abstract void OnHighProcessCount(string eventName, int processCount, int threshold);
 }


### PR DESCRIPTION
## Summary

Closes #162

- Replace unbounded `Task.WhenAll` fan-out with `Chunk(20)` batched delivery in `SignalCorrelationGrain.BroadcastSignal()` and `StartEventListenerGrainBase.FireStartEventCore()` (shared by both signal and message start event listeners)
- Add `[LoggerMessage]` warning when subscriber/process count exceeds 50 (high fan-out observability)
- Add integration test verifying batched delivery with 55 subscribers completes correctly

## Key decisions

- **Unified batch size of 20** for all 3 locations — no-op for small collections (< 20 = single batch), only activates for larger fan-outs
- **Batching logic lives in the base class** (`StartEventListenerGrainBase`) for the two start event listeners, with an abstract `OnHighProcessCount` callback for logging in subclasses
- **No inter-batch delay** — the `await Task.WhenAll` per batch provides natural pacing

## How to test

All existing signal/message tests pass unchanged. New test `SignalBroadcast_ManySubscribers_ShouldDeliverInBatchesAndCompleteAll` creates 55 workflow instances waiting for the same signal, broadcasts once, and verifies all 55 receive delivery and complete.

## Test plan

- [x] All 740 tests pass (739 existing + 1 new)
- [x] Build succeeds with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)