### PR TITLE
feat(website): replace jargon tagline with plain-English subtitle

### DIFF
--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -3,7 +3,7 @@ title: Fleans
 description: BPMN Workflow Engine on Orleans — Camunda on .NET Orleans
 template: splash
 hero:
-  tagline: Design visual workflows, run them at scale in .NET — no JVM required.
+  tagline: Design visual workflows, run them at scale in .NET Orleans.
   image:
     file: ../../assets/logo.svg
   actions:

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -3,7 +3,7 @@ title: Fleans
 description: BPMN Workflow Engine on Orleans — Camunda on .NET Orleans
 template: splash
 hero:
-  tagline: BPMN Workflow Engine on Orleans — Camunda on .NET Orleans.
+  tagline: Design visual workflows, run them at scale in .NET — no JVM required.
   image:
     file: ../../assets/logo.svg
   actions:


### PR DESCRIPTION
## Summary

Closes #299

Replaces the hero tagline on the landing page from jargon-heavy "BPMN Workflow Engine on Orleans — Camunda on .NET Orleans." to accessible "Design visual workflows, run them at scale in .NET — no JVM required."

### Why
Visitors unfamiliar with BPMN, Orleans, or Camunda couldn't understand the value prop. The new tagline communicates what/benefit/differentiator in plain English.

### Change
Single line in `website/src/content/docs/index.mdx` — the `tagline` frontmatter field.
