### PR TITLE
Pin dark palette on splash regardless of active theme

### DIFF
--- a/website/src/styles/silo-background.css
+++ b/website/src/styles/silo-background.css
@@ -1,5 +1,31 @@
 /* Silo background — splash-only. Loaded via SiloBackground.astro. */
 
+/* Splash is dark-only. These overrides pin the Fleans palette to the dark
+ * values on any page that has a hero (`[data-has-hero]` is set by Starlight
+ * on splash-template pages). The rules are scoped by attribute so they
+ * override both `[data-theme='light']` and `[data-theme='dark']` — the
+ * splash ignores the active theme entirely and stays dark even when the
+ * user toggled light elsewhere.
+ *
+ * Selector chain `:root[data-has-hero][data-theme]` has specificity (0,3,1)
+ * which beats custom.css's `:root[data-theme='light']` (0,2,1).
+ */
+:root[data-has-hero][data-theme] {
+  --sl-color-accent-low: #0f2926;
+  --sl-color-accent: #4eb5a6;
+  --sl-color-accent-high: #a8e0d6;
+  --sl-color-white: #f5f5f0;
+  --sl-color-gray-1: #e5e5df;
+  --sl-color-gray-2: #b8b8b1;
+  --sl-color-gray-3: #8a8a82;
+  --sl-color-gray-4: #5a5a53;
+  --sl-color-gray-5: #2e2e2a;
+  --sl-color-gray-6: #1a1a17;
+  --sl-color-black: #0a0a0a;
+  --fleans-accent-2: #9eff00;
+  --fleans-surface: #141411;
+}
+
 /* Splash is dark-only: hide Starlight's theme toggle so the user can't flip
  * to light mode here. The toggle remains visible on doc pages. */
 :root[data-has-hero] starlight-theme-select {


### PR DESCRIPTION
## Summary

Reported: changing the theme on another page (e.g., docs) also changed the palette on the splash landing page, but the splash is supposed to always be dark.

Root cause: `custom.css` sets the Fleans palette per `[data-theme]`. The existing inline script in `SiloBackground.astro` sets `data-theme='dark'` on body parse, but there is still a window (and, with any client-side routing, possibly a persistent mismatch) where `[data-theme='light']` rules are the ones in effect.

Fix: in `silo-background.css`, pin the full dark palette under `:root[data-has-hero][data-theme]` with specificity (0,3,1), beating `:root[data-theme='light']` (0,2,1). The splash is now dark regardless of what `data-theme` says.

## Test plan

- [ ] On docs page, toggle to light. Navigate to `/fleans/` — splash stays dark.
- [ ] Toggle theme-select doesn't exist on splash (still hidden).
- [ ] Docs pages continue to honor the user's theme preference.