### PR TITLE
fix: correct license name in website footer

### DIFF
--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -6,7 +6,7 @@ import Default from '@astrojs/starlight/components/Footer.astro';
 
 <footer class="fleans-footer">
   <div class="fleans-footer-inner">
-    <span>&copy; 2024&ndash;2026 Fleans Contributors &middot; <a href="https://github.com/nightBaker/fleans/blob/main/LICENSE">MIT License</a></span>
+    <span>&copy; 2024&ndash;2026 Fleans Contributors &middot; <a href="https://github.com/nightBaker/fleans/blob/main/LICENSE">PolyForm Noncommercial 1.0.0</a></span>
     <span><a href="https://github.com/nightBaker/fleans">GitHub</a></span>
   </div>
 </footer>


### PR DESCRIPTION
## Summary

Closes #368

- Updated `website/src/components/Footer.astro` to display "PolyForm Noncommercial 1.0.0" instead of "MIT License"
- The actual license (`LICENSE` file) is PolyForm Noncommercial 1.0.0 — the footer text was incorrect
- Audited `concepts/architecture.md` and `reference/api.md` — no other MIT references found

## Test plan

- [x] `cd website && npm run build` passes
- [ ] Visual check: footer text reads correctly in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)