### PR TITLE
refactor(persistence): extract shared persistence config into ServiceDefaults (#289)

### DIFF
--- a/src/Fleans/Fleans.Api/Program.cs
+++ b/src/Fleans/Fleans.Api/Program.cs
@@ -3,11 +3,10 @@ using Fleans.Api;
 using Fleans.Application;
 using Fleans.Application.Logging;
 using Fleans.Infrastructure;
-using Fleans.Persistence;
 using Fleans.Persistence.PostgreSql;
 using Fleans.Persistence.Sqlite;
+using Fleans.ServiceDefaults;
 using Microsoft.AspNetCore.RateLimiting;
-using Microsoft.EntityFrameworkCore;
 using Orleans.Dashboard;
 using Orleans.EventSourcing.CustomStorage;
 
@@ -92,42 +91,11 @@ static void AddPolicyIfConfigured(RateLimiterOptions options, string policyName,
 }
 
 // EF Core persistence — provider selected by Persistence:Provider config key (default: Sqlite)
-var persistenceProvider = builder.Configuration["Persistence:Provider"] ?? "Sqlite";
-if (persistenceProvider.Equals("Postgres", StringComparison.OrdinalIgnoreCase))
-{
-    var pgConnectionString = builder.Configuration.GetConnectionString("fleans")
-        ?? throw new InvalidOperationException("Connection string 'fleans' is required when Persistence:Provider=Postgres");
-    var pgQueryConnectionString = builder.Configuration.GetConnectionString("fleans-query");
-    builder.Services.AddPostgresPersistence(pgConnectionString, pgQueryConnectionString);
-}
-else
-{
-    var sqliteConnectionString = builder.Configuration["FLEANS_SQLITE_CONNECTION"] ?? "DataSource=fleans-dev.db";
-    var queryConnectionString = builder.Configuration["FLEANS_QUERY_CONNECTION"];
-    builder.Services.AddSqlitePersistence(sqliteConnectionString, queryConnectionString);
-}
+builder.AddFleansPersistence();
 
 var app = builder.Build();
 
-// Ensure EF Core database is created / migrated on startup
-using (var scope = app.Services.CreateScope())
-{
-    if (!persistenceProvider.Equals("Postgres", StringComparison.OrdinalIgnoreCase))
-    {
-        // SQLite: use EnsureCreated (fast, idempotent, no migration history required for dev)
-        var dbFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<FleanCommandDbContext>>();
-        using var db = dbFactory.CreateDbContext();
-        SqliteSchemaInitializer.EnsureCreatedIgnoreRaces(db.Database);
-    }
-    else
-    {
-        // PostgreSQL: apply command migrations only (command and query share the same database;
-        // there are no separate query migrations — the query context reads the same schema).
-        var dbFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<FleanCommandDbContext>>();
-        await using var commandDb = dbFactory.CreateDbContext();
-        await commandDb.Database.MigrateAsync();
-    }
-}
+await app.EnsureDatabaseSchemaAsync();
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())

--- a/src/Fleans/Fleans.Aspire/Program.cs
+++ b/src/Fleans/Fleans.Aspire/Program.cs
@@ -16,75 +16,65 @@ var orleans = builder.AddOrleans("cluster")
     .WithGrainStorage("PubSubStore", redis)
     .WithMemoryReminders();
 
