### PR TITLE
feat(api,load): add instance state endpoint and k6 events scenario

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,7 @@ Add it to `Fleans.Api/Controllers/WorkflowController.cs`. DTOs go in `Fleans.Ser
 - Send message: `POST https://localhost:7140/Workflow/message` — body: `{"MessageName":"...", "CorrelationKey":"...", "Variables":{}}`
 - Send signal: `POST https://localhost:7140/Workflow/signal` — body: `{"SignalName":"..."}`
 - Complete activity: `POST https://localhost:7140/Workflow/complete-activity` — body: `{"WorkflowInstanceId":"guid", "ActivityId":"activity-id", "Variables":{}}`
+- Instance state: `GET https://localhost:7140/Workflow/instances/{instanceId}/state` — returns per-instance state snapshot (activeActivityIds, completedActivityIds, isStarted, isCompleted). Diagnostics/load-test endpoint; reads from the eventually-consistent EF projection.
 
 ## Regression tests
 
@@ -139,6 +140,8 @@ The full regression suite is the union of every plan under `tests/manual/`. Each
 26. **Transaction Sub-Process (Happy Path)** — `tests/manual/26-transaction-subprocess/test-plan.md`. Transaction Sub-Process completes normally: variables merge into parent scope, all tasks inside show Completed. Cancel/Hazard paths are `KNOWN BUG` pending issues #230 and #231.
 27. **Multiple Event (Catch, Throw, Boundary)** — `tests/manual/24-multiple-event/test-plan.md` (`message-or-signal-catch.bpmn`, `multi-throw.bpmn`, `multiple-boundary.bpmn`). Multiple intermediate catch races message vs signal (first-fires-wins; loser subscription cancelled); multiple intermediate throw fires every defined signal; multiple interrupting boundary (message + timer) cancels the host activity whichever triggers first.
 28. **Escalation Event** — `tests/manual/24-escalation-event/test-plan.md` (`child-escalation-end.bpmn`, `child-escalation-throw.bpmn`, `parent-escalation-interrupting.bpmn`, `parent-escalation-non-interrupting.bpmn`). Child CallActivity throws escalation; parent's interrupting boundary cancels the CallActivity and runs the handler; non-interrupting boundary runs the handler while the child continues. Specific escalation codes match before catch-all; uncaught escalations are non-faulting per BPMN spec.
+
+29. **Instance State Endpoint** — `tests/manual/27-instance-state-endpoint/test-plan.md`. `GET /Workflow/instances/{id}/state` returns per-instance state snapshot with camelCase JSON keys; verifies active activity tracking through the message-catch lifecycle and 404 for unknown instances.
 
 > When adding a new manual test folder under `tests/manual/`, append a numbered entry here so the regression skill picks it up.
 

--- a/src/Fleans/Fleans.Api/Controllers/WorkflowController.cs
+++ b/src/Fleans/Fleans.Api/Controllers/WorkflowController.cs
@@ -241,6 +241,16 @@ namespace Fleans.Api.Controllers
             return Ok(summary);
         }
 
+        [EnableRateLimiting("polling")]
+        [HttpGet("instances/{instanceId:guid}/state", Name = "GetInstanceState")]
+        public async Task<IActionResult> GetInstanceState(Guid instanceId)
+        {
+            var snapshot = await _workflowQueryService.GetStateSnapshot(instanceId);
+            if (snapshot is null)
+                return NotFound(new ErrorResponse($"Instance {instanceId} not found"));
+            return Ok(snapshot);
+        }
+
         [LoggerMessage(EventId = 8004, Level = LogLevel.Information,
             Message = "Claiming user task {ActivityInstanceId} for user {UserId}")]
         private partial void LogUserTaskClaim(Guid activityInstanceId, string userId);

--- a/src/Fleans/Fleans.Api/Program.cs
+++ b/src/Fleans/Fleans.Api/Program.cs
@@ -64,6 +64,7 @@ if (rateLimitConfig is not null)
         AddPolicyIfConfigured(options, "task-operation", rateLimitConfig.TaskOperation);
         AddPolicyIfConfigured(options, "read", rateLimitConfig.Read);
         AddPolicyIfConfigured(options, "admin", rateLimitConfig.Admin);
