### PR TITLE
fix(ci): bump website workflow Node to 22

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -38,6 +38,7 @@ jobs:
 
   deploy:
     needs: build
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
## Summary
- Astro 6 / Starlight require Node >=22.12.0; CI was on Node 20 and failing.

## Test plan
- [ ] Deploy Website workflow succeeds on this PR / after merge