### PR TITLE
feat(api): add opt-in JWT bearer authentication

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,7 +154,8 @@ The full regression suite is the union of every plan under `tests/manual/`. Each
 28. **Escalation Event** — `tests/manual/24-escalation-event/test-plan.md` (`child-escalation-end.bpmn`, `child-escalation-throw.bpmn`, `parent-escalation-interrupting.bpmn`, `parent-escalation-non-interrupting.bpmn`). Child CallActivity throws escalation; parent's interrupting boundary cancels the CallActivity and runs the handler; non-interrupting boundary runs the handler while the child continues. Specific escalation codes match before catch-all; uncaught escalations are non-faulting per BPMN spec.
 29. **Compensation Events** — `tests/manual/24-compensation-event/test-plan.md` (`compensation-broadcast.bpmn`). Broadcast compensation throw after two script tasks; verifies reverse-order handler execution (cancel_flight before cancel_hotel) and variable mutation by compensation handlers.
 
-29. **Instance State Endpoint** — `tests/manual/27-instance-state-endpoint/test-plan.md`. `GET /Workflow/instances/{id}/state` returns per-instance state snapshot with camelCase JSON keys; verifies active activity tracking through the message-catch lifecycle and 404 for unknown instances.
+30. **Instance State Endpoint** — `tests/manual/27-instance-state-endpoint/test-plan.md`. `GET /Workflow/instances/{id}/state` returns per-instance state snapshot with camelCase JSON keys; verifies active activity tracking through the message-catch lifecycle and 404 for unknown instances.
+31. **API JWT Authentication** — `tests/manual/28-api-auth/test-plan.md`. Opt-in JWT bearer authentication; verifies API works unauthenticated by default, returns 401 when auth is configured and no token is provided, and accepts valid tokens.
 
 > When adding a new manual test folder under `tests/manual/`, append a numbered entry here so the regression skill picks it up.
 

--- a/src/Fleans/Fleans.Api/Fleans.Api.csproj
+++ b/src/Fleans/Fleans.Api/Fleans.Api.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.Orleans.Persistence.Redis" Version="10.0.1" />
     <PackageReference Include="Microsoft.Orleans.Server" Version="10.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
   </ItemGroup>
 

--- a/src/Fleans/Fleans.Api/Program.cs
+++ b/src/Fleans/Fleans.Api/Program.cs
@@ -6,6 +6,8 @@ using Fleans.Infrastructure;
 using Fleans.Persistence.PostgreSql;
 using Fleans.Persistence.Sqlite;
 using Fleans.ServiceDefaults;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.RateLimiting;
 using Orleans.Dashboard;
 using Orleans.EventSourcing.CustomStorage;
@@ -15,6 +17,24 @@ var builder = WebApplication.CreateBuilder(args);
 // Add service defaults & Aspire components first
 // This must be called before UseOrleans when running through Aspire
 builder.AddServiceDefaults();
+
+// Authentication — opt-in: only enabled when Authentication:Authority is configured
+var authAuthority = builder.Configuration["Authentication:Authority"];
+var authEnabled = !string.IsNullOrEmpty(authAuthority);
+if (authEnabled)
+{
+    builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+        .AddJwtBearer(opts =>
+        {
+            opts.Authority = authAuthority;
+            opts.Audience = builder.Configuration["Authentication:Audience"] ?? "fleans-api";
+            opts.RequireHttpsMetadata = builder.Configuration.GetValue("Authentication:RequireHttpsMetadata", true);
+        });
+    builder.Services.AddAuthorizationBuilder()
+        .SetFallbackPolicy(new AuthorizationPolicyBuilder()
+            .RequireAuthenticatedUser()
+            .Build());
+}
 
 // Register Redis client for Aspire-managed Orleans
 builder.AddKeyedRedisClient("orleans-redis");
@@ -111,7 +131,11 @@ app.UseExceptionHandler();
 if (rateLimitConfig is not null)
     app.UseRateLimiter();
 
-app.UseAuthorization();
+if (authEnabled)
+{
+    app.UseAuthentication();
+    app.UseAuthorization();
+}
 
 app.MapControllers();
 app.MapDefaultEndpoints();

--- a/src/Fleans/Fleans.Api/appsettings.json
+++ b/src/Fleans/Fleans.Api/appsettings.json
@@ -6,4 +6,13 @@
     }
   },
   "AllowedHosts": "*"
+
+  // Uncomment to enable JWT bearer authentication (OIDC/OAuth 2.0).
+  // When Authentication:Authority is absent, the API runs unauthenticated.
+  //
+  // "Authentication": {
+  //   "Authority": "https://your-idp.example.com/realms/fleans",
+  //   "Audience": "fleans-api",
+  //   "RequireHttpsMetadata": true
+  // }
 }