+IResourceBuilder<PostgresDatabaseResource>? pg = null;
+string? sqliteConnectionString = null;
+
 if (usePostgres)
 {
-    // PostgreSQL provider: provision a containerised Postgres instance
-    var pg = builder.AddPostgres("postgres")
+    pg = builder.AddPostgres("postgres")
         .WithDataVolume()
         .AddDatabase("fleans");
-
-    // Api = Orleans silo (with PostgreSQL)
-    var fleansSilo = builder.AddProject<Projects.Fleans_Api>("fleans-core")
-        .WithReference(orleans)
-        .WaitFor(redis)
-        .WithReference(pg)
-        .WaitFor(pg)
-        .WithEnvironment("Persistence__Provider", "Postgres")
-        .WithReplicas(1);
-
-    // Web = Orleans client (with PostgreSQL)
-    builder.AddProject<Projects.Fleans_Web>("fleans-management")
-        .WithReference(orleans.AsClient())
-        .WaitFor(fleansSilo)
-        .WithReference(pg)
-        .WaitFor(pg)
-        .WithEnvironment("Persistence__Provider", "Postgres")
-        .WithReplicas(1);
-
-    // MCP = Orleans client (with PostgreSQL)
-    builder.AddProject<Projects.Fleans_Mcp>("fleans-mcp")
-        .WithReference(orleans.AsClient())
-        .WaitFor(fleansSilo)
-        .WithReference(pg)
-        .WaitFor(pg)
-        .WithEnvironment("Persistence__Provider", "Postgres")
-        .WithHttpEndpoint(port: 5200, name: "mcp")
-        .WithReplicas(1);
 }
 else
 {
-    // SQLite provider: shared database file for EF Core persistence (dev only)
     var sqliteDbPath = Path.Combine(Path.GetTempPath(), "fleans-dev.db");
-    var sqliteConnectionString = $"DataSource={sqliteDbPath}";
-    // Read replica connection — defaults to primary for dev (SQLite).
-    // For production with PostgreSQL/SQL Server, point this at a read replica.
-    var queryConnectionString = sqliteConnectionString;
+    sqliteConnectionString = $"DataSource={sqliteDbPath}";
+}
 
-    // Api = Orleans silo
-    var fleansSilo = builder.AddProject<Projects.Fleans_Api>("fleans-core")
-        .WithReference(orleans)
-        .WaitFor(redis)
-        .WithEnvironment("FLEANS_SQLITE_CONNECTION", sqliteConnectionString)
-        .WithEnvironment("FLEANS_QUERY_CONNECTION", queryConnectionString)
-        .WithReplicas(1);
+// Local helper: wires persistence env-vars / resource references onto a project.
+// WaitFor(pg) is intentionally omitted — startup ordering is the caller's responsibility.
+// Web and Mcp already wait for fleansSilo, which waits for pg when using Postgres.
+static IResourceBuilder<ProjectResource> WithPersistence(
+    IResourceBuilder<ProjectResource> project,
+    bool isPostgres,
+    IResourceBuilder<PostgresDatabaseResource>? pgDb,
+    string? sqliteConn)
+{
+    if (isPostgres)
+    {
+        return project
+            .WithReference(pgDb!)
+            .WithEnvironment("Persistence__Provider", "Postgres");
+    }
+    return project
+        .WithEnvironment("FLEANS_SQLITE_CONNECTION", sqliteConn!)
+        .WithEnvironment("FLEANS_QUERY_CONNECTION", sqliteConn!);
+}
 
-    // Web = Orleans client
+// Api = Orleans silo
+var apiProject = builder.AddProject<Projects.Fleans_Api>("fleans-core")
+    .WithReference(orleans)
+    .WaitFor(redis)
+    .WithReplicas(1);
+if (usePostgres) apiProject = apiProject.WaitFor(pg!);
+var fleansSilo = WithPersistence(apiProject, usePostgres, pg, sqliteConnectionString);
+
+// Web = Orleans client
+WithPersistence(
     builder.AddProject<Projects.Fleans_Web>("fleans-management")
         .WithReference(orleans.AsClient())
         .WaitFor(fleansSilo)
-        .WithEnvironment("FLEANS_SQLITE_CONNECTION", sqliteConnectionString)
-        .WithEnvironment("FLEANS_QUERY_CONNECTION", queryConnectionString)
-        .WithReplicas(1);
+        .WithReplicas(1),
+    usePostgres, pg, sqliteConnectionString);
 
-    // MCP = Orleans client (for Claude Code)
+// MCP = Orleans client (for Claude Code)
+WithPersistence(
     builder.AddProject<Projects.Fleans_Mcp>("fleans-mcp")
         .WithReference(orleans.AsClient())
         .WaitFor(fleansSilo)
-        .WithEnvironment("FLEANS_SQLITE_CONNECTION", sqliteConnectionString)
-        .WithEnvironment("FLEANS_QUERY_CONNECTION", queryConnectionString)
         .WithHttpEndpoint(port: 5200, name: "mcp")
-        .WithReplicas(1);
-}
+        .WithReplicas(1),
+    usePostgres, pg, sqliteConnectionString);
 
 using var app = builder.Build();
 await app.RunAsync();

