### PR TITLE
feat(load-testing): BPMN fixtures for load test scenarios (#238)

### DIFF
--- a/tests/load/fixtures/events-workflow.bpmn
+++ b/tests/load/fixtures/events-workflow.bpmn
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+             xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+             xmlns:zeebe="http://camunda.org/schema/zeebe/1.0">
+  <!-- requestId is supplied as an initial variable at workflow start:
+       POST /Workflow/start { "WorkflowId": "load-events", "Variables": { "requestId": "<uuid>" } }
+       The correlation key expression resolves against the workflow variable scope,
+       so initial variables are available without a preceding script task. -->
+  <message id="msg-load" name="loadMessage">
+    <extensionElements>
+      <zeebe:subscription correlationKey="= requestId" />
+    </extensionElements>
+  </message>
+  <process id="load-events" isExecutable="true">
+    <startEvent id="start" />
+    <!-- Minimal work before suspension: adds engine overhead beyond bare Start→Catch -->
+    <scriptTask id="step1" scriptFormat="csharp">
+      <script>_context.step1 = true</script>
+    </scriptTask>
+    <intermediateCatchEvent id="waitMessage">
+      <messageEventDefinition messageRef="msg-load" />
+    </intermediateCatchEvent>
+    <scriptTask id="step2" scriptFormat="csharp">
+      <script>_context.processed = true</script>
+    </scriptTask>
+    <endEvent id="end" />
+    <sequenceFlow id="f1" sourceRef="start" targetRef="step1" />
+    <sequenceFlow id="f2" sourceRef="step1" targetRef="waitMessage" />
+    <sequenceFlow id="f3" sourceRef="waitMessage" targetRef="step2" />
+    <sequenceFlow id="f4" sourceRef="step2" targetRef="end" />
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="load-events">
+      <bpmndi:BPMNShape id="start_di" bpmnElement="start">
+        <dc:Bounds x="180" y="182" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="step1_di" bpmnElement="step1">
+        <dc:Bounds x="280" y="160" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="waitMessage_di" bpmnElement="waitMessage">
+        <dc:Bounds x="442" y="182" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="step2_di" bpmnElement="step2">
+        <dc:Bounds x="540" y="160" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_di" bpmnElement="end">
+        <dc:Bounds x="702" y="182" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="f1_di" bpmnElement="f1">
+        <di:waypoint x="216" y="200" />
+        <di:waypoint x="280" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f2_di" bpmnElement="f2">
+        <di:waypoint x="380" y="200" />
+        <di:waypoint x="442" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f3_di" bpmnElement="f3">
+        <di:waypoint x="478" y="200" />
+        <di:waypoint x="540" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f4_di" bpmnElement="f4">
+        <di:waypoint x="640" y="200" />
+        <di:waypoint x="702" y="200" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/tests/load/fixtures/linear-workflow.bpmn
+++ b/tests/load/fixtures/linear-workflow.bpmn
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+             xmlns:di="http://www.omg.org/spec/DD/20100524/DI">
+  <process id="load-linear" isExecutable="true">
+    <startEvent id="start" />
+    <scriptTask id="step1" scriptFormat="csharp">
+      <script>_context.step1 = true</script>
+    </scriptTask>
+    <scriptTask id="step2" scriptFormat="csharp">
+      <script>_context.step2 = true</script>
+    </scriptTask>
+    <scriptTask id="step3" scriptFormat="csharp">
+      <script>_context.step3 = true</script>
+    </scriptTask>
+    <endEvent id="end" />
+    <sequenceFlow id="f1" sourceRef="start" targetRef="step1" />
+    <sequenceFlow id="f2" sourceRef="step1" targetRef="step2" />
+    <sequenceFlow id="f3" sourceRef="step2" targetRef="step3" />
+    <sequenceFlow id="f4" sourceRef="step3" targetRef="end" />
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="load-linear">
+      <bpmndi:BPMNShape id="start_di" bpmnElement="start">
+        <dc:Bounds x="180" y="182" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="step1_di" bpmnElement="step1">
+        <dc:Bounds x="280" y="160" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="step2_di" bpmnElement="step2">
+        <dc:Bounds x="440" y="160" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="step3_di" bpmnElement="step3">
+        <dc:Bounds x="600" y="160" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_di" bpmnElement="end">
+        <dc:Bounds x="762" y="182" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="f1_di" bpmnElement="f1">
+        <di:waypoint x="216" y="200" />
+        <di:waypoint x="280" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f2_di" bpmnElement="f2">
+        <di:waypoint x="380" y="200" />
+        <di:waypoint x="440" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f3_di" bpmnElement="f3">
+        <di:waypoint x="540" y="200" />
+        <di:waypoint x="600" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f4_di" bpmnElement="f4">
+        <di:waypoint x="700" y="200" />
+        <di:waypoint x="762" y="200" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/tests/load/fixtures/parallel-workflow.bpmn
+++ b/tests/load/fixtures/parallel-workflow.bpmn
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+             xmlns:di="http://www.omg.org/spec/DD/20100524/DI">
+  <process id="load-parallel" isExecutable="true">
+    <startEvent id="start" />
+    <parallelGateway id="fork" />
+    <scriptTask id="branchA" scriptFormat="csharp">
+      <script>_context.branchA = true</script>
+    </scriptTask>
+    <scriptTask id="branchB" scriptFormat="csharp">
+      <script>_context.branchB = true</script>
+    </scriptTask>
+    <scriptTask id="branchC" scriptFormat="csharp">
+      <script>_context.branchC = true</script>
+    </scriptTask>
+    <parallelGateway id="join" />
+    <endEvent id="end" />
+    <sequenceFlow id="f1" sourceRef="start" targetRef="fork" />
+    <sequenceFlow id="f2" sourceRef="fork" targetRef="branchA" />
+    <sequenceFlow id="f3" sourceRef="fork" targetRef="branchB" />
+    <sequenceFlow id="f4" sourceRef="fork" targetRef="branchC" />
+    <sequenceFlow id="f5" sourceRef="branchA" targetRef="join" />
+    <sequenceFlow id="f6" sourceRef="branchB" targetRef="join" />
+    <sequenceFlow id="f7" sourceRef="branchC" targetRef="join" />
+    <sequenceFlow id="f8" sourceRef="join" targetRef="end" />
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="load-parallel">
+      <bpmndi:BPMNShape id="start_di" bpmnElement="start">
+        <dc:Bounds x="180" y="282" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="fork_di" bpmnElement="fork">
+        <dc:Bounds x="280" y="275" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="branchA_di" bpmnElement="branchA">
+        <dc:Bounds x="400" y="60" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="branchB_di" bpmnElement="branchB">
+        <dc:Bounds x="400" y="260" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="branchC_di" bpmnElement="branchC">
+        <dc:Bounds x="400" y="460" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="join_di" bpmnElement="join">
+        <dc:Bounds x="570" y="275" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_di" bpmnElement="end">
+        <dc:Bounds x="682" y="282" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="f1_di" bpmnElement="f1">
+        <di:waypoint x="216" y="300" />
+        <di:waypoint x="280" y="300" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f2_di" bpmnElement="f2">
+        <di:waypoint x="305" y="275" />
+        <di:waypoint x="305" y="100" />
+        <di:waypoint x="400" y="100" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f3_di" bpmnElement="f3">
+        <di:waypoint x="330" y="300" />
+        <di:waypoint x="400" y="300" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f4_di" bpmnElement="f4">
+        <di:waypoint x="305" y="325" />
+        <di:waypoint x="305" y="500" />
+        <di:waypoint x="400" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f5_di" bpmnElement="f5">
+        <di:waypoint x="500" y="100" />
+        <di:waypoint x="595" y="100" />
+        <di:waypoint x="595" y="275" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f6_di" bpmnElement="f6">
+        <di:waypoint x="500" y="300" />
+        <di:waypoint x="570" y="300" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f7_di" bpmnElement="f7">
+        <di:waypoint x="500" y="500" />
+        <di:waypoint x="595" y="500" />
+        <di:waypoint x="595" y="325" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f8_di" bpmnElement="f8">
+        <di:waypoint x="620" y="300" />
+        <di:waypoint x="682" y="300" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>


### PR DESCRIPTION
## Summary

- Add `tests/load/fixtures/linear-workflow.bpmn` (process id: `load-linear`) — Start → 3 sequential ScriptTasks (setting `step1`, `step2`, `step3`) → End; isolates sequential engine throughput and event sourcing write overhead
- Add `tests/load/fixtures/parallel-workflow.bpmn` (process id: `load-parallel`) — Start → parallel fork → 3 branches (setting `branchA`, `branchB`, `branchC`) → join → End; exercises gateway coordination and variable scope cloning under load
- Add `tests/load/fixtures/events-workflow.bpmn` (process id: `load-events`) — Start → ScriptTask → `MessageIntermediateCatch` (`loadMessage` correlated by `= requestId`) → ScriptTask → End; tests grain suspension/resume and message correlation; `requestId` is supplied as an initial variable at workflow start

Closes #238

## Key decisions

- **Process IDs prefixed with `load-`** to avoid conflicts with manual test fixtures
- **Scripts set boolean variables** — minimal CPU overhead to isolate engine latency
- **Correlation via initial variable** (`requestId` passed in `Variables` at workflow start) rather than a script-set value — k6 controls the UUID, making correlation deterministic per VU iteration
- **3 parallel branches** as specified in the design (more realistic variable scope pressure than 2 branches)
- **BPMN authoring rules** from CLAUDE.md: `<scriptTask scriptFormat="csharp">`, Zeebe namespace for message subscription, `BPMNDiagram` section on every fixture

## Smoke test note (from Review Analysis)

The initial-variable correlation path in `events-workflow.bpmn` has not been exercised by existing manual tests. Before merging the k6 events scenario (#239), the implementer should verify: deploy `events-workflow.bpmn`, start one instance with `{"WorkflowId":"load-events","Variables":{"requestId":"smoke-test"}}`, wait for `step1` to complete (instance active at `waitMessage`), then `POST /Workflow/message {"MessageName":"loadMessage","CorrelationKey":"smoke-test","Variables":{}}` and confirm the workflow completes. Fallback: add a ScriptTask that re-writes `requestId` from an input variable (script-based pattern from `message-catch.bpmn`).

## How to test

1. Start the Aspire stack: `dotnet run --project Fleans.Aspire` (from `src/Fleans/`)
2. Deploy the fixture via the Web UI or `POST https://localhost:7140/Workflow/upload-bpmn`
3. Start an instance: `POST https://localhost:7140/Workflow/start {"WorkflowId":"load-linear"}`
4. Observe the workflow completes immediately with `step1=true`, `step2=true`, `step3=true`
5. Repeat for `load-parallel` — confirm `branchA`, `branchB`, `branchC` variables are set
6. For `load-events`: start with `{"WorkflowId":"load-events","Variables":{"requestId":"test-1"}}`, then send `POST /Workflow/message {"MessageName":"loadMessage","CorrelationKey":"test-1","Variables":{}}` and confirm completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)