### PR TITLE
feat(website): rework splash hero cards with concrete pillar claims

### DIFF
--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -30,20 +30,28 @@ import SiloBackground from '../../components/SiloBackground.astro';
 ## Why Fleans?
 
 <CardGrid stagger>
-  <Card title="BPMN 2.0 Native" icon="document">
-    Author workflows as BPMN XML with the familiar Camunda-compatible
-    tooling, then run them on a distributed .NET Orleans cluster.
+  <Card title="Actors, not orchestrators" icon="rocket">
+    Every workflow is an independent Orleans grain. No shared coordinator,
+    no lock contention — add silos, get linear throughput.
   </Card>
-  <Card title="Actor-Based Execution" icon="rocket">
-    Each workflow instance is an Orleans grain — horizontally scalable,
-    location-transparent, and resilient by design.
+  <Card title="Scale reads separately from writes" icon="random">
+    Built-in CQRS split routes read traffic through a NoTracking query
+    context and optional PostgreSQL replica.
   </Card>
-  <Card title="Event-Sourced Core" icon="setting">
-    Workflow state is reconstructed from an immutable event log,
-    giving you audit trails and point-in-time debugging for free.
+  <Card title="Event-sourced, crash-safe state" icon="approve-check">
+    Append-only event log with deterministic replay. Silo dies mid-workflow?
+    Orleans reactivates the grain on another silo — no orphaned state.
   </Card>
-  <Card title=".NET First" icon="seti:c-sharp">
-    Built in modern C#, integrated with ASP.NET Core and .NET Aspire.
-    No JVM, no external workflow engine.
+  <Card title="Typed BPMN recovery paths" icon="warning">
+    Compensation, error boundaries, and escalation events are first-class.
+    Failure modes get explicit semantics, not ad-hoc try/catch.
+  </Card>
+  <Card title="In-memory hot path" icon="star">
+    Active workflows run from RAM — mid-workflow steps skip the database.
+    Events batch into one transaction at the end of each grain call.
+  </Card>
+  <Card title="Materialized read projections" icon="magnifier">
+    Admin UI and state queries read a pre-built EF projection.
+    No event replay to render a list or poll for completion.
   </Card>
 </CardGrid>


### PR DESCRIPTION
## Summary

Closes #351

Replaces the 4 generic landing page cards with 6 concrete pillar-based cards organized by Scalability, Reliability, and Performance.

### New cards
1. **Actors, not orchestrators** — Orleans grain independence, linear scaling
2. **Scale reads separately from writes** — CQRS split, NoTracking, PostgreSQL replica
3. **Event-sourced, crash-safe state** — append-only log, deterministic replay
4. **Typed BPMN recovery paths** — compensation, error boundaries, escalation
5. **In-memory hot path** — RAM state, event batching
6. **Materialized read projections** — pre-built EF projection, no event replay

Each body ≤ 28 words per acceptance criteria.

### How to test
```bash
cd website && npm install && npm run dev
```
Check the landing page — 6 cards should render in a grid.
