### PR TITLE
feat(infra): Aspire Docker compose publisher for load testing (#237)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -414,3 +414,6 @@ FodyWeavers.xsd
 
 # Launch settings (developer-local)
 **/Properties/launchSettings.json
+
+# Aspire Docker compose publisher output
+tests/load/generated/

--- a/src/Fleans/Fleans.Aspire/Fleans.Aspire.csproj
+++ b/src/Fleans/Fleans.Aspire/Fleans.Aspire.csproj
@@ -13,10 +13,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.1.1" />
-    <PackageReference Include="Aspire.Hosting.Orleans" Version="13.1.1" />
-    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.1.1" />
-    <PackageReference Include="Aspire.Hosting.Redis" Version="13.1.1" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.2.3" />
+    <PackageReference Include="Aspire.Hosting.Docker" Version="13.2.3" />
+    <PackageReference Include="Aspire.Hosting.Orleans" Version="13.2.3" />
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.2.3" />
+    <PackageReference Include="Aspire.Hosting.Redis" Version="13.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Fleans/Fleans.Aspire/Program.cs
+++ b/src/Fleans/Fleans.Aspire/Program.cs
@@ -76,5 +76,19 @@ WithPersistence(
         .WithReplicas(1),
     usePostgres, pg, sqliteConnectionString);
 
+// Load-testing topology: 2 silo replicas behind nginx, forced Postgres.
+// Activated by: dotnet run --project Fleans.Aspire -- --publisher docker-compose --output-path <dir>
+if (builder.ExecutionContext.IsPublishMode)
+{
+    apiProject = apiProject
+        .WithHttpEndpoint(port: 8080, name: "http")
+        .WithReplicas(2);
+
+    builder.AddContainer("nginx", "nginx:1.27")
+        .WithBindMount("../../tests/load/nginx.conf", "/etc/nginx/nginx.conf", isReadOnly: true)
+        .WithHttpEndpoint(port: 80, targetPort: 80, name: "http")
+        .WaitFor(apiProject);
+}
+
 using var app = builder.Build();
 await app.RunAsync();

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -5,7 +5,7 @@ k6 load test suite for the Fleans workflow engine.
 ## Prerequisites
 
 - [k6](https://k6.io/docs/get-started/installation/) installed
-- Fleans cluster running (see `docker-compose` in issue #237, or Aspire for local dev)
+- Fleans cluster running (see [Docker Compose setup](#docker-compose-setup) below, or Aspire for local dev)
 - All 3 BPMN fixtures deployed (run `setup.js` first)
 
 ## Scripts
@@ -29,6 +29,40 @@ k6 load test suite for the Fleans workflow engine.
 | `fixtures/linear-workflow.bpmn` | `load-linear` | Simple start → script → end |
 | `fixtures/parallel-workflow.bpmn` | `load-parallel` | Parallel gateway fork/join |
 | `fixtures/events-workflow.bpmn` | `load-events` | Timer + message events |
+
+## Docker Compose Setup
+
+The load-testing Docker stack is generated from the Aspire AppHost using the Docker compose publisher. No hand-written Dockerfiles or compose files.
+
+### Generate
+
+```bash
+dotnet run --project src/Fleans/Fleans.Aspire -- --publisher docker-compose --output-path tests/load/generated
+```
+
+### Start
+
+```bash
+cd tests/load/generated && docker compose up -d
+```
+
+### Verify
+
+```bash
+# Health check — should return 400 (no workflow deployed)
+curl -X POST http://localhost:80/Workflow/start -d '{"WorkflowId":"nonexistent"}' -H "Content-Type: application/json"
+
+# Check all services are running
+docker compose ps
+```
+
+### Teardown
+
+```bash
+docker compose down -v
+```
+
+The generated artifacts are gitignored (`tests/load/generated/`). The AppHost is the single source of truth.
 
 ## Running
 

--- a/tests/load/nginx.conf
+++ b/tests/load/nginx.conf
@@ -1,0 +1,18 @@
+resolver 127.0.0.11 valid=5s;
+
+upstream fleans_api {
+    server fleans-core:8080;
+}
+
+server {
+    listen 80;
+
+    location / {
+        proxy_pass         http://fleans_api;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_read_timeout 120s;
+    }
+}

--- a/tests/manual/27-load-testing-infra/test-plan.md
+++ b/tests/manual/27-load-testing-infra/test-plan.md
@@ -1,0 +1,87 @@
+# Load Testing Infrastructure — Manual Test Plan
+
+## Scenario
+
+Verify the Aspire Docker compose publisher generates a working multi-silo cluster with nginx load balancer.
+
+## Prerequisites
+
+- .NET SDK installed
+- Docker Desktop running
+- k6 installed (for load test scripts)
+
+## Steps
+
+### 1. Generate Docker Compose stack
+
+```bash
+dotnet run --project src/Fleans/Fleans.Aspire -- --publisher docker-compose --output-path tests/load/generated
+```
+
+**Expected:** `tests/load/generated/` contains `docker-compose.yml` and per-project Dockerfiles.
+
+### 2. Start the stack
+
+```bash
+cd tests/load/generated && docker compose up -d
+```
+
+**Expected:** All services start (redis, postgres, 2x fleans-core replicas, nginx).
+
+### 3. Verify services are healthy
+
+```bash
+docker compose ps
+```
+
+**Expected:** All containers show `Up` / `healthy` status.
+
+### 4. Test API endpoint via nginx
+
+```bash
+curl -X POST http://localhost:80/Workflow/start \
+  -H "Content-Type: application/json" \
+  -d '{"WorkflowId":"nonexistent"}'
+```
+
+**Expected:** HTTP 400 response (workflow not deployed, but proves nginx -> silo connectivity).
+
+### 5. Verify round-robin load balancing
+
+Send 4 requests and check logs:
+
+```bash
+for i in 1 2 3 4; do
+  curl -s -o /dev/null -w "%{http_code}\n" -X POST http://localhost:80/Workflow/start \
+    -H "Content-Type: application/json" \
+    -d '{"WorkflowId":"nonexistent"}'
+done
+docker compose logs fleans-core 2>&1 | grep -c "POST" | head -1
+```
+
+**Expected:** Both replicas show request logs (round-robin distribution).
+
+### 6. Teardown
+
+```bash
+docker compose down -v
+```
+
+**Expected:** All containers stopped and removed.
+
+### 7. Dev path unchanged
+
+```bash
+cd src/Fleans && dotnet run --project Fleans.Aspire
+```
+
+**Expected:** Single silo starts normally via Aspire (no nginx, no replicas). Dashboard accessible.
+
+## Checklist
+
+- [ ] Docker compose stack generates from Aspire AppHost
+- [ ] All services start and reach healthy state
+- [ ] nginx proxies to fleans-core replicas
+- [ ] API returns expected responses through nginx
+- [ ] Both replicas receive traffic
+- [ ] Dev path (`dotnet run --project Fleans.Aspire`) still works


### PR DESCRIPTION
## Summary

Closes #237

Replaces PR #322's hand-written Docker stack with Aspire 13.2's Docker compose publisher. The AppHost becomes the single source of truth for the multi-silo load-testing topology, eliminating the FLEANS_STANDALONE divergence.

## Changes

- **Aspire packages:** 13.1.1 -> 13.2.3, added `Aspire.Hosting.Docker`
- **AppHost (`Program.cs`):** `IsPublishMode` block adds 2 silo replicas, nginx LB, explicit port 8080
- **nginx.conf:** Created with Docker Compose DNS (`resolver 127.0.0.11`, `server fleans-core:8080`)
- **README:** Added Docker compose setup section (generate, start, verify, teardown)
- **Manual test plan:** `tests/manual/27-load-testing-infra/test-plan.md`
- **.gitignore:** Added `tests/load/generated/`

## How to test

1. `dotnet run --project src/Fleans/Fleans.Aspire -- --publisher docker-compose --output-path tests/load/generated`
2. `cd tests/load/generated && docker compose up -d`
3. `curl -X POST http://localhost:80/Workflow/start -d '{"WorkflowId":"nonexistent"}'` -> 400
4. Dev path: `dotnet run --project src/Fleans/Fleans.Aspire` still works (single silo, no nginx)

## Note

This PR supersedes PR #322 (hand-written Docker stack). #322 can be closed after this merges.

Generated with [Claude Code](https://claude.com/claude-code)