### PR TITLE
docs(quick-start): show expected output at each step (#295)

### DIFF
--- a/website/src/content/docs/guides/quick-start.md
+++ b/website/src/content/docs/guides/quick-start.md
@@ -19,6 +19,20 @@ dotnet run --project Fleans.Aspire
 Aspire launches the API, Blazor admin UI, and Redis. Open the Aspire dashboard URL from the console
 to find the Web app.
 
+:::note[Expected output]
+Aspire prints (among other startup logs) a dashboard URL like:
+
+```
+Login to the dashboard at https://localhost:<port>/login?t=<token>
+```
+
+Both `<port>` (default `15888` unless overridden by `ASPNETCORE_URLS` or your
+`launchSettings.json`) and `<token>` (a fresh per-boot value) will differ
+run-to-run — use whatever the console prints. Open that URL to reach the
+Aspire dashboard, from which you can click through to the `Fleans.Web`
+service (the Admin UI).
+:::
+
 ## Deploy a workflow
 
 Fleans deploys workflows through the **Admin UI** (Blazor editor), not via a REST endpoint.
@@ -40,6 +54,11 @@ that sets a `greeting` variable.
 
 Download the file, open the Editor, import it, and click **Deploy**.
 
+After clicking **Deploy**, the Editor shows a green success message bar reading
+`Deployed 'my-process' v1 (N activities, M flows)`, the breadcrumb displays the
+process key, and an accent-colored `v1` badge appears next to it. Deploying
+again would produce `v2`, and so on.
+
 :::note
 Script tasks execute automatically — no external `complete-activity` call is needed.
 The engine runs the C# script inline and advances the workflow to the next element.
@@ -55,6 +74,19 @@ curl -X POST https://localhost:7140/Workflow/start \
   -d '{"WorkflowId":"my-process"}'
 ```
 
+:::note[Expected output]
+HTTP `200` with a JSON body like:
+
+```json
+{"workflowInstanceId":"<guid>"}
+```
+
+The `<guid>` is new for every run.
+:::
+
 Because `my-process` contains only a script task, the instance runs to completion
-immediately. You can verify the result in the Admin UI — the instance will show
-a `greeting` variable with the value `"Hello from Fleans!"`.
+immediately. You can verify the result in the Admin UI. From the **Workflows**
+page, click the `my-process` row — this opens the process-instances list for
+that definition (route: `/process-instances/my-process/1`). The instance you
+just started appears there as `Completed`, and opening it shows the variables
+panel containing `greeting = "Hello from Fleans!"`.


### PR DESCRIPTION
## Summary

Adds verification cues to `website/src/content/docs/guides/quick-start.md` so readers can confirm each of the three existing steps worked — without expanding the Quick Start into a longer walkthrough.

Closes #295.

## What changed

- **After `dotnet run --project Fleans.Aspire`** — new `:::note[Expected output]` callout showing the Aspire dashboard URL template (`https://localhost:<port>/login?t=<token>`) with one line explaining that both `<port>` (default `15888`) and `<token>` vary per boot.
- **Inside "Deploy a workflow"** — a short prose paragraph added between the "Download … click Deploy" sentence and the existing `:::note` about script tasks. It describes the Editor's success feedback (green message bar reading `Deployed 'my-process' v1 (N activities, M flows)`, breadcrumb with process key, `v1` badge). Prose rather than a callout because the UI has no plain-text stream to quote.
- **After the `curl start` block** — new `:::note[Expected output]` callout showing `{"workflowInstanceId":"<guid>"}`.
- **Rewrote the closing Admin-UI verification sentence** — it previously sent readers to the Workflows page and implied the instance would be visible there, but `/workflows` lists definitions, not instances. Now it walks the actual click-through: Workflows page → click `my-process` → `/process-instances/my-process/1` → instance shows `Completed`, variables panel contains `greeting = "Hello from Fleans!"`.

## Design decisions

Followed the approved v3 design & plan on #295:

- Callouts for predictable text streams (console line, JSON body); prose for UI feedback that doesn't copy-paste.
- `<port>`, `<token>`, `<guid>` as explicit placeholders for volatile values.
- No new 4th step, no new curl — Quick Start stays a three-section path.

## How to test

```bash
cd website && npm install && npm run build  # passes
```

Or preview locally: `cd website && npm run dev`, open `/fleans/guides/quick-start/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)