### PR TITLE
Drop Playwright prebuild to unblock deploy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ The splash page (`website/src/content/docs/index.mdx`) loads an interactive Thre
 - **Theme-reactive:** a `MutationObserver` on `<html data-theme>` recolors the scene in place — no reload, no rebuild.
 - **Only imported by `index.mdx`:** doc pages are untouched and pay zero bundle cost.
 - **Regenerating posters:** if you change scene visuals, run `cd website && npm run posters` (requires `npx playwright install chromium`). Commit the updated `public/silo-poster-*.webp` files.
-- **Contrast guardrail:** `npm run build` runs a `prebuild` Playwright check that fails if hero text drops below WCAG AA against the themed composite background. Tighten the gradient stops in `src/styles/silo-background.css` if the check fails.
+- **Contrast guardrail:** `cd website && npm run check:contrast` runs a Playwright check that fails if hero text drops below WCAG AA against the themed composite background. It is *not* wired into `npm run build` (that would force CI to install Chromium on every deploy). Run it manually after any change to the silo-background CSS, silo-scene, or hero styling.
 
 ## How to Add a New BPMN Activity
 

--- a/website/package.json
+++ b/website/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "prebuild": "node scripts/check-landing-contrast.mjs",
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",


### PR DESCRIPTION
## Summary

PR #344 wired a Playwright-based contrast check into the `prebuild` hook of `website/package.json`. The deploy workflow (`.github/workflows/deploy-website.yml`) runs `npm run build` on a fresh runner that doesn't have Chromium installed, so every deploy to `main` now fails:

```
browserType.launch: Executable doesn't exist at /home/runner/.cache/ms-playwright/chromium_headless_shell-1217/...
Please run the following command to download new browsers:
    npx playwright install
```

Options considered: install Chromium in CI (~170 MB download + ~30 s per deploy, for a check that's only meaningful when hero/scene styling changes) vs. keep the script but take it off the build path. I went with the second — the contrast script remains available as `npm run check:contrast` for local runs, and `CLAUDE.md` now documents it as a manual step.

## Test plan

- [x] `cd website && npm run build` passes locally
- [ ] CI deploy-website workflow goes green on merge