### PR TITLE
fix: merge compensation handler variables back to parent scope (#326)

### DIFF
--- a/src/Fleans/Fleans.Domain/Aggregates/WorkflowExecution.cs
+++ b/src/Fleans/Fleans.Domain/Aggregates/WorkflowExecution.cs
@@ -590,6 +590,13 @@ public class WorkflowExecution
         Emit(new ChildVariableScopeCreated(handlerVariablesId, parentVariablesId));
         Emit(new VariablesMerged(handlerVariablesId, snapshot.VariablesSnapshot));
 
+        // Overlay the parent scope's current variables so this handler sees changes
+        // made by previous compensation handlers in the same walk. Without this,
+        // each handler would only see the original snapshot and miss side-effects
+        // from earlier handlers that were already merged back to the parent scope.
+        var parentVariables = _state.GetVariableState(parentVariablesId).Variables;
+        Emit(new VariablesMerged(handlerVariablesId, parentVariables));
+
         // Spawn the handler activity
         var handlerInstanceId = Guid.NewGuid();
         Emit(new ActivitySpawned(


### PR DESCRIPTION
## Summary

- After a compensation handler's child scope is seeded from the compensable activity's snapshot, overlay the parent scope's current variables so the handler also sees changes made by prior handlers in the same walk
- This fixes the bug where the second compensation handler would see stale variables and the root scope would lose the first handler's side-effects after the walk completed

## Root cause

In `AdvanceCompensationWalk()`, each handler's scope was seeded only from the immutable `snapshot.VariablesSnapshot`. Even though `AdvanceCompensationWalkIfHandlerCompleted()` correctly merged handler output back to the parent scope (line 655), the next handler's scope never picked up those parent-scope updates.

## Fix

Added a second `VariablesMerged` emit after the snapshot seed in `AdvanceCompensationWalk()` that overlays the parent scope's current variables onto the new handler scope. This ensures each handler starts with the snapshot as a base, then enriched with any parent-scope updates from prior handlers.

## Test plan

- [x] All 930 existing tests pass (253 application + 405 domain + 152 infrastructure + 116 persistence + 4 MCP)
- [x] Existing regression test `CompensationHandler_OutputVariables_ShouldPropagateToParentScope` passes — verifies handler_a sees handler_b's `flightStatus="cancelled"` and root scope shows both statuses as "cancelled"
- [ ] Manual test: `tests/manual/24-compensation-event/test-plan.md`

Fixes #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)