### PR TITLE
Docs: Add deploy endpoint to REST API reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,7 @@ Add it to `Fleans.Api/Controllers/WorkflowController.cs`. DTOs go in `Fleans.Ser
 - **Use short timer durations** for test fixtures (PT5S–PT10S) so tests complete quickly.
 
 ### API Endpoints for Manual Tests
+- Deploy process: `POST https://localhost:7140/Workflow/deploy` — body: `{"BpmnXml":"<raw BPMN XML string>"}` — returns `{"ProcessDefinitionKey":"...","Version":1}` on success, 400 with `{"Error":"..."}` on parse failure
 - Start instance: `POST https://localhost:7140/Workflow/start` — body: `{"WorkflowId":"process-id"}` or `{"WorkflowId":"process-id","Variables":{"key":"value"}}` to set initial variables before workflow starts (required for message event sub-processes that use variables as correlation keys)
 - Send message: `POST https://localhost:7140/Workflow/message` — body: `{"MessageName":"...", "CorrelationKey":"...", "Variables":{}}`
 - Send signal: `POST https://localhost:7140/Workflow/signal` — body: `{"SignalName":"..."}`

--- a/website/src/content/docs/reference/api.md
+++ b/website/src/content/docs/reference/api.md
@@ -7,7 +7,56 @@ All endpoints are served from `https://localhost:7140/Workflow/*` by default.
 
 | Endpoint | Method | Body |
 |---|---|---|
+| `/deploy` | POST | `{"BpmnXml":"<raw BPMN XML string>"}` |
 | `/start` | POST | `{"WorkflowId":"process-id"}` or `{"WorkflowId":"process-id","Variables":{"key":"value"}}` — `Variables` is optional; when provided, the variables are merged into the root scope **before** the workflow starts (required for message event sub-processes that resolve correlation keys from variables at scope entry) |
 | `/message` | POST | `{"MessageName":"...", "CorrelationKey":"...", "Variables":{}}` |
 | `/signal` | POST | `{"SignalName":"..."}` |
 | `/complete-activity` | POST | `{"WorkflowInstanceId":"guid", "ActivityId":"activity-id", "Variables":{}}` |
+
+## Endpoint details
+
+### `POST /Workflow/deploy`
+
+Deploys a BPMN process definition to the engine. The request body contains the raw BPMN XML as a string. On success the engine parses the XML, registers the process definition, and returns the assigned key and version number. If the same process ID is deployed again, the version is incremented automatically.
+
+**Why this endpoint exists:** Before any workflow instance can be started, its process definition must be deployed. This endpoint is the programmatic entry point for uploading BPMN definitions — the Web UI also uses it internally when you import a `.bpmn` file.
+
+**Request**
+
+```json
+POST /Workflow/deploy
+Content-Type: application/json
+
+{
+  "BpmnXml": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><definitions ...>...</definitions>"
+}
+```
+
+**Success response (200)**
+
+```json
+{
+  "ProcessDefinitionKey": "my-process",
+  "Version": 1
+}
+```
+
+**Error response (400)** — returned when the BPMN XML cannot be parsed:
+
+```json
+{
+  "Error": "Failed to parse BPMN: ..."
+}
+```
+
+**Best-practice example**
+
+```bash
+# Deploy a local BPMN file via curl
+BPMN_XML=$(cat my-workflow.bpmn | jq -Rs .)
+curl -s -X POST https://localhost:7140/Workflow/deploy \
+  -H "Content-Type: application/json" \
+  -d "{\"BpmnXml\": $BPMN_XML}"
+```
+
+This reads the `.bpmn` file, JSON-escapes it with `jq -Rs`, and sends it to the deploy endpoint. The response contains the `ProcessDefinitionKey` you pass to `/start` to create instances.


### PR DESCRIPTION
## Summary
- Adds `POST /Workflow/deploy` endpoint documentation to the REST API reference page, including request/response formats, error handling, and a curl best-practice example
- Adds the deploy endpoint to the CLAUDE.md API endpoints list for manual testing

Closes #296

## Test plan
- [x] `npm run build` passes in `website/`
- [ ] Verify the API reference page renders correctly at `/reference/api/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)