### PR TITLE
fix(website): set astro site to real deploy origin

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -3,7 +3,7 @@ import starlight from '@astrojs/starlight';
 
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://example.github.io',
+  site: 'https://nightBaker.github.io',
   base: '/fleans',
   integrations: [
     starlight({


### PR DESCRIPTION
Sets `site` in `astro.config.mjs` from `https://example.github.io` to `https://nightBaker.github.io`.

This fixes sitemap generation, canonical URLs, and the Astro base-path resolution for the GitHub Pages deployment.

1 line changed. Website build passes.

Closes #311