--- a/src/Fleans/Fleans.Mcp/Program.cs
+++ b/src/Fleans/Fleans.Mcp/Program.cs
@@ -1,9 +1,8 @@
 using Fleans.Application;
 using Fleans.Infrastructure;
-using Fleans.Persistence;
 using Fleans.Persistence.PostgreSql;
 using Fleans.Persistence.Sqlite;
-using Microsoft.EntityFrameworkCore;
+using Fleans.ServiceDefaults;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,20 +15,7 @@ builder.Services.AddInfrastructure();
 // EF Core persistence — provider selected by Persistence:Provider config key (default: Sqlite)
 // Note: grain storage registrations from AddEfCorePersistence are unused in this
 // Orleans client, but splitting the registration is a future refactor.
-var persistenceProvider = builder.Configuration["Persistence:Provider"] ?? "Sqlite";
-if (persistenceProvider.Equals("Postgres", StringComparison.OrdinalIgnoreCase))
-{
-    var pgConnectionString = builder.Configuration.GetConnectionString("fleans")
-        ?? throw new InvalidOperationException("Connection string 'fleans' is required when Persistence:Provider=Postgres");
-    var pgQueryConnectionString = builder.Configuration.GetConnectionString("fleans-query");
-    builder.Services.AddPostgresPersistence(pgConnectionString, pgQueryConnectionString);
-}
-else
-{
-    var sqliteConnectionString = builder.Configuration["FLEANS_SQLITE_CONNECTION"] ?? "DataSource=fleans-dev.db";
-    var queryConnectionString = builder.Configuration["FLEANS_QUERY_CONNECTION"];
-    builder.Services.AddSqlitePersistence(sqliteConnectionString, queryConnectionString);
-}
+builder.AddFleansPersistence();
 
 // Redis for Aspire-managed Orleans
 builder.AddKeyedRedisClient("orleans-redis");
@@ -44,15 +30,7 @@ builder.Services.AddMcpServer()
 
 var app = builder.Build();
 
-// Ensure EF Core database schema is ready on startup
-if (!persistenceProvider.Equals("Postgres", StringComparison.OrdinalIgnoreCase))
-{
-    // SQLite: use EnsureCreated — idempotent, race-safe for shared SQLite file with the Api silo
-    using var scope = app.Services.CreateScope();
-    var dbFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<FleanCommandDbContext>>();
-    using var db = dbFactory.CreateDbContext();
-    SqliteSchemaInitializer.EnsureCreatedIgnoreRaces(db.Database);
-}
+await app.EnsureDatabaseSchemaAsync();
 
 app.MapDefaultEndpoints();
 app.MapMcp();

--- a/src/Fleans/Fleans.ServiceDefaults/Fleans.ServiceDefaults.csproj
+++ b/src/Fleans/Fleans.ServiceDefaults/Fleans.ServiceDefaults.csproj
@@ -9,6 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Persistence providers: transitive reference to Fleans.Persistence (core) via these is sufficient. -->
+    <!-- If a third provider is added, consider extracting to a dedicated Fleans.Persistence.Configuration project. -->
+    <ProjectReference Include="..\Fleans.Persistence.Sqlite\Fleans.Persistence.Sqlite.csproj" />
+    <ProjectReference Include="..\Fleans.Persistence.PostgreSql\Fleans.Persistence.PostgreSql.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.1.0" />

