### PR TITLE
Phase 1: Extract Fleans.Persistence.Sqlite provider package (#236)

### DIFF
--- a/src/Fleans/Fleans.Api/Fleans.Api.csproj
+++ b/src/Fleans/Fleans.Api/Fleans.Api.csproj
@@ -12,7 +12,6 @@
   <ItemGroup>
     <PackageReference Include="Aspire.StackExchange.Redis" Version="13.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
     <PackageReference Include="Microsoft.Orleans.Clustering.Redis" Version="10.0.1" />
     <PackageReference Include="Microsoft.Orleans.Dashboard" Version="10.0.1" />
     <PackageReference Include="Microsoft.Orleans.GrainDirectory.Redis" Version="10.0.1" />
@@ -26,6 +25,7 @@
     <ProjectReference Include="..\Fleans.Application\Fleans.Application.csproj" />
     <ProjectReference Include="..\Fleans.Infrastructure\Fleans.Infrastructure.csproj" />
     <ProjectReference Include="..\Fleans.Persistence\Fleans.Persistence.csproj" />
+    <ProjectReference Include="..\Fleans.Persistence.Sqlite\Fleans.Persistence.Sqlite.csproj" />
     <ProjectReference Include="..\Fleans.ServiceDefaults\Fleans.ServiceDefaults.csproj" />
   </ItemGroup>
 

--- a/src/Fleans/Fleans.Api/Program.cs
+++ b/src/Fleans/Fleans.Api/Program.cs
@@ -4,6 +4,7 @@ using Fleans.Application;
 using Fleans.Application.Logging;
 using Fleans.Infrastructure;
 using Fleans.Persistence;
+using Fleans.Persistence.Sqlite;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 using Orleans.Dashboard;
@@ -92,11 +93,7 @@ static void AddPolicyIfConfigured(RateLimiterOptions options, string policyName,
 // EF Core persistence for WorkflowInstanceState
 var sqliteConnectionString = builder.Configuration["FLEANS_SQLITE_CONNECTION"] ?? "DataSource=fleans-dev.db";
 var queryConnectionString = builder.Configuration["FLEANS_QUERY_CONNECTION"];
-builder.Services.AddEfCorePersistence(
-    options => options.UseSqlite(sqliteConnectionString),
-    queryConnectionString is not null
-        ? options => options.UseSqlite(queryConnectionString)
-        : null);
+builder.Services.AddSqlitePersistence(sqliteConnectionString, queryConnectionString);
 
 var app = builder.Build();
 
@@ -105,7 +102,7 @@ using (var scope = app.Services.CreateScope())
 {
     var dbFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<FleanCommandDbContext>>();
     using var db = dbFactory.CreateDbContext();
-    db.Database.EnsureCreated();
+    SqliteSchemaInitializer.EnsureCreatedIgnoreRaces(db.Database);
 }
 
 // Configure the HTTP request pipeline.

--- a/src/Fleans/Fleans.Application.Tests/EventPublisherTests.cs
+++ b/src/Fleans/Fleans.Application.Tests/EventPublisherTests.cs
@@ -12,6 +12,7 @@ using Fleans.Domain.Sequences;
 using Fleans.Persistence;
 using Fleans.Persistence.Events;
 using Microsoft.Data.Sqlite;
+using Fleans.Persistence.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -184,10 +185,10 @@ public class EventPublisherTests
                 .ConfigureServices(services =>
                 {
                     services.AddDbContextFactory<FleanCommandDbContext>(options =>
-                        options.UseSqlite("DataSource=file::memory:?cache=shared"));
+                        options.UseFleansSqlite("DataSource=file::memory:?cache=shared"));
 
                     services.AddDbContextFactory<FleanQueryDbContext>(options =>
-                        options.UseSqlite("DataSource=file::memory:?cache=shared"));
+                        options.UseFleansSqlite("DataSource=file::memory:?cache=shared"));
 
                     services.AddSingleton<IWorkflowStateProjection, EfCoreWorkflowStateProjection>();
                     services.AddSingleton<EfCoreEventStore>();

--- a/src/Fleans/Fleans.Application.Tests/Fleans.Application.Tests.csproj
+++ b/src/Fleans/Fleans.Application.Tests/Fleans.Application.Tests.csproj
@@ -21,12 +21,12 @@
     <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
     <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Fleans.Application\Fleans.Application.csproj" />
     <ProjectReference Include="..\Fleans.Persistence\Fleans.Persistence.csproj" />
+    <ProjectReference Include="..\Fleans.Persistence.Sqlite\Fleans.Persistence.Sqlite.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Fleans/Fleans.Application.Tests/WorkflowTestBase.cs
+++ b/src/Fleans/Fleans.Application.Tests/WorkflowTestBase.cs
@@ -10,6 +10,7 @@ using Fleans.Domain.Sequences;
 using Fleans.Persistence;
 using Fleans.Persistence.Events;
 using Microsoft.Data.Sqlite;
+using Fleans.Persistence.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -140,10 +141,10 @@ public abstract class WorkflowTestBase
                 .ConfigureServices(services =>
                 {
                     services.AddDbContextFactory<FleanCommandDbContext>(options =>
-                        options.UseSqlite("DataSource=file::memory:?cache=shared"));
+                        options.UseFleansSqlite("DataSource=file::memory:?cache=shared"));
 
                     services.AddDbContextFactory<FleanQueryDbContext>(options =>
-                        options.UseSqlite("DataSource=file::memory:?cache=shared"));
+                        options.UseFleansSqlite("DataSource=file::memory:?cache=shared"));
 
                     services.AddKeyedSingleton<IGrainStorage>(GrainStorageNames.TimerSchedulers,
                         (sp, _) => new EfCoreTimerSchedulerGrainStorage(

--- a/src/Fleans/Fleans.Infrastructure.Tests/Fleans.Infrastructure.Tests.csproj
+++ b/src/Fleans/Fleans.Infrastructure.Tests/Fleans.Infrastructure.Tests.csproj
@@ -20,13 +20,13 @@
     <PackageReference Include="Microsoft.Orleans.TestingHost" Version="10.0.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
     <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Fleans.Application\Fleans.Application.csproj" />
     <ProjectReference Include="..\Fleans.Infrastructure\Fleans.Infrastructure.csproj" />
     <ProjectReference Include="..\Fleans.Persistence\Fleans.Persistence.csproj" />
+    <ProjectReference Include="..\Fleans.Persistence.Sqlite\Fleans.Persistence.Sqlite.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Fleans/Fleans.Infrastructure.Tests/MultiInstanceScriptIntegrationTests.cs
+++ b/src/Fleans/Fleans.Infrastructure.Tests/MultiInstanceScriptIntegrationTests.cs
@@ -13,6 +13,7 @@ using Fleans.Infrastructure.Conditions;
 using Fleans.Persistence;
 using Fleans.Persistence.Events;
 using Microsoft.Data.Sqlite;
+using Fleans.Persistence.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -340,10 +341,10 @@ public class MultiInstanceScriptIntegrationTests
                 .ConfigureServices(services =>
                 {
                     services.AddDbContextFactory<FleanCommandDbContext>(options =>
-                        options.UseSqlite("DataSource=file::memory:?cache=shared"));
+                        options.UseFleansSqlite("DataSource=file::memory:?cache=shared"));
 
                     services.AddDbContextFactory<FleanQueryDbContext>(options =>
-                        options.UseSqlite("DataSource=file::memory:?cache=shared"));
+                        options.UseFleansSqlite("DataSource=file::memory:?cache=shared"));
 
                     services.AddSingleton<IWorkflowStateProjection, EfCoreWorkflowStateProjection>();
                     services.AddSingleton<EfCoreEventStore>();

--- a/src/Fleans/Fleans.Mcp/Fleans.Mcp.csproj
+++ b/src/Fleans/Fleans.Mcp/Fleans.Mcp.csproj
@@ -10,12 +10,12 @@
     <ProjectReference Include="..\Fleans.Application\Fleans.Application.csproj" />
     <ProjectReference Include="..\Fleans.Infrastructure\Fleans.Infrastructure.csproj" />
     <ProjectReference Include="..\Fleans.Persistence\Fleans.Persistence.csproj" />
+    <ProjectReference Include="..\Fleans.Persistence.Sqlite\Fleans.Persistence.Sqlite.csproj" />
     <ProjectReference Include="..\Fleans.ServiceDefaults\Fleans.ServiceDefaults.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Aspire.StackExchange.Redis" Version="13.1.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
     <PackageReference Include="Microsoft.Orleans.Client" Version="10.0.1" />
     <PackageReference Include="Microsoft.Orleans.Clustering.Redis" Version="10.0.1" />
     <PackageReference Include="Microsoft.Orleans.Sdk" Version="10.0.1" />

--- a/src/Fleans/Fleans.Mcp/Program.cs
+++ b/src/Fleans/Fleans.Mcp/Program.cs
@@ -1,6 +1,7 @@
 using Fleans.Application;
 using Fleans.Infrastructure;
 using Fleans.Persistence;
+using Fleans.Persistence.Sqlite;
 using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -16,11 +17,7 @@ builder.Services.AddInfrastructure();
 // Orleans client, but splitting the registration is a future refactor.
 var sqliteConnectionString = builder.Configuration["FLEANS_SQLITE_CONNECTION"] ?? "DataSource=fleans-dev.db";
 var queryConnectionString = builder.Configuration["FLEANS_QUERY_CONNECTION"];
-builder.Services.AddEfCorePersistence(
-    options => options.UseSqlite(sqliteConnectionString),
-    queryConnectionString is not null
-        ? options => options.UseSqlite(queryConnectionString)
-        : null);
+builder.Services.AddSqlitePersistence(sqliteConnectionString, queryConnectionString);
 
 // Redis for Aspire-managed Orleans
 builder.AddKeyedRedisClient("orleans-redis");
@@ -41,8 +38,7 @@ using (var scope = app.Services.CreateScope())
 {
     var dbFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<FleanCommandDbContext>>();
     using var db = dbFactory.CreateDbContext();
-    try { db.Database.EnsureCreated(); }
-    catch (Microsoft.Data.Sqlite.SqliteException) { /* tables already created by Api */ }
+    SqliteSchemaInitializer.EnsureCreatedIgnoreRaces(db.Database);
 }
 
 app.MapDefaultEndpoints();

--- a/src/Fleans/Fleans.Persistence.Sqlite/Fleans.Persistence.Sqlite.csproj
+++ b/src/Fleans/Fleans.Persistence.Sqlite/Fleans.Persistence.Sqlite.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>14</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Fleans.Persistence\Fleans.Persistence.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Fleans/Fleans.Persistence.Sqlite/SqliteModelCustomizer.cs
+++ b/src/Fleans/Fleans.Persistence.Sqlite/SqliteModelCustomizer.cs
@@ -1,0 +1,62 @@
+using Fleans.Domain;
+using Fleans.Domain.States;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace Fleans.Persistence.Sqlite;
+
+/// <summary>
+/// SQLite-specific model tweaks applied on top of the shared Fleans model.
+///
+/// SQLite does not support <see cref="DateTimeOffset"/> in <c>ORDER BY</c>. To keep Sieve
+/// sorting working against SQLite, we store every <see cref="DateTimeOffset"/>
+/// (and <see cref="Nullable{DateTimeOffset}"/>) property as an ISO 8601 string.
+/// PostgreSQL and other providers store them natively, so this conversion lives in the
+/// SQLite provider package rather than the shared model.
+/// </summary>
+internal sealed class SqliteModelCustomizer : RelationalModelCustomizer
+{
+    private static readonly ValueConverter<DateTimeOffset?, string?> NullableDtoToStringConverter =
+        new(
+            v => v.HasValue ? v.Value.ToString("O") : null,
+            v => v != null ? DateTimeOffset.Parse(v) : null);
+
+    private static readonly ValueConverter<DateTimeOffset, string> DtoToStringConverter =
+        new(
+            v => v.ToString("O"),
+            v => DateTimeOffset.Parse(v));
+
+    public SqliteModelCustomizer(ModelCustomizerDependencies dependencies)
+        : base(dependencies)
+    {
+    }
+
+    public override void Customize(ModelBuilder modelBuilder, DbContext context)
+    {
+        base.Customize(modelBuilder, context);
+
+        // WorkflowInstanceState — three nullable DateTimeOffset columns
+        modelBuilder.Entity<WorkflowInstanceState>()
+            .Property(e => e.CreatedAt)
+            .HasConversion(NullableDtoToStringConverter);
+
+        modelBuilder.Entity<WorkflowInstanceState>()
+            .Property(e => e.ExecutionStartedAt)
+            .HasConversion(NullableDtoToStringConverter);
+
+        modelBuilder.Entity<WorkflowInstanceState>()
+            .Property(e => e.CompletedAt)
+            .HasConversion(NullableDtoToStringConverter);
+
+        // UserTaskState.CreatedAt — non-nullable DateTimeOffset
+        modelBuilder.Entity<UserTaskState>()
+            .Property(e => e.CreatedAt)
+            .HasConversion(DtoToStringConverter);
+
+        // ProcessDefinition.DeployedAt — non-nullable DateTimeOffset
+        modelBuilder.Entity<ProcessDefinition>()
+            .Property(e => e.DeployedAt)
+            .HasConversion(DtoToStringConverter);
+    }
+}

--- a/src/Fleans/Fleans.Persistence.Sqlite/SqlitePersistenceDependencyInjection.cs
+++ b/src/Fleans/Fleans.Persistence.Sqlite/SqlitePersistenceDependencyInjection.cs
@@ -1,0 +1,90 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Fleans.Persistence.Sqlite;
+
+/// <summary>
+/// DI extensions for registering the SQLite-backed Fleans persistence layer.
+/// </summary>
+public static class SqlitePersistenceDependencyInjection
+{
+    /// <summary>
+    /// Registers Fleans persistence using SQLite as the underlying provider for both
+    /// command and query DbContexts.
+    /// </summary>
+    /// <param name="services">Service collection.</param>
+    /// <param name="commandConnectionString">Connection string for the command DbContext.</param>
+    /// <param name="queryConnectionString">
+    /// Optional connection string for the query DbContext. When null the command connection
+    /// string is reused (the existing behavior of <see cref="EfCorePersistenceDependencyInjection.AddEfCorePersistence"/>).
+    /// </param>
+    public static IServiceCollection AddSqlitePersistence(
+        this IServiceCollection services,
+        string commandConnectionString,
+        string? queryConnectionString = null)
+    {
+        services.AddEfCorePersistence(
+            options => options.UseFleansSqlite(commandConnectionString),
+            queryConnectionString is not null
+                ? options => options.UseFleansSqlite(queryConnectionString)
+                : null);
+
+        return services;
+    }
+}
+
+/// <summary>
+/// Extension helpers for configuring a <see cref="DbContextOptionsBuilder"/> to use
+/// SQLite with the Fleans-specific model customizer applied.
+/// </summary>
+public static class SqliteDbContextOptionsExtensions
+{
+    /// <summary>
+    /// Configures the builder to use SQLite and installs the
+    /// <c>SqliteModelCustomizer</c> so SQLite-specific model tweaks (notably
+    /// <see cref="DateTimeOffset"/> → string conversion) are applied.
+    /// </summary>
+    public static DbContextOptionsBuilder UseFleansSqlite(
+        this DbContextOptionsBuilder builder,
+        string connectionString)
+    {
+        builder.UseSqlite(connectionString);
+        builder.ReplaceService<IModelCustomizer, SqliteModelCustomizer>();
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the builder to use SQLite against an existing
+    /// <see cref="System.Data.Common.DbConnection"/> and installs the
+    /// <c>SqliteModelCustomizer</c>.
+    /// </summary>
+    public static DbContextOptionsBuilder UseFleansSqlite(
+        this DbContextOptionsBuilder builder,
+        System.Data.Common.DbConnection connection)
+    {
+        builder.UseSqlite(connection);
+        builder.ReplaceService<IModelCustomizer, SqliteModelCustomizer>();
+        return builder;
+    }
+
+    /// <inheritdoc cref="UseFleansSqlite(DbContextOptionsBuilder, string)"/>
+    public static DbContextOptionsBuilder<TContext> UseFleansSqlite<TContext>(
+        this DbContextOptionsBuilder<TContext> builder,
+        string connectionString)
+        where TContext : DbContext
+    {
+        UseFleansSqlite((DbContextOptionsBuilder)builder, connectionString);
+        return builder;
+    }
+
+    /// <inheritdoc cref="UseFleansSqlite(DbContextOptionsBuilder, System.Data.Common.DbConnection)"/>
+    public static DbContextOptionsBuilder<TContext> UseFleansSqlite<TContext>(
+        this DbContextOptionsBuilder<TContext> builder,
+        System.Data.Common.DbConnection connection)
+        where TContext : DbContext
+    {
+        UseFleansSqlite((DbContextOptionsBuilder)builder, connection);
+        return builder;
+    }
+}

--- a/src/Fleans/Fleans.Persistence.Sqlite/SqliteSchemaInitializer.cs
+++ b/src/Fleans/Fleans.Persistence.Sqlite/SqliteSchemaInitializer.cs
@@ -1,0 +1,32 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace Fleans.Persistence.Sqlite;
+
+/// <summary>
+/// SQLite-specific schema bootstrap helpers.
+/// </summary>
+public static class SqliteSchemaInitializer
+{
+    /// <summary>
+    /// Calls <see cref="DatabaseFacade.EnsureCreated"/> and swallows
+    /// <see cref="SqliteException"/>s thrown when another process (e.g. a sibling silo
+    /// sharing the same .db file) has already created the tables.
+    /// </summary>
+    /// <remarks>
+    /// This exists so host projects do not need a direct reference to
+    /// <c>Microsoft.Data.Sqlite</c> just for the race-catch block.
+    /// </remarks>
+    public static void EnsureCreatedIgnoreRaces(DatabaseFacade database)
+    {
+        try
+        {
+            database.EnsureCreated();
+        }
+        catch (SqliteException)
+        {
+            // Tables already created by a concurrent process sharing the same SQLite file.
+        }
+    }
+}

--- a/src/Fleans/Fleans.Persistence.Tests/EfCoreEventStoreTests.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/EfCoreEventStoreTests.cs
@@ -3,6 +3,7 @@ using Fleans.Domain.Events;
 using Fleans.Domain.States;
 using Fleans.Persistence.Events;
 using Microsoft.Data.Sqlite;
+using Fleans.Persistence.Sqlite;
 using Microsoft.EntityFrameworkCore;
 
 namespace Fleans.Persistence.Tests;
@@ -21,7 +22,7 @@ public class EfCoreEventStoreTests
         _connection.Open();
 
         var options = new DbContextOptionsBuilder<FleanCommandDbContext>()
-            .UseSqlite(_connection)
+            .UseFleansSqlite(_connection)
             .Options;
 
         _dbContextFactory = new TestDbContextFactory(options);

--- a/src/Fleans/Fleans.Persistence.Tests/EfCoreMessageCorrelationGrainStorageTests.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/EfCoreMessageCorrelationGrainStorageTests.cs
@@ -1,5 +1,6 @@
 using Fleans.Domain.States;
 using Microsoft.Data.Sqlite;
+using Fleans.Persistence.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Orleans.Runtime;
 using Orleans.Storage;
@@ -21,7 +22,7 @@ public class EfCoreMessageCorrelationGrainStorageTests
         _connection.Open();
 
         var options = new DbContextOptionsBuilder<FleanCommandDbContext>()
-            .UseSqlite(_connection)
+            .UseFleansSqlite(_connection)
             .Options;
 
         _dbContextFactory = new TestDbContextFactory(options);

--- a/src/Fleans/Fleans.Persistence.Tests/EfCoreProcessDefinitionGrainStorageTests.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/EfCoreProcessDefinitionGrainStorageTests.cs
@@ -2,6 +2,7 @@ using Fleans.Domain;
 using Fleans.Domain.Activities;
 using Fleans.Domain.Sequences;
 using Microsoft.Data.Sqlite;
+using Fleans.Persistence.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Orleans.Runtime;
 using Orleans.Storage;
@@ -23,7 +24,7 @@ public class EfCoreProcessDefinitionGrainStorageTests
         _connection.Open();
 
         var options = new DbContextOptionsBuilder<FleanCommandDbContext>()
-            .UseSqlite(_connection)
+            .UseFleansSqlite(_connection)
             .Options;
 
         _dbContextFactory = new TestDbContextFactory(options);

--- a/src/Fleans/Fleans.Persistence.Tests/EfCoreProcessDefinitionRepositoryTests.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/EfCoreProcessDefinitionRepositoryTests.cs
@@ -3,6 +3,7 @@ using Fleans.Domain.Activities;
 using Fleans.Domain.Persistence;
 using Fleans.Domain.Sequences;
 using Microsoft.Data.Sqlite;
+using Fleans.Persistence.Sqlite;
 using Microsoft.EntityFrameworkCore;
 
 namespace Fleans.Persistence.Tests;
@@ -22,11 +23,11 @@ public class EfCoreProcessDefinitionRepositoryTests
         _connection.Open();
 
         var commandOptions = new DbContextOptionsBuilder<FleanCommandDbContext>()
-            .UseSqlite(_connection)
+            .UseFleansSqlite(_connection)
             .Options;
 
         var queryOptions = new DbContextOptionsBuilder<FleanQueryDbContext>()
-            .UseSqlite(_connection)
+            .UseFleansSqlite(_connection)
             .Options;
 
         _dbContextFactory = new TestDbContextFactory(commandOptions);

--- a/src/Fleans/Fleans.Persistence.Tests/EfCoreSignalCorrelationGrainStorageTests.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/EfCoreSignalCorrelationGrainStorageTests.cs
@@ -1,5 +1,6 @@
 using Fleans.Domain.States;
 using Microsoft.Data.Sqlite;
+using Fleans.Persistence.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Orleans.Runtime;
 using Orleans.Storage;
@@ -21,7 +22,7 @@ public class EfCoreSignalCorrelationGrainStorageTests
         _connection.Open();
 
         var options = new DbContextOptionsBuilder<FleanCommandDbContext>()
-            .UseSqlite(_connection)
+            .UseFleansSqlite(_connection)
             .Options;
 
         _dbContextFactory = new TestDbContextFactory(options);

--- a/src/Fleans/Fleans.Persistence.Tests/Fleans.Persistence.Tests.csproj
+++ b/src/Fleans/Fleans.Persistence.Tests/Fleans.Persistence.Tests.csproj
@@ -11,7 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="MSTest" Version="4.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>
@@ -20,6 +19,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Fleans.Persistence\Fleans.Persistence.csproj" />
+    <ProjectReference Include="..\Fleans.Persistence.Sqlite\Fleans.Persistence.Sqlite.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Fleans/Fleans.Persistence.Tests/WorkflowQueryServiceTests.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/WorkflowQueryServiceTests.cs
@@ -7,6 +7,7 @@ using Fleans.Domain.Sequences;
 using Fleans.Domain.States;
 using Fleans.Persistence;
 using Microsoft.Data.Sqlite;
+using Fleans.Persistence.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using Sieve.Models;
@@ -29,11 +30,11 @@ public class WorkflowQueryServiceTests
         _connection.Open();
 
         var commandOptions = new DbContextOptionsBuilder<FleanCommandDbContext>()
-            .UseSqlite(_connection)
+            .UseFleansSqlite(_connection)
             .Options;
 
         var queryOptions = new DbContextOptionsBuilder<FleanQueryDbContext>()
-            .UseSqlite(_connection)
+            .UseFleansSqlite(_connection)
             .Options;
 
         _commandDbContextFactory = new TestCommandDbContextFactory(commandOptions);

--- a/src/Fleans/Fleans.Persistence/FleanModelConfiguration.cs
+++ b/src/Fleans/Fleans.Persistence/FleanModelConfiguration.cs
@@ -40,14 +40,10 @@ internal static class FleanModelConfiguration
 
             entity.Property(e => e.ProcessDefinitionId).HasMaxLength(512);
 
-            // SQLite does not support DateTimeOffset in ORDER BY.
-            // Store as ISO 8601 strings so Sieve sorting works correctly.
-            var dtoConverter = new ValueConverter<DateTimeOffset?, string?>(
-                v => v.HasValue ? v.Value.ToString("O") : null,
-                v => v != null ? DateTimeOffset.Parse(v) : null);
-            entity.Property(e => e.CreatedAt).HasConversion(dtoConverter);
-            entity.Property(e => e.ExecutionStartedAt).HasConversion(dtoConverter);
-            entity.Property(e => e.CompletedAt).HasConversion(dtoConverter);
+            // DateTimeOffset columns (CreatedAt / ExecutionStartedAt / CompletedAt) are stored
+            // natively in the shared model. Provider packages may override this — e.g. the
+            // SQLite provider applies a string converter via its IModelCustomizer because SQLite
+            // does not support DateTimeOffset in ORDER BY.
 
             // UserTasks is an in-memory dictionary rehydrated from the UserTasks table on activation.
             entity.Ignore(e => e.UserTasks);
@@ -243,12 +239,8 @@ internal static class FleanModelConfiguration
                     v => v == null ? null : JsonConvert.SerializeObject(v),
                     v => v == null ? null : JsonConvert.DeserializeObject<List<string>>(v));
 
-            // SQLite does not support DateTimeOffset in ORDER BY.
-            // Store as ISO 8601 string so Sieve sorting works correctly.
-            entity.Property(e => e.CreatedAt)
-                .HasConversion(
-                    v => v.ToString("O"),
-                    v => DateTimeOffset.Parse(v));
+            // CreatedAt is stored natively; SQLite provider package overrides this with a
+            // string converter (see SqliteModelCustomizer).
 
             entity.HasOne<WorkflowInstanceState>()
                 .WithMany()
@@ -272,12 +264,8 @@ internal static class FleanModelConfiguration
 
             entity.Property(e => e.IsActive).HasDefaultValue(true);
 
-            // SQLite does not support DateTimeOffset in ORDER BY.
-            // Store as ISO 8601 string so Sieve sorting works correctly.
-            entity.Property(e => e.DeployedAt)
-                .HasConversion(
-                    v => v.ToString("O"),
-                    v => DateTimeOffset.Parse(v));
+            // DeployedAt is stored natively; SQLite provider package overrides this with a
+            // string converter (see SqliteModelCustomizer).
 
             var jsonSettings = new JsonSerializerSettings
             {

--- a/src/Fleans/Fleans.Web/Fleans.Web.csproj
+++ b/src/Fleans/Fleans.Web/Fleans.Web.csproj
@@ -11,12 +11,12 @@
       <ProjectReference Include="..\Fleans.Application\Fleans.Application.csproj" />
       <ProjectReference Include="..\Fleans.Infrastructure\Fleans.Infrastructure.csproj" />
       <ProjectReference Include="..\Fleans.Persistence\Fleans.Persistence.csproj" />
+      <ProjectReference Include="..\Fleans.Persistence.Sqlite\Fleans.Persistence.Sqlite.csproj" />
       <ProjectReference Include="..\Fleans.ServiceDefaults\Fleans.ServiceDefaults.csproj" />
     </ItemGroup>
 
     <ItemGroup>
       <PackageReference Include="Aspire.StackExchange.Redis" Version="13.1.1" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
       <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.14.0" />
       <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Emoji" Version="4.14.0" />
       <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.14.0" />

--- a/src/Fleans/Fleans.Web/Program.cs
+++ b/src/Fleans/Fleans.Web/Program.cs
@@ -1,6 +1,7 @@
 using Fleans.Application;
 using Fleans.Infrastructure;
 using Fleans.Persistence;
+using Fleans.Persistence.Sqlite;
 using Fleans.Web.Components;
 using Fleans.Web.Services;
 using Microsoft.EntityFrameworkCore;
@@ -27,11 +28,7 @@ builder.Services.AddInfrastructure();
 // EF Core persistence — shared SQLite file with Api silo
 var sqliteConnectionString = builder.Configuration["FLEANS_SQLITE_CONNECTION"] ?? "DataSource=fleans-dev.db";
 var queryConnectionString = builder.Configuration["FLEANS_QUERY_CONNECTION"];
-builder.Services.AddEfCorePersistence(
-    options => options.UseSqlite(sqliteConnectionString),
-    queryConnectionString is not null
-        ? options => options.UseSqlite(queryConnectionString)
-        : null);
+builder.Services.AddSqlitePersistence(sqliteConnectionString, queryConnectionString);
 
 // Register Redis client for Aspire-managed Orleans
 builder.AddKeyedRedisClient("orleans-redis");
@@ -50,8 +47,7 @@ using (var scope = app.Services.CreateScope())
 {
     var dbFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<FleanCommandDbContext>>();
     using var db = dbFactory.CreateDbContext();
-    try { db.Database.EnsureCreated(); }
-    catch (Microsoft.Data.Sqlite.SqliteException) { /* tables already created by Api */ }
+    SqliteSchemaInitializer.EnsureCreatedIgnoreRaces(db.Database);
 }
 
 // Configure the HTTP request pipeline.

--- a/src/Fleans/Fleans.sln
+++ b/src/Fleans/Fleans.sln
@@ -33,6 +33,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fleans.Mcp", "Fleans.Mcp\Fl
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fleans.Mcp.Tests", "Fleans.Mcp.Tests\Fleans.Mcp.Tests.csproj", "{499B7808-8022-4388-AAED-040A1B411058}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fleans.Persistence.Sqlite", "Fleans.Persistence.Sqlite\Fleans.Persistence.Sqlite.csproj", "{85899511-19F3-46C9-B3BA-250665406922}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -211,6 +213,18 @@ Global
 		{499B7808-8022-4388-AAED-040A1B411058}.Release|x64.Build.0 = Release|Any CPU
 		{499B7808-8022-4388-AAED-040A1B411058}.Release|x86.ActiveCfg = Release|Any CPU
 		{499B7808-8022-4388-AAED-040A1B411058}.Release|x86.Build.0 = Release|Any CPU
+		{85899511-19F3-46C9-B3BA-250665406922}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{85899511-19F3-46C9-B3BA-250665406922}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{85899511-19F3-46C9-B3BA-250665406922}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{85899511-19F3-46C9-B3BA-250665406922}.Debug|x64.Build.0 = Debug|Any CPU
+		{85899511-19F3-46C9-B3BA-250665406922}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{85899511-19F3-46C9-B3BA-250665406922}.Debug|x86.Build.0 = Debug|Any CPU
+		{85899511-19F3-46C9-B3BA-250665406922}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{85899511-19F3-46C9-B3BA-250665406922}.Release|Any CPU.Build.0 = Release|Any CPU
+		{85899511-19F3-46C9-B3BA-250665406922}.Release|x64.ActiveCfg = Release|Any CPU
+		{85899511-19F3-46C9-B3BA-250665406922}.Release|x64.Build.0 = Release|Any CPU
+		{85899511-19F3-46C9-B3BA-250665406922}.Release|x86.ActiveCfg = Release|Any CPU
+		{85899511-19F3-46C9-B3BA-250665406922}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary

Phase 1 of the PostgreSQL persistence provider work (#236). Pure refactor — no schema change, no behavior change. Splits SQLite-specific concerns out of `Fleans.Persistence` into a new `Fleans.Persistence.Sqlite` project, leaving the shared model provider-agnostic.

Scoped to Phase 1 only, per the approved design & plan v2 which explicitly calls out Phase 1 as its own PR. Phases 2-5 (migrations, PostgreSQL provider, tests, docs/CI) will land in follow-up PRs.

## What's in this PR

- **New `Fleans.Persistence.Sqlite` project**
  - `SqliteModelCustomizer : RelationalModelCustomizer` — applies the `DateTimeOffset → ISO 8601 string` converters to `WorkflowInstanceState.{CreatedAt,ExecutionStartedAt,CompletedAt}`, `UserTaskState.CreatedAt`, `ProcessDefinition.DeployedAt`. Installed via `ReplaceService<IModelCustomizer>` on the options instance so EF Core's model cache stays per-provider (addresses review Q1).
  - `AddSqlitePersistence(...)` DI extension and `UseFleansSqlite(...)` `DbContextOptionsBuilder` extensions (both generic + non-generic).
  - `SqliteSchemaInitializer.EnsureCreatedIgnoreRaces(...)` helper so hosts no longer need a direct `Microsoft.Data.Sqlite` reference just for the race-catch.

- **`Fleans.Persistence` shared model**
  - Removed the three `DateTimeOffset → string` `ValueConverter` blocks from `FleanModelConfiguration`. The shared model now stores `DateTimeOffset` natively; provider packages override when needed.

- **Hosts (Api, Web, Mcp)**
  - Removed direct `Microsoft.EntityFrameworkCore.Sqlite` package reference; now reference `Fleans.Persistence.Sqlite` instead.
  - Replaced inline `AddEfCorePersistence(o => o.UseSqlite(...))` with `AddSqlitePersistence(...)`.
  - Replaced the `try { EnsureCreated() } catch (SqliteException)` block with `SqliteSchemaInitializer.EnsureCreatedIgnoreRaces(db.Database)`.

- **Tests (Persistence.Tests, Application.Tests, Infrastructure.Tests)**
  - Reference `Fleans.Persistence.Sqlite` and use `.UseFleansSqlite(...)` so the SQLite model customizer is applied in test DbContexts.
  - The existing `GetInstancesByKey_Paginated_SortedByCreatedAtDesc` test exercises `ORDER BY CreatedAt` on SQLite end-to-end and continues to pass — i.e. the regression lane called out in plan step 7a is already covered by existing tests; without the customizer being applied it would fail with SQLite's "ORDER BY DateTimeOffset not supported" error.

## Key decisions

- `ReplaceService<IModelCustomizer>` (not DI-resolved `IPersistenceProviderConfigurator`) — matches design v2 Q1: EF Core's model cache key incorporates context option extensions, so per-provider models are isolated. Ordering is deterministic: `base.Customize()` runs the shared `FleanModelConfiguration` first, provider tweaks second.
- No `MigrationsAssembly` wiring yet — deferred to Phase 2 when initial migrations are generated. Hosts still use `EnsureCreated`, unchanged.

## Out of scope (follow-ups)

- Phase 2 — initial SQLite migrations, `BaselineMigrations` helper, `EnsureMigratedAsync`.
- Phase 3 — `Fleans.Persistence.PostgreSql` package, `PostgresModelCustomizer`, host provider selection, Aspire wiring.
- Phase 4 — parametrised Sqlite/Postgres test fixtures via Testcontainers.
- Phase 5 — README "Persistence providers" section, CI PG job.

## Test plan

- [x] `dotnet build Fleans.sln` — 0 errors
- [x] `dotnet test Fleans.sln` — 780 passed, 0 failed (Domain 344, Persistence 116, Infrastructure 109, Application 207, Mcp 4)

Closes part of #236 (Phase 1 of the v2 plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)