### PR TITLE
fix(website): replace <github-user> placeholders with nightBaker

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -15,7 +15,7 @@ export default defineConfig({
       },
       favicon: '/favicon.svg',
       social: [
-        { icon: 'github', label: 'GitHub', href: 'https://github.com/<github-user>/fleans' },
+        { icon: 'github', label: 'GitHub', href: 'https://github.com/nightBaker/fleans' },
       ],
       sidebar: [
         {

--- a/website/src/content/docs/guides/quick-start.md
+++ b/website/src/content/docs/guides/quick-start.md
@@ -11,7 +11,7 @@ description: Run Fleans locally in under 5 minutes.
 ## Clone and run
 
 ```bash
-git clone https://github.com/<github-user>/fleans.git
+git clone https://github.com/nightBaker/fleans.git
 cd fleans/src/Fleans
 dotnet run --project Fleans.Aspire
 ```

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -12,7 +12,7 @@ hero:
       icon: right-arrow
       variant: primary
     - text: View on GitHub
-      link: https://github.com/<github-user>/fleans
+      link: https://github.com/nightBaker/fleans
       icon: external
 ---
 


### PR DESCRIPTION
## Summary

Replaces `<github-user>` placeholder with `nightBaker` in 3 website files:
- `astro.config.mjs` — GitHub social link
- `index.mdx` — hero "View on GitHub" button
- `guides/quick-start.md` — clone command

Closes #310