--- a/src/Fleans/Fleans.ServiceDefaults/FleansPersistenceExtensions.cs
+++ b/src/Fleans/Fleans.ServiceDefaults/FleansPersistenceExtensions.cs
@@ -1,0 +1,75 @@
+using Fleans.Persistence;
+using Fleans.Persistence.PostgreSql;
+using Fleans.Persistence.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace Fleans.ServiceDefaults;
+
+public static class FleansPersistenceExtensions
+{
+    /// <summary>
+    /// Configures Fleans EF Core persistence based on the Persistence:Provider config key.
+    /// Supports "Sqlite" (default) and "Postgres".
+    /// Registers <see cref="FleansPersistenceOptions"/> so that
+    /// <see cref="EnsureDatabaseSchemaAsync"/> can resolve the provider choice
+    /// without re-reading configuration.
+    /// </summary>
+    public static IHostApplicationBuilder AddFleansPersistence(this IHostApplicationBuilder builder)
+    {
+        var provider = builder.Configuration["Persistence:Provider"] ?? "Sqlite";
+
+        builder.Services.Configure<FleansPersistenceOptions>(opts => opts.Provider = provider);
+
+        if (provider.Equals("Postgres", StringComparison.OrdinalIgnoreCase))
+        {
+            var connStr = builder.Configuration.GetConnectionString("fleans")
+                ?? throw new InvalidOperationException(
+                    "Connection string 'fleans' is required when Persistence:Provider=Postgres");
+            var queryConnStr = builder.Configuration.GetConnectionString("fleans-query");
+            builder.Services.AddPostgresPersistence(connStr, queryConnStr);
+        }
+        else
+        {
+            var connStr = builder.Configuration["FLEANS_SQLITE_CONNECTION"] ?? "DataSource=fleans-dev.db";
+            var queryConnStr = builder.Configuration["FLEANS_QUERY_CONNECTION"];
+            builder.Services.AddSqlitePersistence(connStr, queryConnStr);
+        }
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Ensures the database schema is ready. Call after builder.Build().
+    /// For SQLite: EnsureCreated (idempotent, race-safe).
+    /// For PostgreSQL: MigrateAsync (idempotent, uses EF Core migration lock).
+    ///
+    /// Note: All apps (Api, Web, Mcp) call this uniformly. For Postgres, all three apps
+    /// call MigrateAsync — this is safe because MigrateAsync is idempotent and EF Core
+    /// serializes concurrent migration attempts via __EFMigrationsLock.
+    /// Under Aspire, Web and Mcp wait for the Api silo to start (which applies migrations
+    /// first), so in practice their MigrateAsync calls are no-ops.
+    /// </summary>
+    public static async Task EnsureDatabaseSchemaAsync(this IHost app)
+    {
+        var options = app.Services.GetRequiredService<IOptions<FleansPersistenceOptions>>().Value;
+
+        using var scope = app.Services.CreateScope();
+        var dbFactory = scope.ServiceProvider
+            .GetRequiredService<IDbContextFactory<FleanCommandDbContext>>();
+
+        if (options.Provider.Equals("Postgres", StringComparison.OrdinalIgnoreCase))
+        {
+            await using var db = dbFactory.CreateDbContext();
+            await db.Database.MigrateAsync();
+        }
+        else
+        {
+            using var db = dbFactory.CreateDbContext();
+            SqliteSchemaInitializer.EnsureCreatedIgnoreRaces(db.Database);
+        }
+    }
+}

--- a/src/Fleans/Fleans.ServiceDefaults/FleansPersistenceOptions.cs
+++ b/src/Fleans/Fleans.ServiceDefaults/FleansPersistenceOptions.cs
@@ -1,0 +1,10 @@
+namespace Fleans.ServiceDefaults;
+
+/// <summary>
+/// Holds the persistence provider choice registered once during AddFleansPersistence().
+/// Resolved by EnsureDatabaseSchemaAsync() to avoid re-reading configuration.
+/// </summary>
+public sealed class FleansPersistenceOptions
+{
+    public string Provider { get; set; } = "Sqlite";
+}

--- a/src/Fleans/Fleans.Web/Program.cs
+++ b/src/Fleans/Fleans.Web/Program.cs
@@ -1,11 +1,10 @@
 using Fleans.Application;
 using Fleans.Infrastructure;
-using Fleans.Persistence;
 using Fleans.Persistence.PostgreSql;
 using Fleans.Persistence.Sqlite;
+using Fleans.ServiceDefaults;
 using Fleans.Web.Components;
 using Fleans.Web.Services;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Orleans.Dashboard;
 
@@ -27,20 +26,7 @@ builder.Services.AddApplication();
 builder.Services.AddInfrastructure();
 
 // EF Core persistence — provider selected by Persistence:Provider config key (default: Sqlite)
-var persistenceProvider = builder.Configuration["Persistence:Provider"] ?? "Sqlite";
-if (persistenceProvider.Equals("Postgres", StringComparison.OrdinalIgnoreCase))
-{
-    var pgConnectionString = builder.Configuration.GetConnectionString("fleans")
-        ?? throw new InvalidOperationException("Connection string 'fleans' is required when Persistence:Provider=Postgres");
-    var pgQueryConnectionString = builder.Configuration.GetConnectionString("fleans-query");
-    builder.Services.AddPostgresPersistence(pgConnectionString, pgQueryConnectionString);
-}
-else
-{
-    var sqliteConnectionString = builder.Configuration["FLEANS_SQLITE_CONNECTION"] ?? "DataSource=fleans-dev.db";
-    var queryConnectionString = builder.Configuration["FLEANS_QUERY_CONNECTION"];
-    builder.Services.AddSqlitePersistence(sqliteConnectionString, queryConnectionString);
-}
+builder.AddFleansPersistence();
 
 // Register Redis client for Aspire-managed Orleans
 builder.AddKeyedRedisClient("orleans-redis");
@@ -53,15 +39,7 @@ builder.UseOrleansClient(clientBuilder =>
 
 var app = builder.Build();
 
-// Ensure EF Core database schema is ready on startup
-if (!persistenceProvider.Equals("Postgres", StringComparison.OrdinalIgnoreCase))
-{
-    // SQLite: use EnsureCreated — idempotent, race-safe for shared SQLite file with the Api silo
-    using var scope = app.Services.CreateScope();
-    var dbFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<FleanCommandDbContext>>();
-    using var db = dbFactory.CreateDbContext();
-    SqliteSchemaInitializer.EnsureCreatedIgnoreRaces(db.Database);
-}
+await app.EnsureDatabaseSchemaAsync();
 
 // Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())


### PR DESCRIPTION
## Summary

- Adds `AddFleansPersistence(IHostApplicationBuilder)` and `EnsureDatabaseSchemaAsync(IHost)` extension methods to `Fleans.ServiceDefaults`, encapsulating provider selection and DB init in one place
- Replaces 15+ line duplicated provider-selection and 10+ line DB-init blocks in `Api`, `Web`, and `Mcp` `Program.cs` with two one-line calls each
- Extracts a `WithPersistence` local helper in `Aspire/Program.cs` to deduplicate environment-variable wiring across 3 project registrations
- Introduces `FleansPersistenceOptions` (registered via `Configure<T>`) as a single source of truth so `EnsureDatabaseSchemaAsync` resolves provider choice from DI rather than re-reading configuration

Closes #289

## Key decisions

- **`ServiceDefaults` placement**: Adds project references to `Fleans.Persistence.Sqlite` and `Fleans.Persistence.PostgreSql`. Transitive reference to `Fleans.Persistence` (core) is sufficient — no direct reference needed. A code comment documents the graduation path to a dedicated `Fleans.Persistence.Configuration` project if a third provider is ever added.
- **Presentation apps retain direct provider references**: Required for EF Core design-time tooling (`dotnet ef migrations add`).
- **Behavioral change for Web/Mcp (Postgres)**: Both apps now call `MigrateAsync()` on startup (previously they did nothing for Postgres). This is safe — `MigrateAsync` is idempotent and EF Core serializes concurrent attempts via `__EFMigrationsLock`. Under Aspire, migrations will already be applied by Api before Web/Mcp start.
- **`WithPersistence` in Aspire**: `WaitFor(pg!)` removed from the helper — startup ordering is the caller's responsibility. Api explicitly calls `.WaitFor(pg!)` before passing to the helper; Web/Mcp rely on their existing `.WaitFor(fleansSilo)`.

## How to test

- `dotnet build` — should compile cleanly
- `dotnet test` — all tests pass (835 passed, 0 failed)
- Run via Aspire (`dotnet run --project Fleans.Aspire`) — SQLite path: start workflow, verify it completes. Postgres path: set `FLEANS_PERSISTENCE_PROVIDER=Postgres` and repeat.