--- a/src/Fleans/Fleans.ServiceDefaults/Extensions.cs
+++ b/src/Fleans/Fleans.ServiceDefaults/Extensions.cs
@@ -104,13 +104,14 @@ namespace Microsoft.Extensions.Hosting
         public static WebApplication MapDefaultEndpoints(this WebApplication app)
         {
             // All health checks must pass for app to be considered ready to accept traffic after starting
-            app.MapHealthChecks("/health");
+            // AllowAnonymous ensures health probes work even when JWT auth is enabled
+            app.MapHealthChecks("/health").AllowAnonymous();
 
             // Only health checks tagged with the "live" tag must pass for app to be considered alive
             app.MapHealthChecks("/alive", new HealthCheckOptions
             {
                 Predicate = r => r.Tags.Contains("live")
-            });
+            }).AllowAnonymous();
 
             return app;
         }

--- a/tests/manual/28-api-auth/test-plan.md
+++ b/tests/manual/28-api-auth/test-plan.md
@@ -1,0 +1,124 @@
+# API JWT Authentication — Manual Test Plan
+
+## Scenario
+
+Verify that JWT bearer authentication is opt-in and works correctly when configured.
+
+## Prerequisites
+
+- Aspire stack running: `dotnet run --project Fleans.Aspire` (from `src/Fleans/`)
+- For **Scenario A** (no auth): default `appsettings.json` with no `Authentication` section
+- For **Scenario B** (auth enabled): a running OIDC provider (e.g., Keycloak) with a realm/client configured for `fleans-api`
+
+---
+
+## Scenario A — Authentication disabled (default)
+
+Verify the API works exactly as before when no `Authentication:Authority` is configured.
+
+### Steps
+
+1. Start the Aspire stack with default configuration (no `Authentication` section in appsettings).
+
+2. **Health endpoints are accessible:**
+   ```bash
+   curl -k https://localhost:7140/health
+   curl -k https://localhost:7140/alive
+   ```
+
+3. **API endpoints work without a token:**
+   ```bash
+   curl -k -X POST https://localhost:7140/Workflow/start \
+     -H "Content-Type: application/json" \
+     -d '{"WorkflowId":"nonexistent"}'
+   ```
+   Expected: returns a response (error about missing workflow is fine — the point is no 401).
+
+### Expected outcomes
+
+- [ ] `GET /health` returns 200 Healthy
+- [ ] `GET /alive` returns 200 Healthy
+- [ ] `POST /Workflow/start` does NOT return 401 Unauthorized
+- [ ] No authentication/authorization middleware errors in logs
+
+---
+
+## Scenario B — Authentication enabled
+
+Verify the API enforces JWT bearer tokens when `Authentication:Authority` is configured.
+
+### Prerequisites for Scenario B
+
+Set up an OIDC provider (e.g., Keycloak dev instance):
+
+```bash
+docker run -p 8080:8080 -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin quay.io/keycloak/keycloak:latest start-dev
+```
+
+1. Create a realm (e.g., `fleans`)
+2. Create a client `fleans-api` with client authentication enabled
+3. Note the client secret
+
+Configure `appsettings.json` (or environment variables):
+
+```json
+{
+  "Authentication": {
+    "Authority": "http://localhost:8080/realms/fleans",
+    "Audience": "fleans-api",
+    "RequireHttpsMetadata": false
+  }
+}
+```
+
+### Steps
+
+1. Start the Aspire stack with the authentication configuration above.
+
+2. **Health endpoints still accessible without a token:**
+   ```bash
+   curl -k https://localhost:7140/health
+   curl -k https://localhost:7140/alive
+   ```
+
+3. **API endpoints reject unauthenticated requests:**
+   ```bash
+   curl -k -X POST https://localhost:7140/Workflow/start \
+     -H "Content-Type: application/json" \
+     -d '{"WorkflowId":"test"}'
+   ```
+   Expected: 401 Unauthorized.
+
+4. **Obtain a token and make an authenticated request:**
+   ```bash
+   TOKEN=$(curl -s -X POST http://localhost:8080/realms/fleans/protocol/openid-connect/token \
+     -d "grant_type=client_credentials" \
+     -d "client_id=fleans-api" \
+     -d "client_secret=YOUR_SECRET" | jq -r '.access_token')
+
+   curl -k -X POST https://localhost:7140/Workflow/start \
+     -H "Content-Type: application/json" \
+     -H "Authorization: Bearer $TOKEN" \
+     -d '{"WorkflowId":"test"}'
+   ```
+   Expected: request is processed (no 401).
+
+5. **Expired/invalid token is rejected:**
+   ```bash
+   curl -k -X POST https://localhost:7140/Workflow/start \
+     -H "Content-Type: application/json" \
+     -H "Authorization: Bearer invalid-token-here" \
+     -d '{"WorkflowId":"test"}'
+   ```
+   Expected: 401 Unauthorized.
+
+### Expected outcomes
+
+- [ ] `GET /health` returns 200 without a token
+- [ ] `GET /alive` returns 200 without a token
+- [ ] `POST /Workflow/start` without token returns 401
+- [ ] `POST /Workflow/start` with valid token does NOT return 401
+- [ ] `POST /Workflow/start` with invalid token returns 401
+- [ ] `POST /Workflow/deploy` without token returns 401
+- [ ] `POST /Workflow/message` without token returns 401
+- [ ] `POST /Workflow/signal` without token returns 401

