### PR TITLE
feat(website): add GitHub stars badge and custom footer

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -38,6 +38,9 @@ export default defineConfig({
           autogenerate: { directory: 'reference' },
         },
       ],
+      components: {
+        Footer: './src/components/Footer.astro',
+      },
       customCss: ['./src/styles/custom.css'],
     }),
   ],

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -1,0 +1,12 @@
+---
+import Default from '@astrojs/starlight/components/Footer.astro';
+---
+
+<Default {...Astro.props}><slot /></Default>
+
+<footer class="fleans-footer">
+  <div class="fleans-footer-inner">
+    <span>&copy; 2024&ndash;2026 Fleans Contributors &middot; <a href="https://github.com/nightBaker/fleans/blob/main/LICENSE">MIT License</a></span>
+    <span><a href="https://github.com/nightBaker/fleans">GitHub</a></span>
+  </div>
+</footer>

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -18,6 +18,12 @@ hero:
 
 import { Card, CardGrid } from '@astrojs/starlight/components';
 
+<p style="text-align: center; margin-top: -1rem; margin-bottom: 2rem;">
+  <a href="https://github.com/nightBaker/fleans">
+    <img src="https://img.shields.io/github/stars/nightBaker/fleans?style=social" alt="GitHub stars" />
+  </a>
+</p>
+
 ## Why Fleans?
 
 <CardGrid stagger>

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -346,3 +346,29 @@
     animation: none !important;
   }
 }
+
+/* --- Custom footer --- */
+.fleans-footer {
+  border-top: 1px solid var(--sl-color-hairline);
+  padding: 1.5rem 1rem;
+  font-size: var(--sl-text-xs);
+  color: var(--sl-color-gray-3);
+}
+
+.fleans-footer-inner {
+  max-width: 72rem;
+  margin: 0 auto;
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.fleans-footer a {
+  color: var(--sl-color-accent);
+  text-decoration: none;
+}
+
+.fleans-footer a:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
## Summary

Closes #300

Adds a GitHub stars badge to the landing page hero and a custom footer across all pages.

### Changes

- **`website/src/content/docs/index.mdx`** — shields.io GitHub stars badge below hero actions
- **`website/src/components/Footer.astro`** — new Starlight component override that renders the default footer plus a custom section with copyright, MIT license link, and GitHub link
- **`website/astro.config.mjs`** — registered `Footer` component override
- **`website/src/styles/custom.css`** — footer styling (hairline border, flex layout, accent-colored links)

### Key decisions

- Used shields.io `?style=social` badge — zero JS, auto-updating star count, widely recognized
- Footer extends (not replaces) Starlight's default footer via `<Default>` import
- No new npm dependencies

### How to test

```bash
cd website && npm run dev
```

1. Visit the landing page — stars badge should appear below the hero actions
2. Navigate to any docs page — footer should appear at the bottom with copyright, MIT license link, and GitHub link
3. `npm run build` should complete without errors
