### PR TITLE
style(website): refine color palette per design direction (Candidate 1)

### DIFF
--- a/website/DESIGN.md
+++ b/website/DESIGN.md
@@ -1,0 +1,109 @@
+# Fleans design doc
+
+## Overview
+
+Design doc for the Fleans marketing + docs site. Sections owned by individual design issues.
+
+## Color palette
+
+Chosen direction: **Candidate 1 — Brutalist-technical** (owner decision on [#258](https://github.com/nightBaker/fleans/issues/258)). The site signals a workflow engine for backend developers — industrial orange on near-black reads like CLI output and industrial signage, not like default Starlight with a blue tint.
+
+Owner decisions fixed up front:
+
+1. Aesthetic direction: Candidate 1 — brutalist-technical.
+2. Per-candidate token completeness: option (a) — full token map for every Starlight token plus the two `--fleans-*` tokens, both themes.
+3. `--fleans-accent-2` usage: contract-only in this PR; real usage deferred to [#259](https://github.com/nightBaker/fleans/issues/259) / [#260](https://github.com/nightBaker/fleans/issues/260).
+
+### Dark theme token map
+
+| Token | Hex | Role |
+|---|---|---|
+| `--sl-color-accent-low` | `#2a1609` | Callout / admonition background |
+| `--sl-color-accent` | `#ff5f1f` | Primary accent — links, focus rings, sidebar hover (industrial orange) |
+| `--sl-color-accent-high` | `#ffb38f` | Admonition/callout titles on accent-low |
+| `--sl-color-white` | `#f5f5f0` | Body text (Starlight "max-contrast-vs-bg") |
+| `--sl-color-gray-1` | `#e5e5df` | Text-adjacent |
+| `--sl-color-gray-2` | `#b8b8b1` | |
+| `--sl-color-gray-3` | `#8a8a82` | Muted text |
+| `--sl-color-gray-4` | `#5a5a53` | |
+| `--sl-color-gray-5` | `#2e2e2a` | Panel / card background |
+| `--sl-color-gray-6` | `#1a1a17` | Near-bg |
+| `--sl-color-black` | `#0a0a0a` | Page bg — Starlight derives `--sl-color-bg` from this |
+| `--fleans-accent-2` | `#9eff00` | Sharp secondary accent — terminal lime (contract-only this PR) |
+| `--fleans-surface` | `#141411` | Elevated card / code-block surface (dark-only cue) |
+
+Narrative page bg: `#0a0a0a` (near-true black).
+
+### Light theme token map
+
+| Token | Hex | Role |
+|---|---|---|
+| `--sl-color-accent-low` | `#fbe6d9` | Callout / admonition background |
+| `--sl-color-accent` | `#ad2f08` | Primary accent — darker industrial orange for AA on light bg |
+| `--sl-color-accent-high` | `#8a2706` | Admonition/callout titles on accent-low |
+| `--sl-color-white` | `#0a0a0a` | Body text (Starlight "max-contrast-vs-bg", flipped) |
+| `--sl-color-gray-1` | `#1a1a17` | Text-adjacent |
+| `--sl-color-gray-2` | `#2e2e2a` | |
+| `--sl-color-gray-3` | `#5a5a53` | Muted text |
+| `--sl-color-gray-4` | `#8a8a82` | |
+| `--sl-color-gray-5` | `#b8b8b1` | Panel / card background |
+| `--sl-color-gray-6` | `#e0e0d9` | Near-bg |
+| `--sl-color-gray-7` | `#efefea` | Very near-bg |
+| `--sl-color-black` | `#f5f5f0` | Page bg — Starlight derives `--sl-color-bg` from this |
+| `--fleans-accent-2` | `#3a7d00` | Sharp secondary accent — deeper lime for AA on light bg |
+| `--fleans-surface` | `#f5f5f0` | Collapses to bg in light mode (dark-only elevation cue) |
+
+Narrative page bg: `#f5f5f0` (warm off-white).
+
+### Derivation rule
+
+Any future palette tweak follows this rule rather than ad-hoc picks:
+
+- `--sl-color-accent-low` = dominant accent blended toward bg to **L\* ≈ 12%** (dark) / **L\* ≈ 92%** (light) in OKLCH. Produces a background-like tint that stays recognizably the accent hue.
+- `--sl-color-accent-high` = dominant accent shifted toward text-color end until it hits **AA (≥4.5:1)** against `--sl-color-accent-low`. Used for admonition titles sitting on callout backgrounds.
+- `--sl-color-gray-1 … -6/-7` = perceptually even OKLCH L\* steps, anchored as follows:
+  - `gray-1` at **L\*(text) minus 2%** (text-adjacent, moved toward bg)
+  - `gray-6` (dark) / `gray-7` (light) at **L\*(bg) plus 2%** (bg-adjacent, moved toward text)
+  - intermediate stops at **equal L\* intervals** between the two endpoints
+  - the ramp inherits any warm/cool bias the bg carries (Candidate 1 light's bg `#f5f5f0` gives a faintly warm ramp)
+- `--sl-color-white` = the theme's text color (Starlight semantic: "max-contrast-vs-bg").
+- `--sl-color-black` = the theme's page background color. Starlight's `--sl-color-bg` derives from this token, so setting it to the narrative bg value (instead of a "one step beyond" extreme) is what actually renders the intended background. The derivation rule gives "bg or one step beyond"; we pick "bg" to match the brutalist-technical narrative.
+- `--fleans-accent-2` = secondary accent verbatim (no derivation).
+- `--fleans-surface` = one step off `--sl-color-gray-6` in dark mode (elevation cue); collapses to bg in light mode (elevation via color is counter-productive on light surfaces).
+
+Re-tuning during implementation stays within **±5% OKLCH L\*** of the table values. Anything beyond the envelope is a design change and needs a fresh review.
+
+Note on the current light-theme `--sl-color-accent`: the plan's starting value `#c4380b` (OklabL = 54.7) missed AA on `accent-on-accent-low` (4.45:1, need 4.5:1) and AA-large on `accent-on-gray-5` (2.69:1, need 3.0:1). Re-tuning darker to `#ad2f08` (OklabL = 49.7, ΔL\* = −4.98, within envelope) lands all pairs above their minimums with comfortable margin.
+
+### Contrast matrix (verified)
+
+WCAG ratios via the sRGB relative-luminance formula (W3C WCAG 2.1 §1.4.3). Verified programmatically (`website/scripts/check-contrast.mjs`). Format: `pair: <fg-token-name> (<#hex>) on <bg-token-name> (<#hex>) = <ratio>:1 (<verdict>)`.
+
+**Dark theme**
+
+```
+pair: --sl-color-white (#f5f5f0) on bg (#0a0a0a) = 18.10:1 (AA pass)
+pair: --sl-color-accent (#ff5f1f) on bg (#0a0a0a) = 6.51:1 (AA pass)
+pair: --sl-color-accent-high (#ffb38f) on --sl-color-accent-low (#2a1609) = 9.94:1 (AA pass)
+pair: --sl-color-accent (#ff5f1f) on --sl-color-accent-low (#2a1609) = 5.68:1 (AA pass)
+pair: --sl-color-gray-3 (#8a8a82) on bg (#0a0a0a) = 5.69:1 (AA pass)
+pair: --fleans-accent-2 (#9eff00) on bg (#0a0a0a) = 15.80:1 (AA-large pass)
+pair: --sl-color-accent (#ff5f1f) on --sl-color-gray-5 (#2e2e2a) = 4.48:1 (AA-large pass)
+pair: --sl-color-accent (#ff5f1f) on --sl-color-gray-6 (#1a1a17) = 5.74:1 (AA-large pass)
+pair: --sl-color-accent (#ff5f1f) on --fleans-surface (#141411) = 6.07:1 (AA-large pass)
+```
+
+**Light theme**
+
+```
+pair: --sl-color-white (#0a0a0a) on bg (#f5f5f0) = 18.10:1 (AA pass)
+pair: --sl-color-accent (#ad2f08) on bg (#f5f5f0) = 6.03:1 (AA pass)
+pair: --sl-color-accent-high (#8a2706) on --sl-color-accent-low (#fbe6d9) = 7.34:1 (AA pass)
+pair: --sl-color-accent (#ad2f08) on --sl-color-accent-low (#fbe6d9) = 5.47:1 (AA pass)
+pair: --sl-color-gray-3 (#5a5a53) on bg (#f5f5f0) = 6.35:1 (AA pass)
+pair: --fleans-accent-2 (#3a7d00) on bg (#f5f5f0) = 4.67:1 (AA-large pass)
+pair: --sl-color-accent (#ad2f08) on --sl-color-gray-5 (#b8b8b1) = 3.30:1 (AA-large pass)
+pair: --sl-color-accent (#ad2f08) on --sl-color-gray-6 (#e0e0d9) = 4.97:1 (AA-large pass)
+```
+
+Row 7b (accent on `--fleans-surface`) is dark-only; in light theme `--fleans-surface = bg`, so the pair degenerates to row 2 which already passes.

--- a/website/scripts/check-contrast.mjs
+++ b/website/scripts/check-contrast.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+// Ad-hoc WCAG contrast checker for the Candidate 1 palette.
+// Not committed to the build — run via `node scripts/check-contrast.mjs`.
+
+function hexToRgb(hex) {
+  const h = hex.replace('#', '');
+  return {
+    r: parseInt(h.slice(0, 2), 16),
+    g: parseInt(h.slice(2, 4), 16),
+    b: parseInt(h.slice(4, 6), 16),
+  };
+}
+
+function srgbToLinear(c) {
+  const s = c / 255;
+  return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+}
+
+function luminance({ r, g, b }) {
+  return (
+    0.2126 * srgbToLinear(r) +
+    0.7152 * srgbToLinear(g) +
+    0.0722 * srgbToLinear(b)
+  );
+}
+
+function contrast(fg, bg) {
+  const L1 = luminance(hexToRgb(fg));
+  const L2 = luminance(hexToRgb(bg));
+  const [a, b] = L1 >= L2 ? [L1, L2] : [L2, L1];
+  return (a + 0.05) / (b + 0.05);
+}
+
+function verdict(ratio, minKind) {
+  const min = minKind === 'AA-large' ? 3.0 : 4.5;
+  return ratio >= min ? `${minKind} pass` : 'FAIL';
+}
+
+const dark = {
+  '--sl-color-accent-low': '#2a1609',
+  '--sl-color-accent': '#ff5f1f',
+  '--sl-color-accent-high': '#ffb38f',
+  '--sl-color-white': '#f5f5f0',
+  '--sl-color-gray-1': '#e5e5df',
+  '--sl-color-gray-2': '#b8b8b1',
+  '--sl-color-gray-3': '#8a8a82',
+  '--sl-color-gray-4': '#5a5a53',
+  '--sl-color-gray-5': '#2e2e2a',
+  '--sl-color-gray-6': '#1a1a17',
+  '--sl-color-black': '#050504',
+  '--fleans-accent-2': '#9eff00',
+  '--fleans-surface': '#141411',
+};
+
+const light = {
+  '--sl-color-accent-low': '#fbe6d9',
+  '--sl-color-accent': '#ad2f08',
+  '--sl-color-accent-high': '#8a2706',
+  '--sl-color-white': '#0a0a0a',
+  '--sl-color-gray-1': '#1a1a17',
+  '--sl-color-gray-2': '#2e2e2a',
+  '--sl-color-gray-3': '#5a5a53',
+  '--sl-color-gray-4': '#8a8a82',
+  '--sl-color-gray-5': '#b8b8b1',
+  '--sl-color-gray-6': '#e0e0d9',
+  '--sl-color-gray-7': '#efefea',
+  '--sl-color-black': '#ffffff',
+  '--fleans-accent-2': '#3a7d00',
+  '--fleans-surface': '#f5f5f0',
+};
+
+// Effective page bg per Starlight: dark uses --sl-color-black-derived bg, light uses near-white.
+// We treat "bg" pairwise as the likely rendered background — the darkest/lightest extreme.
+// For dark, Starlight renders body against ~var(--sl-color-black). For light, ~var(--sl-color-black) too (which is white).
+// To match the plan's narrative bg (#0a0a0a dark / #f5f5f0 light), we verify contrast against BOTH the actual --sl-color-black
+// AND the narrative "bg" values used by the plan's tables (accent row etc).
+
+function runTheme(name, p, narrativeBg) {
+  console.log(`\n--- ${name} ---`);
+  const rows = [
+    { id: 1, fg: p['--sl-color-white'], fgName: '--sl-color-white', bg: narrativeBg, bgName: 'bg', min: 'AA' },
+    { id: 2, fg: p['--sl-color-accent'], fgName: '--sl-color-accent', bg: narrativeBg, bgName: 'bg', min: 'AA' },
+    { id: 3, fg: p['--sl-color-accent-high'], fgName: '--sl-color-accent-high', bg: p['--sl-color-accent-low'], bgName: '--sl-color-accent-low', min: 'AA' },
+    { id: 4, fg: p['--sl-color-accent'], fgName: '--sl-color-accent', bg: p['--sl-color-accent-low'], bgName: '--sl-color-accent-low', min: 'AA' },
+    { id: 5, fg: p['--sl-color-gray-3'], fgName: '--sl-color-gray-3', bg: narrativeBg, bgName: 'bg', min: 'AA' },
+    { id: 6, fg: p['--fleans-accent-2'], fgName: '--fleans-accent-2', bg: narrativeBg, bgName: 'bg', min: 'AA-large' },
+    { id: '7a-5', fg: p['--sl-color-accent'], fgName: '--sl-color-accent', bg: p['--sl-color-gray-5'], bgName: '--sl-color-gray-5', min: 'AA-large' },
+    { id: '7a-6', fg: p['--sl-color-accent'], fgName: '--sl-color-accent', bg: p['--sl-color-gray-6'], bgName: '--sl-color-gray-6', min: 'AA-large' },
+  ];
+  if (name === 'dark') {
+    rows.push({ id: '7b', fg: p['--sl-color-accent'], fgName: '--sl-color-accent', bg: p['--fleans-surface'], bgName: '--fleans-surface', min: 'AA-large' });
+  }
+  for (const r of rows) {
+    const ratio = contrast(r.fg, r.bg);
+    console.log(`  row ${r.id}: pair: ${r.fgName} (${r.fg}) on ${r.bgName} (${r.bg}) = ${ratio.toFixed(2)}:1 (${verdict(ratio, r.min)})`);
+  }
+}
+
+runTheme('dark', dark, '#0a0a0a');
+runTheme('light', light, '#f5f5f0');

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -1,29 +1,33 @@
-/* Fleans brand colors — tweak freely */
+/* Palette source of truth: website/DESIGN.md § Color palette */
 :root[data-theme='dark'] {
-  --sl-color-accent-low: #1e2a3a;
-  --sl-color-accent: #3b82f6;
-  --sl-color-accent-high: #93c5fd;
-  --sl-color-white: #ffffff;
-  --sl-color-gray-1: #eceef2;
-  --sl-color-gray-2: #c0c2c7;
-  --sl-color-gray-3: #888b96;
-  --sl-color-gray-4: #545861;
-  --sl-color-gray-5: #353841;
-  --sl-color-gray-6: #24272f;
-  --sl-color-black: #17181c;
+  --sl-color-accent-low: #2a1609;
+  --sl-color-accent: #ff5f1f;
+  --sl-color-accent-high: #ffb38f;
+  --sl-color-white: #f5f5f0;
+  --sl-color-gray-1: #e5e5df;
+  --sl-color-gray-2: #b8b8b1;
+  --sl-color-gray-3: #8a8a82;
+  --sl-color-gray-4: #5a5a53;
+  --sl-color-gray-5: #2e2e2a;
+  --sl-color-gray-6: #1a1a17;
+  --sl-color-black: #0a0a0a;
+  --fleans-accent-2: #9eff00;
+  --fleans-surface: #141411;
 }
 
 :root[data-theme='light'] {
-  --sl-color-accent-low: #d5e4fb;
-  --sl-color-accent: #2563eb;
-  --sl-color-accent-high: #1e3a8a;
-  --sl-color-white: #17181c;
-  --sl-color-gray-1: #24272f;
-  --sl-color-gray-2: #353841;
-  --sl-color-gray-3: #545861;
-  --sl-color-gray-4: #888b96;
-  --sl-color-gray-5: #c0c2c7;
-  --sl-color-gray-6: #eceef2;
-  --sl-color-gray-7: #f5f6f8;
-  --sl-color-black: #ffffff;
+  --sl-color-accent-low: #fbe6d9;
+  --sl-color-accent: #ad2f08;
+  --sl-color-accent-high: #8a2706;
+  --sl-color-white: #0a0a0a;
+  --sl-color-gray-1: #1a1a17;
+  --sl-color-gray-2: #2e2e2a;
+  --sl-color-gray-3: #5a5a53;
+  --sl-color-gray-4: #8a8a82;
+  --sl-color-gray-5: #b8b8b1;
+  --sl-color-gray-6: #e0e0d9;
+  --sl-color-gray-7: #efefea;
+  --sl-color-black: #f5f5f0;
+  --fleans-accent-2: #3a7d00;
+  --fleans-surface: #f5f5f0;
 }


### PR DESCRIPTION
Closes #258.

## Owner decisions applied verbatim

> 1. Aesthetic direction: Candidate 1 — brutalist-technical.
> 2. Per-candidate token completeness: option (a) — full token map for every Starlight token plus the two `--fleans-*` tokens, both themes.
> 3. `--fleans-accent-2` usage: contract-only in this PR; real usage deferred to #259 / #260.

## Summary

- Replaces the generic Tailwind-blue `--sl-color-*` overrides in `website/src/styles/custom.css` with the Candidate 1 full token map for both themes (15 tokens per theme, including the two new `--fleans-*` tokens).
- Creates `website/DESIGN.md` with the `## Color palette` section only (per plan: this PR owns that section; #256 will add every other section).
- Adds `website/scripts/check-contrast.mjs` — a tiny no-dependency node script that prints the contrast matrix. Re-runnable for any future palette tweak.

## Deviations from the plan

1. **Light-theme `--sl-color-accent` tuned.** Plan's starting `#c4380b` missed AA on `accent-on-accent-low` (4.45:1, need 4.5:1) and AA-large on `accent-on-gray-5` (2.69:1, need 3.0:1). Re-tuned darker to `#ad2f08` (OklabL = 49.7, ΔL\* = −4.98 vs baseline 54.7 — right at the ±5% OKLCH envelope). All pairs now clear their minimums.
2. **`--sl-color-black` set to narrative bg, not "one step beyond".** Plan's Candidate 1 tables listed `--sl-color-black` as `#050504` (dark) / `#ffffff` (light), labelled "one step beyond bg" / "Starlight flip". But Starlight derives `--sl-color-bg` directly from `--sl-color-black`, so those values make the page render with a too-dark / too-white surface instead of the narrative `#0a0a0a` / `#f5f5f0`. The derivation rule in §B permits "bg OR one step beyond"; this PR picks "bg" so the rendered background matches the brutalist-technical narrative. Documented in `DESIGN.md § Derivation rule`.

## Contrast matrix (verified)

Ratios below were produced by `node website/scripts/check-contrast.mjs`. Same data lives in `website/DESIGN.md § Color palette`.

**Dark theme**

```
pair: --sl-color-white (#f5f5f0) on bg (#0a0a0a) = 18.10:1 (AA pass)
pair: --sl-color-accent (#ff5f1f) on bg (#0a0a0a) = 6.51:1 (AA pass)
pair: --sl-color-accent-high (#ffb38f) on --sl-color-accent-low (#2a1609) = 9.94:1 (AA pass)
pair: --sl-color-accent (#ff5f1f) on --sl-color-accent-low (#2a1609) = 5.68:1 (AA pass)
pair: --sl-color-gray-3 (#8a8a82) on bg (#0a0a0a) = 5.69:1 (AA pass)
pair: --fleans-accent-2 (#9eff00) on bg (#0a0a0a) = 15.80:1 (AA-large pass)
pair: --sl-color-accent (#ff5f1f) on --sl-color-gray-5 (#2e2e2a) = 4.48:1 (AA-large pass)
pair: --sl-color-accent (#ff5f1f) on --sl-color-gray-6 (#1a1a17) = 5.74:1 (AA-large pass)
pair: --sl-color-accent (#ff5f1f) on --fleans-surface (#141411) = 6.07:1 (AA-large pass)
```

**Light theme**

```
pair: --sl-color-white (#0a0a0a) on bg (#f5f5f0) = 18.10:1 (AA pass)
pair: --sl-color-accent (#ad2f08) on bg (#f5f5f0) = 6.03:1 (AA pass)
pair: --sl-color-accent-high (#8a2706) on --sl-color-accent-low (#fbe6d9) = 7.34:1 (AA pass)
pair: --sl-color-accent (#ad2f08) on --sl-color-accent-low (#fbe6d9) = 5.47:1 (AA pass)
pair: --sl-color-gray-3 (#5a5a53) on bg (#f5f5f0) = 6.35:1 (AA pass)
pair: --fleans-accent-2 (#3a7d00) on bg (#f5f5f0) = 4.67:1 (AA-large pass)
pair: --sl-color-accent (#ad2f08) on --sl-color-gray-5 (#b8b8b1) = 3.30:1 (AA-large pass)
pair: --sl-color-accent (#ad2f08) on --sl-color-gray-6 (#e0e0d9) = 4.97:1 (AA-large pass)
```

## How to test

```
cd website
npm install
npm run build    # must pass — already verified locally
npm run dev      # smoke-check both themes
node scripts/check-contrast.mjs   # re-run matrix verification
```

Smoke-checked locally across landing + Quick Start guide + REST API reference, both themes. Screenshots taken via preview; link color = industrial orange, active sidebar uses accent-high, code blocks render cleanly, no console errors. `--fleans-accent-2` / `--fleans-surface` presence verified in `getComputedStyle(:root)` (contract-only; no component consumer yet).

## Test plan

- [ ] `npm run build` passes
- [ ] `node website/scripts/check-contrast.mjs` — every row reports a pass verdict
- [ ] Visit landing page in both themes — bg is warm near-black (dark) / warm off-white (light); "Fleans" hero + CTAs use the accent
- [ ] Visit a guide page (e.g. `guides/quick-start`) — active sidebar item uses `--sl-color-accent-high`; "On this page" active anchor uses `--sl-color-accent`
- [ ] Visit a reference page (e.g. `reference/api`) — tables and inline code render readably in both themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)