### PR TITLE
feat(load-testing): k6 mixed workload scenario (#242)

### DIFF
--- a/tests/load/scripts/metrics.js
+++ b/tests/load/scripts/metrics.js
@@ -1,0 +1,22 @@
+// tests/load/scripts/metrics.js
+//
+// Shared k6 metric instances for the Fleans load test suite.
+//
+// Import from here — do NOT call new Trend() with the same name in dependency scripts.
+// k6 uses a global metric registry keyed by name; defining the same metric in multiple
+// modules is an undocumented implementation detail. Using a single shared module
+// avoids any ambiguity around duplicate registration across k6 versions.
+//
+// Required by: linear.js (#239), parallel.js (#240), events.js (#241), mixed.js (#242)
+
+import { Trend } from 'k6/metrics';
+
+// Duration of the POST /Workflow/start HTTP call, in milliseconds.
+// Each dependency script must call: workflowStartDuration.add(res.timings.duration)
+// at its POST /Workflow/start call site.
+//
+// WARNING: k6 silently skips thresholds for metrics that are never emitted.
+// If a script does not call .add(), the 'workflow_start_duration' threshold in
+// mixed.js will be silently ignored rather than failed. Ensure all three
+// dependency scripts instrument this metric.
+export const workflowStartDuration = new Trend('workflow_start_duration');

--- a/tests/load/scripts/mixed.js
+++ b/tests/load/scripts/mixed.js
@@ -1,0 +1,111 @@
+// tests/load/scripts/mixed.js
+//
+// Mixed-workload k6 scenario that runs all three workflow patterns in parallel.
+//
+// PURPOSE
+// -------
+// The three individual scenario scripts (linear.js, parallel.js, events.js) test
+// each workflow pattern in isolation. This script composes them into a single run
+// so their workloads overlap, revealing system-level bottlenecks that only emerge
+// under heterogeneous load: database write contention across workflow types,
+// Redis cluster pressure from concurrent grain activations, and scheduler/thread
+// competition between CPU-bound and IO-bound paths.
+//
+// PREREQUISITES
+// -------------
+// 1. All BPMN fixtures must be deployed before this script runs:
+//      k6 run tests/load/scripts/setup.js
+//    Verify that all fixtures report `deployed: true` before proceeding.
+//    If fixtures are not deployed, POST /Workflow/start calls will return errors
+//    and the run results will be meaningless.
+//
+// 2. Dependency scripts must satisfy the contract in docs/plans/2026-04-19-mixed-load-scenario-design.md:
+//    - linear.js  : exports `linearWorkflow`, imports workflowStartDuration from ./metrics.js
+//    - parallel.js: exports `parallelWorkflow`, imports workflowStartDuration from ./metrics.js
+//    - events.js  : exports `eventDrivenWorkflow`, imports workflowStartDuration from ./metrics.js
+//    - None of the above may rely on their own setup()/teardown() for state that
+//      their named export function depends on.
+//
+// PER-SCENARIO METRIC TAGS
+// ------------------------
+// k6 automatically tags all emitted metrics with the scenario name (e.g., scenario:linear_40pct).
+// Use these tags to isolate bottlenecks per workload type when analyzing results:
+//   k6 run --out json=full-run-results.json tests/load/scripts/mixed.js
+// Then filter by tags.scenario in the JSON output or a Grafana dashboard.
+//
+// THRESHOLD NOTE
+// --------------
+// Once tests/load/thresholds.json exists (created by #239), verify that
+// http_req_failed and http_req_duration values here align with or intentionally
+// diverge from the shared values. The workflow_start_duration threshold (3000ms)
+// is intentionally relaxed vs. the isolation baseline (tighter) to account for
+// cross-workload contention under 100 concurrent VUs.
+
+import { linearWorkflow }      from './linear.js';
+import { parallelWorkflow }    from './parallel.js';
+import { eventDrivenWorkflow } from './events.js';
+
+export const options = {
+  scenarios: {
+    // 40% of peak VUs — linear workflow generates the highest write pressure
+    // (one DB write per activity completion, no waiting), so it gets the
+    // largest share to maximize write contention visibility.
+    linear_40pct: {
+      executor:     'ramping-vus',
+      exec:         'linearWorkflow',
+      startVUs:     0,
+      gracefulStop: '30s',
+      stages: [
+        { duration: '1m', target: 40 },
+        { duration: '3m', target: 40 },
+        { duration: '1m', target:  0 },
+      ],
+    },
+
+    // 30% of peak VUs — parallel workflow involves internal fork/join coordination;
+    // less frequent in typical workloads but important to cover under concurrent load.
+    parallel_30pct: {
+      executor:     'ramping-vus',
+      exec:         'parallelWorkflow',
+      startVUs:     0,
+      gracefulStop: '30s',
+      stages: [
+        { duration: '1m', target: 30 },
+        { duration: '3m', target: 30 },
+        { duration: '1m', target:  0 },
+      ],
+    },
+
+    // 30% of peak VUs — event-driven workflow involves more internal coordination
+    // (message delivery, signal routing); covered at 30% to reveal IO-bound contention.
+    events_30pct: {
+      executor:     'ramping-vus',
+      exec:         'eventDrivenWorkflow',
+      startVUs:     0,
+      gracefulStop: '30s',
+      stages: [
+        { duration: '1m', target: 30 },
+        { duration: '3m', target: 30 },
+        { duration: '1m', target:  0 },
+      ],
+    },
+  },
+
+  thresholds: {
+    // Align with thresholds.json from #239 once that file exists.
+    'http_req_failed':   ['rate<0.01'],
+    'http_req_duration': ['p(95)<2000'],
+
+    // Intentionally relaxed vs. isolation baseline to account for contention
+    // from 100 concurrent VUs across three workflow types.
+    // REQUIRES: all three dependency scripts emit workflowStartDuration.add(res.timings.duration)
+    // for their POST /Workflow/start call (via import from ./metrics.js).
+    // Silently skipped by k6 if the metric is never emitted.
+    'workflow_start_duration': ['p(95)<3000'],
+  },
+};
+
+// k6 requires exec: functions to be exported from the same file that declares options.
+// The re-exports below satisfy that requirement. The default export (for standalone
+// runs of each dependency script) is unaffected.
+export { linearWorkflow, parallelWorkflow, eventDrivenWorkflow };

--- a/tests/load/scripts/smoke-mixed.js
+++ b/tests/load/scripts/smoke-mixed.js
@@ -1,0 +1,81 @@
+// tests/load/scripts/smoke-mixed.js
+//
+// Smoke test variant of the mixed-workload scenario.
+//
+// PURPOSE
+// -------
+// A shorter validation run (≈2 minutes total) for quick checks after deployments
+// or code changes. Uses the same three workflow functions as mixed.js but with
+// reduced VU counts and shortened stage durations.
+//
+// VU COUNTS: 5 per-scenario = 15 total across all three scenarios.
+//
+// WHY A SEPARATE FILE?
+// --------------------
+// When options.scenarios defines named scenarios, the --stage CLI flag is silently
+// ignored by k6 (or conflicts by implicitly creating a default scenario). The named
+// scenarios always run with the stages declared in the script regardless of CLI flags.
+// smoke-mixed.js solves this by declaring shortened stages explicitly in code.
+//
+// PREREQUISITES
+// -------------
+// Same as mixed.js — all BPMN fixtures must be deployed first:
+//   k6 run tests/load/scripts/setup.js
+// Verify all fixtures report `deployed: true` before proceeding.
+//
+// PER-SCENARIO METRIC TAGS
+// ------------------------
+// k6 tags all metrics with the scenario name (e.g., scenario:linear_smoke).
+// Use --out json=smoke-results.json to capture output and filter by tags.scenario.
+
+import { linearWorkflow }      from './linear.js';
+import { parallelWorkflow }    from './parallel.js';
+import { eventDrivenWorkflow } from './events.js';
+
+export const options = {
+  scenarios: {
+    linear_smoke: {
+      executor:     'ramping-vus',
+      exec:         'linearWorkflow',
+      startVUs:     0,
+      gracefulStop: '10s',
+      stages: [
+        { duration: '30s', target: 5 },  // 5 VUs for this scenario
+        { duration: '1m',  target: 5 },
+        { duration: '30s', target: 0 },
+      ],
+    },
+
+    parallel_smoke: {
+      executor:     'ramping-vus',
+      exec:         'parallelWorkflow',
+      startVUs:     0,
+      gracefulStop: '10s',
+      stages: [
+        { duration: '30s', target: 5 },  // 5 VUs for this scenario
+        { duration: '1m',  target: 5 },
+        { duration: '30s', target: 0 },
+      ],
+    },
+
+    events_smoke: {
+      executor:     'ramping-vus',
+      exec:         'eventDrivenWorkflow',
+      startVUs:     0,
+      gracefulStop: '10s',
+      stages: [
+        { duration: '30s', target: 5 },  // 5 VUs for this scenario
+        { duration: '1m',  target: 5 },
+        { duration: '30s', target: 0 },
+      ],
+    },
+  },
+
+  thresholds: {
+    'http_req_failed':         ['rate<0.01'],
+    'http_req_duration':       ['p(95)<2000'],
+    'workflow_start_duration': ['p(95)<3000'],
+  },
+};
+
+export { linearWorkflow, parallelWorkflow, eventDrivenWorkflow };


### PR DESCRIPTION
## Summary

Closes #242

Implements the k6 mixed-workload load test infrastructure designed in `docs/plans/2026-04-19-mixed-load-scenario-design.md`.

- **`tests/load/scripts/metrics.js`** — shared `workflowStartDuration` Trend metric module. All three dependency scripts (#239, #240, #241) must import from here instead of calling `new Trend()` independently, avoiding undocumented duplicate metric registration behaviour across k6 modules.
- **`tests/load/scripts/mixed.js`** — main mixed workload script: three named k6 scenarios (`linear_40pct` 40 VUs, `parallel_30pct` 30 VUs, `events_30pct` 30 VUs) running in parallel with `gracefulStop: '30s'` each. Total peak: 100 VUs. Thresholds: `http_req_failed < 1%`, `http_req_duration p(95) < 2000ms`, `workflow_start_duration p(95) < 3000ms`.
- **`tests/load/scripts/smoke-mixed.js`** — smoke variant with 5 VUs per-scenario (15 total) and shortened stages (30s/1m/30s) for quick post-deployment checks. Uses a separate file rather than `--stage` CLI flag because the `--stage` flag is silently ignored when `options.scenarios` defines named scenarios.

## Key decisions

- **Separate `smoke-mixed.js`** instead of `--stage` override: k6 silently ignores the `--stage` flag when named scenarios are declared in `options.scenarios`. A dedicated file with shortened stages is the only reliable way to run a smoke test.
- **Shared `metrics.js`** as a prerequisite for #239, #240, #241: created here so the dependency scripts can import from day one without risk of duplicate metric registration.
- **`gracefulStop: '30s'`** on all full-run scenarios to avoid orphaned workflow instances in the database from abrupt VU teardown.
- **40%/30%/30% VU split**: linear gets the larger share because it generates the highest DB write pressure (one write per activity with no waiting). Parallel and event-driven involve more internal coordination and are covered at 30% each.

## Deferred validation

`k6 inspect` and smoke/full run validation are deferred until dependency scripts exist:
- `linear.js` → #239
- `parallel.js` → #240
- `events.js` → #241
- `setup.js` (BPMN fixture deployment) → #239

## Test plan

1. Once #239, #240, #241 are implemented, verify dependency contracts:
   ```bash
   grep -n "export function linearWorkflow"      tests/load/scripts/linear.js
   grep -n "export function parallelWorkflow"    tests/load/scripts/parallel.js
   grep -n "export function eventDrivenWorkflow" tests/load/scripts/events.js
   grep -n "from './metrics.js'"                 tests/load/scripts/linear.js
   grep -n "workflowStartDuration.add"           tests/load/scripts/linear.js
   # repeat for parallel.js and events.js
   ```
2. `k6 inspect tests/load/scripts/mixed.js` — should list three named scenarios with correct VU counts.
3. `k6 inspect tests/load/scripts/smoke-mixed.js` — should list three scenarios with 5 VUs each.
4. Deploy fixtures: `k6 run tests/load/scripts/setup.js`
5. Smoke run: `k6 run tests/load/scripts/smoke-mixed.js`
6. Full run (optional): `k6 run --out json=full-run-results.json tests/load/scripts/mixed.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)