### PR TITLE
Query context isolation: route reads through FleanQueryDbContext (#170)

### DIFF
--- a/src/Fleans/Fleans.Api/Program.cs
+++ b/src/Fleans/Fleans.Api/Program.cs
@@ -88,7 +88,12 @@ static void AddPolicyIfConfigured(RateLimiterOptions options, string policyName,
 
 // EF Core persistence for WorkflowInstanceState
 var sqliteConnectionString = builder.Configuration["FLEANS_SQLITE_CONNECTION"] ?? "DataSource=fleans-dev.db";
-builder.Services.AddEfCorePersistence(options => options.UseSqlite(sqliteConnectionString));
+var queryConnectionString = builder.Configuration["FLEANS_QUERY_CONNECTION"];
+builder.Services.AddEfCorePersistence(
+    options => options.UseSqlite(sqliteConnectionString),
+    queryConnectionString is not null
+        ? options => options.UseSqlite(queryConnectionString)
+        : null);
 
 var app = builder.Build();
 

--- a/src/Fleans/Fleans.Aspire/Program.cs
+++ b/src/Fleans/Fleans.Aspire/Program.cs
@@ -3,6 +3,9 @@ var builder = DistributedApplication.CreateBuilder(args);
 // Shared SQLite database file for EF Core persistence (dev only)
 var sqliteDbPath = Path.Combine(Path.GetTempPath(), "fleans-dev.db");
 var sqliteConnectionString = $"DataSource={sqliteDbPath}";
+// Read replica connection — defaults to primary for dev (SQLite).
+// For production with PostgreSQL/SQL Server, point this at a read replica.
+var queryConnectionString = sqliteConnectionString;
 
 // Add Redis for Orleans clustering and storage.
 // Aspire 13.1+ auto-configures TLS for Redis containers, but the Orleans Redis
@@ -21,6 +24,7 @@ var fleansSilo = builder.AddProject<Projects.Fleans_Api>("fleans-core")
     .WithReference(orleans)
     .WaitFor(redis)
     .WithEnvironment("FLEANS_SQLITE_CONNECTION", sqliteConnectionString)
+    .WithEnvironment("FLEANS_QUERY_CONNECTION", queryConnectionString)
     .WithReplicas(1);
 
 // Web = Orleans client
@@ -28,6 +32,7 @@ builder.AddProject<Projects.Fleans_Web>("fleans-management")
     .WithReference(orleans.AsClient())
     .WaitFor(fleansSilo)
     .WithEnvironment("FLEANS_SQLITE_CONNECTION", sqliteConnectionString)
+    .WithEnvironment("FLEANS_QUERY_CONNECTION", queryConnectionString)
     .WithReplicas(1);
 
 // MCP = Orleans client (for Claude Code)
@@ -35,6 +40,7 @@ builder.AddProject<Projects.Fleans_Mcp>("fleans-mcp")
     .WithReference(orleans.AsClient())
     .WaitFor(fleansSilo)
     .WithEnvironment("FLEANS_SQLITE_CONNECTION", sqliteConnectionString)
+    .WithEnvironment("FLEANS_QUERY_CONNECTION", queryConnectionString)
     .WithHttpEndpoint(port: 5200, name: "mcp")
     .WithReplicas(1);
 

--- a/src/Fleans/Fleans.Mcp/Program.cs
+++ b/src/Fleans/Fleans.Mcp/Program.cs
@@ -15,7 +15,12 @@ builder.Services.AddInfrastructure();
 // Note: grain storage registrations from AddEfCorePersistence are unused in this
 // Orleans client, but splitting the registration is a future refactor.
 var sqliteConnectionString = builder.Configuration["FLEANS_SQLITE_CONNECTION"] ?? "DataSource=fleans-dev.db";
-builder.Services.AddEfCorePersistence(options => options.UseSqlite(sqliteConnectionString));
+var queryConnectionString = builder.Configuration["FLEANS_QUERY_CONNECTION"];
+builder.Services.AddEfCorePersistence(
+    options => options.UseSqlite(sqliteConnectionString),
+    queryConnectionString is not null
+        ? options => options.UseSqlite(queryConnectionString)
+        : null);
 
 // Redis for Aspire-managed Orleans
 builder.AddKeyedRedisClient("orleans-redis");

--- a/src/Fleans/Fleans.Persistence.Tests/EfCoreProcessDefinitionRepositoryTests.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/EfCoreProcessDefinitionRepositoryTests.cs
@@ -12,6 +12,7 @@ public class EfCoreProcessDefinitionRepositoryTests
 {
     private SqliteConnection _connection = null!;
     private IDbContextFactory<FleanCommandDbContext> _dbContextFactory = null!;
+    private IDbContextFactory<FleanQueryDbContext> _queryDbContextFactory = null!;
     private IProcessDefinitionRepository _repository = null!;
 
     [TestInitialize]
@@ -20,12 +21,17 @@ public class EfCoreProcessDefinitionRepositoryTests
         _connection = new SqliteConnection("DataSource=:memory:");
         _connection.Open();
 
-        var options = new DbContextOptionsBuilder<FleanCommandDbContext>()
+        var commandOptions = new DbContextOptionsBuilder<FleanCommandDbContext>()
             .UseSqlite(_connection)
             .Options;
 
-        _dbContextFactory = new TestDbContextFactory(options);
-        _repository = new EfCoreProcessDefinitionRepository(_dbContextFactory);
+        var queryOptions = new DbContextOptionsBuilder<FleanQueryDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        _dbContextFactory = new TestDbContextFactory(commandOptions);
+        _queryDbContextFactory = new TestQueryDbContextFactory(queryOptions);
+        _repository = new EfCoreProcessDefinitionRepository(_dbContextFactory, _queryDbContextFactory);
 
         using var db = _dbContextFactory.CreateDbContext();
         db.Database.EnsureCreated();

--- a/src/Fleans/Fleans.Persistence.Tests/TestInfrastructure.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/TestInfrastructure.cs
@@ -24,3 +24,18 @@ internal class TestDbContextFactory : IDbContextFactory<FleanCommandDbContext>
     public Task<FleanCommandDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default)
         => Task.FromResult(CreateDbContext());
 }
+
+internal class TestQueryDbContextFactory : IDbContextFactory<FleanQueryDbContext>
+{
+    private readonly DbContextOptions<FleanQueryDbContext> _options;
+
+    public TestQueryDbContextFactory(DbContextOptions<FleanQueryDbContext> options)
+    {
+        _options = options;
+    }
+
+    public FleanQueryDbContext CreateDbContext() => new(_options);
+
+    public Task<FleanQueryDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(CreateDbContext());
+}

--- a/src/Fleans/Fleans.Persistence/EfCoreProcessDefinitionRepository.cs
+++ b/src/Fleans/Fleans.Persistence/EfCoreProcessDefinitionRepository.cs
@@ -6,26 +6,28 @@ namespace Fleans.Persistence;
 
 public class EfCoreProcessDefinitionRepository : IProcessDefinitionRepository
 {
-    private readonly IDbContextFactory<FleanCommandDbContext> _dbContextFactory;
+    private readonly IDbContextFactory<FleanCommandDbContext> _commandDbFactory;
+    private readonly IDbContextFactory<FleanQueryDbContext> _queryDbFactory;
 
-    public EfCoreProcessDefinitionRepository(IDbContextFactory<FleanCommandDbContext> dbContextFactory)
+    public EfCoreProcessDefinitionRepository(
+        IDbContextFactory<FleanCommandDbContext> commandDbFactory,
+        IDbContextFactory<FleanQueryDbContext> queryDbFactory)
     {
-        _dbContextFactory = dbContextFactory;
+        _commandDbFactory = commandDbFactory;
+        _queryDbFactory = queryDbFactory;
     }
 
     public async Task<ProcessDefinition?> GetByIdAsync(string processDefinitionId)
     {
-        await using var db = await _dbContextFactory.CreateDbContextAsync();
+        await using var db = await _queryDbFactory.CreateDbContextAsync();
         return await db.ProcessDefinitions
-            .AsNoTracking()
             .FirstOrDefaultAsync(d => d.ProcessDefinitionId == processDefinitionId);
     }
 
     public async Task<List<ProcessDefinition>> GetByKeyAsync(string processDefinitionKey)
     {
-        await using var db = await _dbContextFactory.CreateDbContextAsync();
+        await using var db = await _queryDbFactory.CreateDbContextAsync();
         return await db.ProcessDefinitions
-            .AsNoTracking()
             .Where(d => d.ProcessDefinitionKey == processDefinitionKey)
             .OrderBy(d => d.Version)
             .ToListAsync();
@@ -33,9 +35,8 @@ public class EfCoreProcessDefinitionRepository : IProcessDefinitionRepository
 
     public async Task<List<ProcessDefinition>> GetAllAsync()
     {
-        await using var db = await _dbContextFactory.CreateDbContextAsync();
+        await using var db = await _queryDbFactory.CreateDbContextAsync();
         return await db.ProcessDefinitions
-            .AsNoTracking()
             .OrderBy(d => d.ProcessDefinitionKey)
             .ThenBy(d => d.Version)
             .ToListAsync();
@@ -43,7 +44,7 @@ public class EfCoreProcessDefinitionRepository : IProcessDefinitionRepository
 
     public async Task<List<string>> GetAllDistinctKeysAsync()
     {
-        await using var db = await _dbContextFactory.CreateDbContextAsync();
+        await using var db = await _queryDbFactory.CreateDbContextAsync();
         return await db.ProcessDefinitions
             .Select(d => d.ProcessDefinitionKey)
             .Distinct()
@@ -53,7 +54,7 @@ public class EfCoreProcessDefinitionRepository : IProcessDefinitionRepository
 
     public async Task SaveAsync(ProcessDefinition definition)
     {
-        await using var db = await _dbContextFactory.CreateDbContextAsync();
+        await using var db = await _commandDbFactory.CreateDbContextAsync();
 
         var existing = await db.ProcessDefinitions.FindAsync(definition.ProcessDefinitionId);
         if (existing is not null)
@@ -71,7 +72,7 @@ public class EfCoreProcessDefinitionRepository : IProcessDefinitionRepository
     /// </summary>
     public async Task UpdateAsync(ProcessDefinition definition)
     {
-        await using var db = await _dbContextFactory.CreateDbContextAsync();
+        await using var db = await _commandDbFactory.CreateDbContextAsync();
 
         var existing = await db.ProcessDefinitions.FindAsync(definition.ProcessDefinitionId)
             ?? throw new InvalidOperationException(
@@ -87,7 +88,7 @@ public class EfCoreProcessDefinitionRepository : IProcessDefinitionRepository
 
     public async Task DeleteAsync(string processDefinitionId)
     {
-        await using var db = await _dbContextFactory.CreateDbContextAsync();
+        await using var db = await _commandDbFactory.CreateDbContextAsync();
 
         var existing = await db.ProcessDefinitions.FindAsync(processDefinitionId);
         if (existing is null)

--- a/src/Fleans/Fleans.Web/Program.cs
+++ b/src/Fleans/Fleans.Web/Program.cs
@@ -26,7 +26,12 @@ builder.Services.AddInfrastructure();
 
 // EF Core persistence — shared SQLite file with Api silo
 var sqliteConnectionString = builder.Configuration["FLEANS_SQLITE_CONNECTION"] ?? "DataSource=fleans-dev.db";
-builder.Services.AddEfCorePersistence(options => options.UseSqlite(sqliteConnectionString));
+var queryConnectionString = builder.Configuration["FLEANS_QUERY_CONNECTION"];
+builder.Services.AddEfCorePersistence(
+    options => options.UseSqlite(sqliteConnectionString),
+    queryConnectionString is not null
+        ? options => options.UseSqlite(queryConnectionString)
+        : null);
 
 // Register Redis client for Aspire-managed Orleans
 builder.AddKeyedRedisClient("orleans-redis");


### PR DESCRIPTION
## Summary

Closes #170

- **EfCoreProcessDefinitionRepository** now injects both `IDbContextFactory<FleanCommandDbContext>` (for writes) and `IDbContextFactory<FleanQueryDbContext>` (for reads), removing manual `.AsNoTracking()` calls since `FleanQueryDbContext` configures `NoTracking` by default
- **Api, Web, Mcp** `Program.cs` files read an optional `FLEANS_QUERY_CONNECTION` environment variable and pass it as `configureQueryDb` to `AddEfCorePersistence()` — when absent, the existing fallback (`configureQueryDb ?? configureCommandDb`) maintains backward compatibility
- **Aspire** distributes `FLEANS_QUERY_CONNECTION` to all services (defaults to the primary SQLite connection for dev)
- **Test infrastructure** adds `TestQueryDbContextFactory` and updates `EfCoreProcessDefinitionRepositoryTests` to pass both factories

### Key decisions
- DI registration in `DependencyInjection.cs` needed no changes — both context factories are already registered and the container auto-resolves the new constructor
- `EfCoreWorkflowStateProjection` correctly excluded — it reads-then-writes in the same scope and must use the command context
- No documentation file added per CLAUDE.md ("NEVER create documentation files unless explicitly requested")

### Files changed
| File | Change |
|------|--------|
| `EfCoreProcessDefinitionRepository.cs` | Dual-factory injection; reads via query factory, writes via command factory |
| `TestInfrastructure.cs` | Added `TestQueryDbContextFactory` |
| `EfCoreProcessDefinitionRepositoryTests.cs` | Updated setup for dual-factory |
| `Fleans.Api/Program.cs` | Read `FLEANS_QUERY_CONNECTION`, pass `configureQueryDb` |
| `Fleans.Web/Program.cs` | Same |
| `Fleans.Mcp/Program.cs` | Same |
| `Fleans.Aspire/Program.cs` | Distribute `FLEANS_QUERY_CONNECTION` env var |

## Test plan

- [x] All 739 existing tests pass (0 failures)
- [x] Build succeeds with 0 errors
- [ ] Manual: deploy via Aspire, verify query endpoints return data correctly
- [ ] Manual: verify with single connection string (no `FLEANS_QUERY_CONNECTION`) behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)