+        AddPolicyIfConfigured(options, "polling", rateLimitConfig.Polling);
 
         options.OnRejected = async (context, token) =>
         {

--- a/src/Fleans/Fleans.Api/RateLimitingConfiguration.cs
+++ b/src/Fleans/Fleans.Api/RateLimitingConfiguration.cs
@@ -6,6 +6,7 @@ public class RateLimitingConfiguration
     public RateLimitPolicy? TaskOperation { get; set; }
     public RateLimitPolicy? Read { get; set; }
     public RateLimitPolicy? Admin { get; set; }
+    public RateLimitPolicy? Polling { get; set; }
 }
 
 public class RateLimitPolicy

--- a/src/Fleans/Fleans.Application.Tests/Fleans.Application.Tests.csproj
+++ b/src/Fleans/Fleans.Application.Tests/Fleans.Application.Tests.csproj
@@ -24,9 +24,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Fleans.Application\Fleans.Application.csproj" />
     <ProjectReference Include="..\Fleans.Persistence\Fleans.Persistence.csproj" />
     <ProjectReference Include="..\Fleans.Persistence.Sqlite\Fleans.Persistence.Sqlite.csproj" />
+    <ProjectReference Include="..\Fleans.ServiceDefaults\Fleans.ServiceDefaults.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Fleans/Fleans.Application.Tests/JsonContractTests.cs
+++ b/src/Fleans/Fleans.Application.Tests/JsonContractTests.cs
@@ -1,0 +1,69 @@
+using System.Text.Json;
+using Fleans.Application.QueryModels;
+using Fleans.ServiceDefaults.DTOs;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Fleans.Application.Tests;
+
+// Locks the JSON wire shape that k6 load scripts depend on.
+// If Program.cs adds AddJsonOptions(...), it propagates here via the resolved JsonOptions.
+// A dedicated Fleans.Api.Tests project would be the more principled home; this is pragmatic
+// given only three tests need the MVC pipeline's JsonSerializerOptions.
+[TestClass]
+public class JsonContractTests
+{
+    private static readonly JsonSerializerOptions ApiOptions = BuildApiOptions();
+
+    private static JsonSerializerOptions BuildApiOptions()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddControllers();
+        using var sp = services.BuildServiceProvider();
+        return sp.GetRequiredService<IOptions<JsonOptions>>().Value.JsonSerializerOptions;
+    }
+
+    [TestMethod]
+    public void StartWorkflowResponse_Serialises_WithCamelCaseKey()
+    {
+        var dto = new StartWorkflowResponse(Guid.NewGuid());
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(dto, ApiOptions));
+        Assert.IsTrue(doc.RootElement.TryGetProperty("workflowInstanceId", out _),
+            "Expected camelCase 'workflowInstanceId' — the k6 load script reads this exact key.");
+    }
+
+    [TestMethod]
+    public void InstanceStateSnapshot_Serialises_WithCamelCaseKeys()
+    {
+        var dto = new InstanceStateSnapshot(
+            ActiveActivityIds: new() { "waitMessage" },
+            CompletedActivityIds: new() { "start" },
+            IsStarted: true,
+            IsCompleted: false,
+            IsCancelled: false,
+            ActiveActivities: new(),
+            CompletedActivities: new(),
+            VariableStates: new(),
+            ConditionSequences: new(),
+            ProcessDefinitionId: "load-events",
+            CreatedAt: null,
+            ExecutionStartedAt: null,
+            CompletedAt: null);
+
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(dto, ApiOptions));
+        foreach (var key in new[] { "activeActivityIds", "completedActivityIds", "isStarted", "isCompleted" })
+            Assert.IsTrue(doc.RootElement.TryGetProperty(key, out _),
+                $"Expected camelCase '{key}' — the k6 load script reads this exact key.");
+    }
+
+    [TestMethod]
+    public void ErrorResponse_Serialises_WithCamelCaseErrorKey()
+    {
+        var dto = new ErrorResponse("Instance abc123 not found");
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(dto, ApiOptions));
+        Assert.IsTrue(doc.RootElement.TryGetProperty("error", out _),
+            "Expected camelCase 'error' — ErrorResponse.Error is the established wire field across all controller error paths.");
+    }
+}

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -1,0 +1,72 @@
+# Fleans Load Tests
+
+k6-based load test suite for the Fleans BPMN workflow engine.
+
+## Prerequisites
+
+- [k6](https://k6.io/docs/getting-started/installation/) installed
+- Target cluster running (Aspire or docker-compose)
+- BPMN fixtures deployed via the Workflows UI (`https://localhost:7140/workflows`)
+
+## Scripts & hooks
+
+| Script | Purpose | Invocation |
+|---|---|---|
+| `setup.js` | One-time cluster bootstrap — deploys fixtures | `k6 run scripts/setup.js` |
+| `events.js` | Scenario 3 — event-driven with message correlation | `k6 run scripts/events.js` |
+| `mixed.js` | Mixed workload combining all scenarios | `k6 run scripts/mixed.js` |
+
+**`setup.js`** (from #239) is a standalone file you run once via `k6 run setup.js` to deploy fixtures and verify the cluster is ready.
+
+**`setup()`** exported from `events.js` is k6's per-run init hook — it verifies the `load-events` process is deployed and active before spawning VUs. Both are required but invoked at different times.
+
+## Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `K6_TARGET_URL` | `https://localhost:7140` | Base URL of the Fleans API |
+| `K6_POLL_INTERVAL_MS` | `100` | Initial poll interval (ms) |
+| `K6_POLL_MAX_ATTEMPTS` | `20` | Safety ceiling for poll iterations |
+| `K6_POLL_BACKOFF_CAP_MS` | `500` | Max backoff per poll sleep |
+| `K6_POLL_TOTAL_BUDGET_MS` | `3000` | Wall-clock budget for the entire poll phase |
+| `K6_MESSAGE_RETRY_BUDGET_MS` | `1000` | Wall-clock budget for message delivery retries on 404 |
+| `K6_MESSAGE_RETRY_INTERVAL_MS` | `150` | Sleep between message retry attempts. Starting heuristic — re-tune via this env var after #244's Cloud run publishes grain-commit latencies. |
+
+All env vars must be unset or set to a positive integer. An empty string (e.g., `K6_POLL_INTERVAL_MS=`) falls back to the default.
+
+## Metrics
+
+| Metric | Type | Threshold | Notes |
+|---|---|---|---|
+| `workflow_start_duration` | Trend | `p(95)<2000` | HTTP duration of `POST /Workflow/start` |
+| `poll_until_catch_duration` | Trend | `p(95)<2500` | Wall-clock from start to poll success |
+| `message_accept_duration` | Trend | `p(95)<2000` | HTTP duration of the final `POST /Workflow/message` attempt (200 or final 404) |
+| `message_retry_attempts` | Trend | *(none)* | Number of message delivery attempts (1 = first-try success). Diagnostic only. |
+| `poll_stalls` | Rate | `rate<0.01` | Rate of iterations where poll budget expired without catching `waitMessage`. Denominator: all iterations. |
+| `correlation_miss` | Rate | `rate<0.01` | Rate of iterations where message retry budget expired (all attempts 404). Denominator: iterations where poll succeeded (message was sent). Compare cautiously — `poll_stalls` and `correlation_miss` have different denominators. |
+
+## Rate-limit policy: `polling`
+
+The `GET /Workflow/instances/{id}/state` endpoint uses `[EnableRateLimiting("polling")]`. This attribute is **opt-in** via the `RateLimiting:Polling` config section:
+
+- **Section entirely absent** (default) → `UseRateLimiter()` is not registered; attribute is a no-op. Fails open.
+- **Section populated for `Polling` but missing `WorkflowMutation`/`TaskOperation`/`Read`/`Admin`** → `UseRateLimiter()` activates, but requests to endpoints with unregistered policy names throw `InvalidOperationException` → HTTP 500. Fails closed.
+- **All five policies populated** → full opt-in enforcement.
+
+Load-test deployments must populate all five together; production deployments should either populate all five or leave the section absent.
+
+### Rate-limit sizing (for docker-compose load profile)
+
+Target: 200 VU × 5 min sustained.
+
+| Policy | Peak rate | Compose env (`Window=1`) |
+|---|---|---|
+| `WorkflowMutation` | ~133 rps (200 VU × 2 mutations/iter / ~3s iter) | `RateLimiting__WorkflowMutation__PermitLimit=1000` |
+| `TaskOperation` | 0 in events scenario | `RateLimiting__TaskOperation__PermitLimit=100` |
+| `Read` | `setup()` × 1 + admin | `RateLimiting__Read__PermitLimit=100` |
+| `Admin` | 0 | `RateLimiting__Admin__PermitLimit=100` |
+| `Polling` | ~1333 rps (200 VU × 20 polls / 3s budget) | `RateLimiting__Polling__PermitLimit=10000` |
+
+## Dev-host runs
+
+When running against Aspire locally (without docker-compose), rate limiting is off by default because `appsettings.json` has no `RateLimiting` section. Do **not** partially populate the section — either set all five policies or leave it absent entirely.

--- a/tests/load/scripts/events.js
+++ b/tests/load/scripts/events.js
@@ -1,0 +1,171 @@
+// tests/load/scripts/events.js
+//
+// Scenario 3 — event-driven load test with message correlation.
+// Prerequisite: run setup.js (from #239) once against the target cluster
+// to bootstrap fixtures. setup() below is k6's per-run init hook — it only
+// verifies deployment, not provisioning.
+//
+// Flow per VU iteration:
+//   1. POST /Workflow/start  { WorkflowId: 'load-events', Variables: { requestId: <uuid> } }
+//   2. Poll GET /Workflow/instances/{id}/state until activeActivityIds includes 'waitMessage',
+//      with exponential backoff capped at K6_POLL_BACKOFF_CAP_MS and a K6_POLL_TOTAL_BUDGET_MS
+//      wall-clock deadline.
+//   3. POST /Workflow/message { MessageName: 'loadMessage', CorrelationKey: requestId }
+//      with budgeted retry on 404 (subscription-grain commit race).
+
+import http                        from 'k6/http';
+import { check, group, sleep }     from 'k6';
+import { uuidv4 }                  from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
+import {
+  workflowStartDuration,
+  pollUntilCatchDuration,
+  messageAcceptDuration,
+  messageRetryAttempts,
+  pollStallsRate,
+  correlationMissRate,
+} from './metrics.js';
+import thresholds from '../thresholds.json';
+
+const int = (name, def) => {
+  const n = Number(__ENV[name]);
+  return Number.isFinite(n) && n > 0 ? n : def;
+};
+
+const BASE_URL             = __ENV.K6_TARGET_URL || 'https://localhost:7140';
+const POLL_INTERVAL        = int('K6_POLL_INTERVAL_MS',        100);
+const POLL_MAX             = int('K6_POLL_MAX_ATTEMPTS',        20);
+const POLL_CAP             = int('K6_POLL_BACKOFF_CAP_MS',     500);
+const POLL_TOTAL_BUDGET    = int('K6_POLL_TOTAL_BUDGET_MS',   3000);
+const MESSAGE_RETRY_BUDGET   = int('K6_MESSAGE_RETRY_BUDGET_MS',   1000);
+const MESSAGE_RETRY_INTERVAL = int('K6_MESSAGE_RETRY_INTERVAL_MS',  150);
+
+const POST_HEADERS = { 'Content-Type': 'application/json' };
+const GET_HEADERS  = { 'Accept': 'application/json' };
+
+// Must match tests/load/fixtures/events-workflow.bpmn verbatim — see #238 / PR #323.
+// On fixture rename, update this block only.
+const FIXTURE = {
+  processId:      'load-events',
+  catchId:        'waitMessage',
+  messageName:    'loadMessage',
+  correlationVar: 'requestId',
+};
+
+export const options = {
+  stages: [
+    { duration: '1m', target: 200 },
+    { duration: '3m', target: 200 },
+    { duration: '1m', target:   0 },
+  ],
+  insecureSkipTLSVerify: true,
+  thresholds: { ...thresholds },
+};
+
+export function setup() {
+  const probe = http.get(
+    `${BASE_URL}/Workflow/definitions?page=1&pageSize=200`,
+    { headers: GET_HEADERS });
+
+  if (probe.status !== 200) {
+    throw new Error(
+      `[events.js] Setup probe GET /Workflow/definitions returned ${probe.status}. ` +
+      `Cannot start a load run against ${BASE_URL}.`);
+  }
+
+  const items = probe.json('items') || [];
+  const deployed = items.some(d =>
+    d.processDefinitionKey === FIXTURE.processId && d.isActive === true);
+
+  if (!deployed) {
+    throw new Error(
+      `[events.js] Process '${FIXTURE.processId}' is not deployed (or not active) on ${BASE_URL}.\n` +
+      `  1. Open the Workflows page: ${BASE_URL}/workflows\n` +
+      `  2. Click "Deploy BPMN" and select: tests/load/fixtures/events-workflow.bpmn\n` +
+      `  3. Re-run this script.\n` +
+      `See tests/load/README.md for the full load-test walk-through.`);
+  }
+}
+
+export function eventsWorkflow() {
+  const requestId = uuidv4();
+  let instanceId;
+
+  // Phase 1 — start
+  group('start', () => {
+    const res = http.post(
+      `${BASE_URL}/Workflow/start`,
+      JSON.stringify({ WorkflowId: FIXTURE.processId, Variables: { [FIXTURE.correlationVar]: requestId } }),
+      { headers: POST_HEADERS });
+    workflowStartDuration.add(res.timings.duration);
+    check(res, { 'start: status 200': (r) => r.status === 200 });
+    instanceId = res.json('workflowInstanceId');
+  });
+  if (!instanceId) return;
+
+  // Phase 2 — poll for waitMessage with exponential backoff and wall-clock budget.
+  // `return` inside the group callback exits only the callback; the outer function
+  // reads `caught` to decide whether to continue to the message phase.
+  let caught = false;
+  group('poll', () => {
+    const pollStart    = Date.now();
+    const pollDeadline = pollStart + POLL_TOTAL_BUDGET;
+    let wait = POLL_INTERVAL;
+    for (let i = 0; i < POLL_MAX; i++) {
+      if (Date.now() >= pollDeadline) break;
+      const res = http.get(
+        `${BASE_URL}/Workflow/instances/${instanceId}/state`,
+        { headers: GET_HEADERS });
+      if (res.status === 200) {
+        const activeIds = res.json('activeActivityIds') || [];
+        if (activeIds.includes(FIXTURE.catchId)) {
+          pollUntilCatchDuration.add(Date.now() - pollStart);
+          caught = true;
+          return;
+        }
+      }
+      const remaining = pollDeadline - Date.now();
+      if (remaining <= 0) break;
+      if (i < POLL_MAX - 1) sleep(Math.min(wait, remaining) / 1000);
+      wait = Math.min(Math.floor(wait * 1.5), POLL_CAP);
+    }
+  });
+  // poll_stalls: p(95)<2500 threshold keeps slow-but-caught iterations separate
+  // from hard timeouts — don't lower K6_POLL_TOTAL_BUDGET_MS below the threshold
+  // without adjusting thresholds.json.
+  pollStallsRate.add(!caught);
+  check(caught, { 'caught waitMessage': (c) => c === true });
+  if (!caught) return;
+
+  // Phase 3 — send message with budgeted retry on 404 (subscription-grain commit race).
+  // GET /instances/{id}/state reads the EF projection; POST /Workflow/message dispatches
+  // via IMessageCorrelationGrain.DeliverMessage (direct grain call). These are independent
+  // commit paths — seeing waitMessage in activeActivityIds is evidence the projection saw
+  // the event, not proof the subscription grain has committed.
+  group('message', () => {
+    const body = JSON.stringify({
+      MessageName:    FIXTURE.messageName,
+      CorrelationKey: requestId,
+      Variables:      {},
+    });
+
+    const deadline = Date.now() + MESSAGE_RETRY_BUDGET;
+    let attempts = 0;
+    let res;
+    while (true) {
+      res = http.post(`${BASE_URL}/Workflow/message`, body, { headers: POST_HEADERS });
+      attempts += 1;
+      if (res.status !== 404) break;
+      if (Date.now() >= deadline) break;
+      sleep(MESSAGE_RETRY_INTERVAL / 1000);
+    }
+
+    messageAcceptDuration.add(res.timings.duration);
+    messageRetryAttempts.add(attempts);
+    correlationMissRate.add(res.status === 404);
+
+    check(res, { 'message: status 200': (r) => r.status === 200 });
+    check(attempts, { 'message: first-try success': (a) => a === 1 });
+  });
+}
+
+export default eventsWorkflow;

--- a/tests/load/scripts/metrics.js
+++ b/tests/load/scripts/metrics.js
@@ -9,7 +9,7 @@
 //
 // Required by: linear.js (#239), parallel.js (#240), events.js (#241), mixed.js (#242)
 
-import { Trend } from 'k6/metrics';
+import { Rate, Trend } from 'k6/metrics';
 
 // Duration of the POST /Workflow/start HTTP call, in milliseconds.
 // Each dependency script must call: workflowStartDuration.add(res.timings.duration)
@@ -20,3 +20,9 @@ import { Trend } from 'k6/metrics';
 // mixed.js will be silently ignored rather than failed. Ensure all three
 // dependency scripts instrument this metric.
 export const workflowStartDuration = new Trend('workflow_start_duration');
+
+export const pollUntilCatchDuration = new Trend('poll_until_catch_duration');
+export const messageAcceptDuration  = new Trend('message_accept_duration');
+export const messageRetryAttempts   = new Trend('message_retry_attempts');
+export const pollStallsRate         = new Rate('poll_stalls');
+export const correlationMissRate    = new Rate('correlation_miss');

--- a/tests/load/thresholds.json
+++ b/tests/load/thresholds.json
@@ -1,0 +1,9 @@
+{
+  "http_req_failed":           ["rate<0.01"],
+  "http_req_duration":         ["p(95)<2000"],
+  "workflow_start_duration":   ["p(95)<2000"],
+  "poll_until_catch_duration": ["p(95)<2500"],
+  "message_accept_duration":   ["p(95)<2000"],
+  "poll_stalls":               ["rate<0.01"],
+  "correlation_miss":          ["rate<0.01"]
+}

--- a/tests/manual/27-instance-state-endpoint/test-plan.md
+++ b/tests/manual/27-instance-state-endpoint/test-plan.md
@@ -1,0 +1,53 @@
+# Instance State Endpoint — Manual Test Plan
+
+## Scenario
+
+Verify `GET /Workflow/instances/{instanceId}/state` returns per-instance state with correct JSON shape and active activity tracking.
+
+## Prerequisites
+
+- Aspire stack running: `dotnet run --project Fleans.Aspire` (from `src/Fleans/`)
+- Deploy `tests/load/fixtures/events-workflow.bpmn` via the Workflows UI at `https://localhost:7140/workflows`
+
+## Steps
+
+1. Start an instance with a correlation variable:
+   ```bash
+   curl -k -X POST https://localhost:7140/Workflow/start \
+     -H "Content-Type: application/json" \
+     -d '{"WorkflowId":"load-events","Variables":{"requestId":"test-123"}}'
+   ```
+   Note the `workflowInstanceId` from the response.
+
+2. Poll the instance state endpoint:
+   ```bash
+   curl -k https://localhost:7140/Workflow/instances/<instanceId>/state
+   ```
+
+3. Verify the response shape:
+   - [ ] Response is HTTP 200
+   - [ ] JSON keys are camelCase: `activeActivityIds`, `completedActivityIds`, `isStarted`, `isCompleted`
+   - [ ] `isStarted` is `true`
+   - [ ] `activeActivityIds` contains `"waitMessage"` (the message intermediate catch event)
+
+4. Verify 404 for unknown instance:
+   ```bash
+   curl -k https://localhost:7140/Workflow/instances/00000000-0000-0000-0000-000000000000/state
+   ```
+   - [ ] Response is HTTP 404
+   - [ ] Body contains `{"error":"Instance 00000000-0000-0000-0000-000000000000 not found"}`
+
+5. Send the correlated message to unblock the instance:
+   ```bash
+   curl -k -X POST https://localhost:7140/Workflow/message \
+     -H "Content-Type: application/json" \
+     -d '{"MessageName":"loadMessage","CorrelationKey":"test-123","Variables":{}}'
+   ```
+
+6. Poll the state again:
+   ```bash
+   curl -k https://localhost:7140/Workflow/instances/<instanceId>/state
+   ```
+   - [ ] `isCompleted` is `true`
+   - [ ] `activeActivityIds` is empty
+   - [ ] `completedActivityIds` contains `"waitMessage"`

--- a/website/src/content/docs/reference/api.md
+++ b/website/src/content/docs/reference/api.md
@@ -11,3 +11,24 @@ All endpoints are served from `https://localhost:7140/Workflow/*` by default.
 | `/message` | POST | `{"MessageName":"...", "CorrelationKey":"...", "Variables":{}}` |
 | `/signal` | POST | `{"SignalName":"..."}` |
 | `/complete-activity` | POST | `{"WorkflowInstanceId":"guid", "ActivityId":"activity-id", "Variables":{}}` |
+| `/instances/{instanceId}/state` | GET | *(none)* — Returns the current state snapshot for a specific workflow instance |
+
+### Instance State endpoint
+
+`GET /Workflow/instances/{instanceId}/state` returns a per-instance state snapshot including `activeActivityIds`, `completedActivityIds`, `isStarted`, `isCompleted`, and related fields.
+
+This endpoint is intended for **diagnostics and load-test polling**, not for high-frequency production use. The response reflects the read-side EF projection, which is eventually consistent with the event stream — callers that need realtime certainty should drive via the grain API directly.
+
+```bash
+curl -k https://localhost:7140/Workflow/instances/<guid>/state
+```
+
+> `-k` (or `--insecure`) skips dev-cert validation. In production behind a proper TLS cert, drop the flag.
+
+Returns 404 with `{"error":"Instance {id} not found"}` if the instance ID does not exist in the projection.
+
+Rate limiting: uses the `polling` policy. See [Rate Limiting](#rate-limiting) below for opt-in semantics.
+
+### Rate limiting
+
+All API endpoints have rate-limiting attributes (`workflow-mutation`, `task-operation`, `read`, `admin`, `polling`), but rate limiting is **opt-in**: it only activates when the `RateLimiting` configuration section is present. Default `appsettings.json` has no such section, so the middleware is off by default. When activating rate limiting, populate **all five** policies together — partially populating the section causes unregistered-policy endpoints to return HTTP 500.


### PR DESCRIPTION
## Summary

Closes #241

Implements the approved v7 Design & Plan for the k6 event-driven load test scenario with polling. Two deliverables:

1. **New API endpoint** `GET /Workflow/instances/{instanceId}/state` — returns `InstanceStateSnapshot` for per-instance state polling. Uses a new `polling` rate-limit policy (opt-in, no `appsettings.json` changes).

2. **k6 events scenario** (`tests/load/scripts/events.js`) — starts a workflow with a unique `requestId`, polls until `waitMessage` is active (wall-clock-budgeted 3s with exponential backoff), sends a correlated `loadMessage` with budgeted retry on 404 (subscription-grain commit race). Includes `setup()` deployment probe against `GET /Workflow/definitions`.

### Key decisions
- Rate-limit policy `polling` is isolated from existing `read`/`workflow-mutation` policies
- JSON contract locked via 3 serialization tests using MVC's resolved `JsonOptions` (not just defaults)
- `messageAcceptDuration` records only the final attempt duration (not 404 retries)
- `poll_stalls` and `correlation_miss` are Rate metrics scaling with VU volume
- `FIXTURE` constants block pinned against #238's `events-workflow.bpmn`

### Dependencies
- **#238** (merged) — provides `events-workflow.bpmn` fixture
- **#239** (open) — provides `setup.js`; `metrics.js` extended in this PR
- **#237** — docker-compose profile must populate all five rate-limit policies

## Test plan

- [x] 3 JSON contract tests pass (StartWorkflowResponse, InstanceStateSnapshot, ErrorResponse casing)
- [x] Full test suite passes
- [ ] Manual smoke: deploy events-workflow.bpmn → start instance → poll state endpoint → verify activeActivityIds → send message → verify completion
- [ ] Manual test plan at `tests/manual/27-instance-state-endpoint/test-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)