### PR TITLE
docs: add sample BPMN file and fix Quick Start deploy command

### DIFF
--- a/website/public/samples/my-process.bpmn
+++ b/website/public/samples/my-process.bpmn
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+             xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+             id="Definitions_1"
+             targetNamespace="http://bpmn.io/schema/bpmn">
+
+  <process id="my-process" name="My First Process" isExecutable="true">
+    <startEvent id="start" name="Start">
+      <outgoing>flow1</outgoing>
+    </startEvent>
+
+    <scriptTask id="greet" name="Set Greeting" scriptFormat="csharp">
+      <incoming>flow1</incoming>
+      <outgoing>flow2</outgoing>
+      <script>_context.greeting = "Hello from Fleans!";</script>
+    </scriptTask>
+
+    <endEvent id="end" name="End">
+      <incoming>flow2</incoming>
+    </endEvent>
+
+    <sequenceFlow id="flow1" sourceRef="start" targetRef="greet" />
+    <sequenceFlow id="flow2" sourceRef="greet" targetRef="end" />
+  </process>
+
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="my-process">
+      <bpmndi:BPMNShape id="start_di" bpmnElement="start">
+        <dc:Bounds x="180" y="160" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="186" y="203" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="greet_di" bpmnElement="greet">
+        <dc:Bounds x="280" y="138" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_di" bpmnElement="end">
+        <dc:Bounds x="450" y="160" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="458" y="203" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="flow1_di" bpmnElement="flow1">
+        <di:waypoint x="216" y="178" />
+        <di:waypoint x="280" y="178" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow2_di" bpmnElement="flow2">
+        <di:waypoint x="380" y="178" />
+        <di:waypoint x="450" y="178" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/website/src/content/docs/guides/quick-start.md
+++ b/website/src/content/docs/guides/quick-start.md
@@ -21,16 +21,40 @@ to find the Web app.
 
 ## Deploy a workflow
 
-```bash
-curl -X POST https://localhost:7140/Workflow/deploy \
-  -H "Content-Type: application/json" \
-  -d @my-process.bpmn
+Fleans deploys workflows through the **Admin UI** (Blazor editor), not via a REST endpoint.
+
+1. Open the Web app (default: `https://localhost:7141`)
+2. Navigate to the **Editor** page
+3. Import or paste your BPMN XML, then click **Deploy**
+
+A sample BPMN file is available to get you started:
+[**my-process.bpmn**](/samples/my-process.bpmn) — a minimal workflow with a single script task
+that sets a `greeting` variable.
+
+```xml
+<!-- Excerpt from my-process.bpmn -->
+<scriptTask id="greet" name="Set Greeting" scriptFormat="csharp">
+  <script>_context.greeting = "Hello from Fleans!";</script>
+</scriptTask>
 ```
 
+Download the file, open the Editor, import it, and click **Deploy**.
+
+:::note
+Script tasks execute automatically — no external `complete-activity` call is needed.
+The engine runs the C# script inline and advances the workflow to the next element.
+:::
+
 ## Start an instance
+
+Once the workflow is deployed, start an instance via the API:
 
 ```bash
 curl -X POST https://localhost:7140/Workflow/start \
   -H "Content-Type: application/json" \
   -d '{"WorkflowId":"my-process"}'
 ```
+
+Because `my-process` contains only a script task, the instance runs to completion
+immediately. You can verify the result in the Admin UI — the instance will show
+a `greeting` variable with the value `"Hello from Fleans!"`.

--- a/website/src/content/docs/guides/quick-start.md
+++ b/website/src/content/docs/guides/quick-start.md
@@ -23,7 +23,7 @@ to find the Web app.
 
 Fleans deploys workflows through the **Admin UI** (Blazor editor), not via a REST endpoint.
 
-1. Open the Web app (default: `https://localhost:7141`)
+1. Open the **Web app** — find its URL on the Aspire dashboard
 2. Navigate to the **Editor** page
 3. Import or paste your BPMN XML, then click **Deploy**
 


### PR DESCRIPTION
## Summary
- Adds a downloadable sample BPMN file (`website/public/samples/my-process.bpmn`) with a Start -> ScriptTask -> End workflow that sets a `greeting` variable
- Fixes the Quick Start guide's broken deploy `curl` command — the `/Workflow/deploy` endpoint doesn't exist; deployment is done through the Admin UI editor
- Clarifies that script tasks auto-complete (no `complete-activity` call needed)

Closes #293

## Test plan
- [ ] `npm run build` in `website/` passes (verified locally)
- [ ] Download link at `/samples/my-process.bpmn` serves the BPMN file
- [ ] Quick Start guide renders correctly with the note callout and XML excerpt

🤖 Generated with [Claude Code](https://claude.com/claude-code)