--- a/website/src/content/docs/reference/api.md
+++ b/website/src/content/docs/reference/api.md
@@ -248,3 +248,74 @@ RateLimiting__Polling__PermitLimit=10000
 ```
 
 > **Important:** Either configure all five policies or leave the `RateLimiting` section absent entirely. A partial configuration will cause HTTP 500 errors on endpoints whose policy is not registered.
+
+### Authentication
+
+The API supports **opt-in JWT bearer authentication** via any OIDC-compliant identity provider (Keycloak, Auth0, Entra ID, etc.). When no `Authentication:Authority` is configured, the API runs fully unauthenticated — identical to previous behavior.
+
+**Why opt-in?** Local development and single-tenant deployments often don't need auth. Production multi-tenant deployments need it. By making it configuration-driven, the same binary serves both scenarios.
+
+#### Enabling authentication
+
+Add the `Authentication` section to your `appsettings.json` (or use environment variables):
+
+```json
+{
+  "Authentication": {
+    "Authority": "https://your-idp.example.com/realms/fleans",
+    "Audience": "fleans-api",
+    "RequireHttpsMetadata": true
+  }
+}
+```
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `Authority` | Yes (to enable auth) | *(absent — auth disabled)* | OIDC issuer URL. When set, all API endpoints require a valid JWT. |
+| `Audience` | No | `fleans-api` | Expected `aud` claim in the JWT. |
+| `RequireHttpsMetadata` | No | `true` | Set to `false` only for local dev with an HTTP-only IdP (e.g., Keycloak dev mode). |
+
+#### Environment variable overrides
+
+```bash
+Authentication__Authority=https://your-idp.example.com/realms/fleans
+Authentication__Audience=fleans-api
+Authentication__RequireHttpsMetadata=false
+```
+
+#### Behavior when enabled
+
+- **All API endpoints** (`/Workflow/*`) require a valid `Authorization: Bearer <token>` header. Unauthenticated requests receive `401 Unauthorized`.
+- **Health endpoints** (`/health`, `/alive`) remain unauthenticated — they are exempt so that load balancers and orchestrators can probe without credentials.
+- **Swagger UI** remains accessible in development mode for testing.
+
+#### Best-practice example: Keycloak
+
+```bash
+# 1. Start Keycloak dev instance
+docker run -p 8080:8080 \
+  -e KC_BOOTSTRAP_ADMIN_USERNAME=admin \
+  -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin \
+  quay.io/keycloak/keycloak:latest start-dev
+
+# 2. Create realm "fleans", client "fleans-api" with client credentials grant
+
+# 3. Configure Fleans
+#    appsettings.json:
+#    "Authentication": {
+#      "Authority": "http://localhost:8080/realms/fleans",
+#      "Audience": "fleans-api",
+#      "RequireHttpsMetadata": false
+#    }
+
+# 4. Obtain a token and call the API
+TOKEN=$(curl -s -X POST http://localhost:8080/realms/fleans/protocol/openid-connect/token \
+  -d "grant_type=client_credentials" \
+  -d "client_id=fleans-api" \
+  -d "client_secret=YOUR_SECRET" | jq -r '.access_token')
+
+curl -X POST https://localhost:7140/Workflow/deploy \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"BpmnXml":"..."}'
+```


### PR DESCRIPTION
## Summary
- Add opt-in JWT bearer authentication to `Fleans.Api` via `Authentication:Authority` config key (#341)
- When `Authentication:Authority` is absent (default), API runs fully unauthenticated — zero behavior change
- When configured, all `/Workflow/*` endpoints require a valid `Authorization: Bearer <token>` header (401 otherwise)
- Health endpoints (`/health`, `/alive`) are exempt via `AllowAnonymous()` so load balancers/orchestrators can probe without credentials

## Changes
- `Fleans.Api.csproj` — add `Microsoft.AspNetCore.Authentication.JwtBearer` package
- `Program.cs` — conditional auth/authz service registration and middleware (authentication + authorization only wired when `Authentication:Authority` is set)
- `Extensions.cs` (ServiceDefaults) — `.AllowAnonymous()` on health check endpoint mappings
- `appsettings.json` — commented-out `Authentication` section as documentation
- `website/src/content/docs/reference/api.md` — authentication section with config table and Keycloak example
- `tests/manual/28-api-auth/test-plan.md` — manual test plan covering both auth-disabled and auth-enabled scenarios
- `CLAUDE.md` — regression test entry #31

## Test plan
- [x] `dotnet build` passes (0 errors)
- [x] `dotnet test` passes (930 tests, 0 failures)
- [ ] Manual: Scenario A (no auth config) — all endpoints work without tokens
- [ ] Manual: Scenario B (auth enabled) — unauthenticated requests get 401, valid tokens accepted, health endpoints remain open

Closes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)