### PR TITLE
feat(web): opt-in OIDC authentication for Management UI (#370)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,7 @@ The full regression suite is the union of every plan under `tests/manual/`. Each
 31. **API JWT Authentication** — `tests/manual/28-api-auth/test-plan.md`. Opt-in JWT bearer authentication; verifies API works unauthenticated by default, returns 401 when auth is configured and no token is provided, and accepts valid tokens.
 32. **Conditional Events** — `tests/manual/24-conditional-event/test-plan.md` (`conditional-event-test.bpmn`). Conditional intermediate catch event blocks until condition is true; conditional start event creates instances via evaluate-conditions API; conditional boundary event (interrupting) cancels host.
 33. **Editor Tabs** — `tests/manual/29-editor-tabs/test-plan.md`. Multi-tab BPMN editor in the Admin UI: open/switch/close tabs, dirty tracking with confirm-close dialog, 10-tab cap, `localStorage` persistence across refresh, `beforeunload` warning when any tab is dirty.
+34. **Management UI Authentication** — `tests/manual/30-web-auth/test-plan.md`. Opt-in OIDC for the Blazor Server admin UI; verifies (a) anonymous browse is allowed when no `Authentication` config is present, (b) `/dashboard` and any cascading-`AuthorizeView` page return 302 → IdP when auth is enabled, (c) login round-trip lands on the requested page (including `?query` parameters), (d) `/Account/Logout` is antiforgery-protected (bare POST is rejected, form-bound POST signs out and clears both schemes).
 
 > When adding a new manual test folder under `tests/manual/`, append a numbered entry here so the regression skill picks it up.
 

--- a/src/Fleans/Fleans.Aspire/Program.cs
+++ b/src/Fleans/Fleans.Aspire/Program.cs
@@ -10,6 +10,14 @@ var usePostgres = persistenceProvider.Equals("Postgres", StringComparison.Ordina
 // provider doesn't negotiate TLS. Disable to avoid health check failures (dotnet/aspire#13612).
 var redis = builder.AddRedis("orleans-redis").WithoutHttpsCertificate();
 
+// Authentication parameters (D2a) — declared unconditionally with empty defaults so the
+// AppHost contract is stable. When the operator does not supply values at run-time, the
+// downstream Web project sees empty strings for Authority/ClientId and falls into
+// auth-disabled mode (single source of truth lives in Fleans.Web/Program.cs).
+var authAuthority = builder.AddParameter("auth-authority", () => "");
+var authClientId = builder.AddParameter("auth-client-id", () => "");
+var authClientSecret = builder.AddParameter("auth-client-secret", () => "", secret: true);
+
 // Centralized Orleans configuration
 var orleans = builder.AddOrleans("cluster")
     .WithClustering(redis)
@@ -64,6 +72,9 @@ WithPersistence(
     builder.AddProject<Projects.Fleans_Web>("fleans-management")
         .WithReference(orleans.AsClient())
         .WaitFor(fleansSilo)
+        .WithEnvironment("Authentication__Authority", authAuthority)
+        .WithEnvironment("Authentication__ClientId", authClientId)
+        .WithEnvironment("Authentication__ClientSecret", authClientSecret)
         .WithReplicas(1),
     usePostgres, pg, sqliteConnectionString);
 

--- a/src/Fleans/Fleans.Web/Components/Layout/NavMenu.razor
+++ b/src/Fleans/Fleans.Web/Components/Layout/NavMenu.razor
@@ -1,3 +1,5 @@
+@using Microsoft.AspNetCore.Components.Forms
+
 <div class="navmenu">
     <FluentAppBar>
         <FluentAppBarItem Href="/workflows"
@@ -9,4 +11,15 @@
                           IconRest="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size24.DrawShape())"
                           IconActive="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Filled.Size24.DrawShape())" />
     </FluentAppBar>
+    <AuthorizeView>
+        <Authorized>
+            <div class="nav-user">
+                <span class="nav-user-name">Signed in as @context.User.Identity?.Name</span>
+                <form action="/Account/Logout" method="post" class="nav-user-logout">
+                    <AntiforgeryToken />
+                    <FluentButton Type="ButtonType.Submit" Appearance="Appearance.Stealth">Sign out</FluentButton>
+                </form>
+            </div>
+        </Authorized>
+    </AuthorizeView>
 </div>

--- a/src/Fleans/Fleans.Web/Components/Routes.razor
+++ b/src/Fleans/Fleans.Web/Components/Routes.razor
@@ -1,6 +1,26 @@
-﻿<Router AppAssembly="typeof(Program).Assembly" NotFoundPage="typeof(Pages.NotFound)">
-    <Found Context="routeData">
-        <RouteView RouteData="routeData" DefaultLayout="typeof(Layout.MainLayout)"/>
-        <FocusOnNavigate RouteData="routeData" Selector="h1"/>
-    </Found>
-</Router>
+@using Microsoft.AspNetCore.Components.Authorization
+@using Fleans.Web.Security
+@inject AuthOptions AuthOptions
+
+@if (AuthOptions.Enabled)
+{
+    <Router AppAssembly="typeof(Program).Assembly" NotFoundPage="typeof(Pages.NotFound)">
+        <Found Context="routeData">
+            <AuthorizeRouteView RouteData="routeData" DefaultLayout="typeof(Layout.MainLayout)">
+                <NotAuthorized>
+                    <RedirectToLogin />
+                </NotAuthorized>
+            </AuthorizeRouteView>
+            <FocusOnNavigate RouteData="routeData" Selector="h1" />
+        </Found>
+    </Router>
+}
+else
+{
+    <Router AppAssembly="typeof(Program).Assembly" NotFoundPage="typeof(Pages.NotFound)">
+        <Found Context="routeData">
+            <RouteView RouteData="routeData" DefaultLayout="typeof(Layout.MainLayout)" />
+            <FocusOnNavigate RouteData="routeData" Selector="h1" />
+        </Found>
+    </Router>
+}

--- a/src/Fleans/Fleans.Web/Components/_Imports.razor
+++ b/src/Fleans/Fleans.Web/Components/_Imports.razor
@@ -8,7 +8,10 @@
 @using Microsoft.JSInterop
 @using Microsoft.FluentUI.AspNetCore.Components
 @using Microsoft.FluentUI.AspNetCore.Components.Icons
+@using Microsoft.AspNetCore.Components.Authorization
+@using Microsoft.AspNetCore.Authorization
 @using Fleans.Web
 @using Fleans.Web.Components
 @using Fleans.Web.Components.Layout
 @using Fleans.Web.Components.Shared
+@using Fleans.Web.Security

--- a/src/Fleans/Fleans.Web/Fleans.Web.csproj
+++ b/src/Fleans/Fleans.Web/Fleans.Web.csproj
@@ -18,6 +18,9 @@
 
     <ItemGroup>
       <PackageReference Include="Aspire.StackExchange.Redis" Version="13.1.1" />
+      <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.0" />
+      <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.0" />
+      <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="10.0.0" />
       <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.14.0" />
       <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Emoji" Version="4.14.0" />
       <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.14.0" />

--- a/src/Fleans/Fleans.Web/Program.cs
+++ b/src/Fleans/Fleans.Web/Program.cs
@@ -1,12 +1,24 @@
+using System.Net;
 using Fleans.Application;
 using Fleans.Infrastructure;
 using Fleans.Persistence.PostgreSql;
 using Fleans.Persistence.Sqlite;
 using Fleans.ServiceDefaults;
 using Fleans.Web.Components;
+using Fleans.Web.Security;
 using Fleans.Web.Services;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.DataProtection.KeyManagement;
+using Microsoft.AspNetCore.DataProtection.StackExchangeRedis;
+using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.Extensions.Options;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Orleans.Dashboard;
+using StackExchange.Redis;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -37,6 +49,74 @@ builder.UseOrleansClient(clientBuilder =>
     clientBuilder.AddDashboard();
 });
 
+// Authentication — opt-in: only enabled when both Authority and ClientId are configured.
+// Single source of truth (D2a). Mirrors Fleans.Api's Authentication section name so the
+// same Aspire parameter block can configure both services against the same IdP.
+var authAuthority = builder.Configuration["Authentication:Authority"];
+var authClientId = builder.Configuration["Authentication:ClientId"];
+var authEnabled = !string.IsNullOrEmpty(authAuthority) && !string.IsNullOrEmpty(authClientId);
+
+builder.Services.AddSingleton(new AuthOptions(authEnabled, authAuthority ?? "", authClientId ?? ""));
+
+if (authEnabled)
+{
+    var cookieMinutes = builder.Configuration.GetValue("Authentication:CookieExpireMinutes", 60);
+
+    builder.Services
+        .AddAuthentication(o =>
+        {
+            o.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+            o.DefaultChallengeScheme = OpenIdConnectDefaults.AuthenticationScheme;
+        })
+        .AddCookie(o =>
+        {
+            o.ExpireTimeSpan = TimeSpan.FromMinutes(cookieMinutes);
+            o.SlidingExpiration = true;
+            o.Cookie.SameSite = SameSiteMode.Lax;
+            o.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+        })
+        .AddOpenIdConnect(o =>
+        {
+            o.Authority = authAuthority;
+            o.ClientId = authClientId;
+            o.ClientSecret = builder.Configuration["Authentication:ClientSecret"];
+            o.ResponseType = "code";
+            o.UsePkce = true;
+            // Slice 3 has no API-token consumer; future slices flip together with refresh wiring (D13).
+            o.SaveTokens = false;
+            // Keycloak omits email/name from the ID token in default config — backfill from UserInfo.
+            o.GetClaimsFromUserInfoEndpoint = true;
+            o.RequireHttpsMetadata = builder.Configuration.GetValue("Authentication:RequireHttpsMetadata", true);
+            o.Scope.Add("openid");
+            o.Scope.Add("profile");
+            o.Scope.Add("email");
+            o.TokenValidationParameters.NameClaimType = "preferred_username";
+            // Prepares the deferred role-policy slice — claim is harmless when absent.
+            o.TokenValidationParameters.RoleClaimType = "roles";
+        });
+
+    builder.Services.AddAuthorizationBuilder()
+        .SetFallbackPolicy(new AuthorizationPolicyBuilder()
+            .RequireAuthenticatedUser()
+            .Build());
+
+    // Multi-instance support: persist Data Protection keys to the keyed orleans-redis multiplexer
+    // so cookies issued by replica A decrypt on replica B (D10). Configured via
+    // KeyManagementOptions because PersistKeysToStackExchangeRedis lacks an
+    // IServiceProvider-aware overload for keyed Redis resolution.
+    builder.Services.AddDataProtection().SetApplicationName("Fleans.Web");
+    builder.Services.AddOptions<KeyManagementOptions>()
+        .Configure<IServiceProvider>((opts, sp) =>
+        {
+            var multiplexer = sp.GetRequiredKeyedService<IConnectionMultiplexer>("orleans-redis");
+            opts.XmlRepository = new RedisXmlRepository(
+                () => multiplexer.GetDatabase(),
+                "fleans-web-dataprotection-keys");
+        });
+}
+
+builder.Services.AddCascadingAuthenticationState();
+
 var app = builder.Build();
 
 await app.EnsureDatabaseSchemaAsync();
@@ -49,17 +129,85 @@ if (!app.Environment.IsDevelopment())
     app.UseHsts();
 }
 
+if (authEnabled)
+{
+    // D12 — Forwarded headers for reverse-proxy deployments. Empty allowlists = headers ignored
+    // (avoids spoofing from untrusted networks). CIDR strings parsed by System.Net.IPNetwork
+    // (the canonical .NET 8+ type; Microsoft.AspNetCore.HttpOverrides.IPNetwork is deprecated).
+    var fwdOptions = new ForwardedHeadersOptions
+    {
+        ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
+    };
+    foreach (var ip in builder.Configuration.GetSection("Authentication:KnownProxies").Get<string[]>() ?? [])
+    {
+        fwdOptions.KnownProxies.Add(IPAddress.Parse(ip));
+    }
+    foreach (var net in builder.Configuration.GetSection("Authentication:KnownNetworks").Get<string[]>() ?? [])
+    {
+        fwdOptions.KnownIPNetworks.Add(System.Net.IPNetwork.Parse(net));
+    }
+    app.UseForwardedHeaders(fwdOptions);
+}
+
 app.UseStatusCodePagesWithReExecute("/not-found", createScopeForStatusCodePages: true);
 app.UseHttpsRedirection();
 
 app.UseAntiforgery();
 
+if (authEnabled)
+{
+    app.UseAuthentication();
+    app.UseAuthorization();
+}
+
 app.MapStaticAssets();
 app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();
+
+if (authEnabled)
+{
+    // D6 — Login challenge (anonymous, externally reachable).
+    app.MapGet("/Account/Login", (string? returnUrl, HttpContext ctx) =>
+    {
+        var safe = IsLocalUrl(returnUrl) ? returnUrl! : "/";
+        return Results.Challenge(
+            new AuthenticationProperties { RedirectUri = safe },
+            [OpenIdConnectDefaults.AuthenticationScheme]);
+    }).AllowAnonymous();
+
+    // D6 — Logout (antiforgery-protected POST per D8; the NavMenu form binds the token).
+    app.MapPost("/Account/Logout", (HttpContext ctx) =>
+        Results.SignOut(
+            new AuthenticationProperties { RedirectUri = "/" },
+            [CookieAuthenticationDefaults.AuthenticationScheme,
+             OpenIdConnectDefaults.AuthenticationScheme]));
+
+    // D4 — Orleans Dashboard does not honour [Authorize]; gate it explicitly before MapOrleansDashboard.
+    app.UseWhen(
+        ctx => ctx.Request.Path.StartsWithSegments("/dashboard"),
+        branch => branch.Use(async (ctx, next) =>
+        {
+            if (ctx.User.Identity?.IsAuthenticated != true)
+            {
+                await ctx.ChallengeAsync(OpenIdConnectDefaults.AuthenticationScheme);
+                return;
+            }
+            await next();
+        }));
+}
 
 // Orleans Dashboard at /dashboard
 app.MapOrleansDashboard(routePrefix: "/dashboard");
 app.MapDefaultEndpoints();
 
 app.Run();
+
+// D6 — local-URL predicate. Same shape as Microsoft.AspNetCore.Mvc.IUrlHelper.IsLocalUrl,
+// expressed as a free static so the minimal-API delegate compiles without an IUrlHelper dependency.
+// Rejects null/empty, paths without a leading '/', protocol-relative ("//evil.com"), and
+// back-slash-escape ("/\evil.com") shapes. '\\' in source is one backslash character.
+static bool IsLocalUrl(string? url) =>
+    !string.IsNullOrEmpty(url)
+    && url[0] == '/'
+    && (url.Length == 1
+        || (url[1] != '/' && url[1] != '\\'));

--- a/src/Fleans/Fleans.Web/Security/AuthOptions.cs
+++ b/src/Fleans/Fleans.Web/Security/AuthOptions.cs
@@ -1,0 +1,7 @@
+namespace Fleans.Web.Security;
+
+// Singleton record built once at startup from configuration. Razor components inject it
+// to decide whether to render auth-aware UI (cascading auth state, login redirect).
+// Auth is enabled iff both Authority and ClientId are non-empty — the same single
+// source of truth used by Program.cs to gate middleware registration.
+public sealed record AuthOptions(bool Enabled, string Authority, string ClientId);

--- a/src/Fleans/Fleans.Web/Security/RedirectToLogin.razor
+++ b/src/Fleans/Fleans.Web/Security/RedirectToLogin.razor
@@ -1,0 +1,13 @@
+@inject NavigationManager NavigationManager
+
+@code {
+    protected override void OnInitialized()
+    {
+        // ToBaseRelativePath strips origin + base-href, giving e.g. "workflows?filter=active".
+        // Prepending "/" produces a relative path the D6 IsLocalUrl predicate accepts.
+        // EscapeDataString handles any "?" or "&" so a single decode by the model binder restores the original.
+        var relPath = "/" + NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
+        var encoded = Uri.EscapeDataString(relPath);
+        NavigationManager.NavigateTo($"/Account/Login?returnUrl={encoded}", forceLoad: true);
+    }
+}

--- a/src/Fleans/Fleans.Web/appsettings.example.jsonc
+++ b/src/Fleans/Fleans.Web/appsettings.example.jsonc
@@ -1,0 +1,37 @@
+// Documentation only — this file is NOT loaded by the host.
+// Copy the relevant block into appsettings.json (or set the equivalent env vars)
+// to enable OIDC authentication for the Fleans Management UI.
+//
+// Auth is enabled iff Authority AND ClientId are both non-empty (single source of truth).
+// Leaving the section absent (the default) preserves today's open-access behaviour.
+{
+  "Authentication": {
+    // OIDC issuer URL (required to enable auth).
+    "Authority": "https://keycloak.example.com/realms/fleans",
+
+    // OAuth client id (required to enable auth). Must match a confidential client
+    // registered with the IdP.
+    "ClientId": "fleans-web",
+
+    // Confidential-client secret. In dev, prefer `dotnet user-secrets`; in prod,
+    // set via the Aspire `auth-client-secret` parameter (secret: true) or env var
+    // Authentication__ClientSecret. NEVER commit a real secret to source control.
+    "ClientSecret": "<from-IdP>",
+
+    // Optional. Defaults to true. Set to false ONLY for local Keycloak dev mode (HTTP).
+    "RequireHttpsMetadata": true,
+
+    // Optional. Defaults to 60. Cookie expiry for the management UI session.
+    // Align with the IdP's access-token / management-page session lifetime
+    // so admin sessions in the Web UI and tokens used against the API don't drift apart.
+    "CookieExpireMinutes": 60,
+
+    // Optional. List of trusted reverse-proxy IP addresses (D12 — forwarded headers).
+    // Empty list = X-Forwarded-* headers are ignored. Add proxy IPs only if Fleans.Web
+    // sits behind a reverse proxy that terminates TLS.
+    "KnownProxies": [],
+
+    // Optional. List of trusted reverse-proxy CIDR networks (D12). Same gating as above.
+    "KnownNetworks": []
+  }
+}

--- a/tests/manual/30-web-auth/keycloak-dev.md
+++ b/tests/manual/30-web-auth/keycloak-dev.md
@@ -1,0 +1,52 @@
+# Local Keycloak Quickstart
+
+A copy-paste recipe for running a Keycloak dev instance pre-configured with the `fleans` realm + `fleans-web` client used by the manual test plan.
+
+## Run Keycloak with the realm imported
+
+Run from the repository root so the `-v` mount path resolves:
+
+```bash
+docker run -d --name fleans-keycloak \
+  -p 8081:8080 \
+  -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=admin \
+  -v "$(pwd)/tests/manual/30-web-auth/keycloak-fleans-realm.json:/opt/keycloak/data/import/realm.json:ro" \
+  quay.io/keycloak/keycloak:latest start-dev --import-realm
+```
+
+Verify Keycloak is up: `curl -fsS http://localhost:8081/realms/fleans/.well-known/openid-configuration`.
+
+## Configure Fleans.Web user-secrets
+
+```bash
+cd src/Fleans/Fleans.Web
+dotnet user-secrets set "Authentication:Authority"            "http://localhost:8081/realms/fleans"
+dotnet user-secrets set "Authentication:ClientId"             "fleans-web"
+dotnet user-secrets set "Authentication:ClientSecret"         "fleans-web-dev-secret"
+dotnet user-secrets set "Authentication:RequireHttpsMetadata" "false"
+```
+
+(`RequireHttpsMetadata=false` is needed because the dev Keycloak serves HTTP only.)
+
+## Test the round-trip
+
+```bash
+cd src/Fleans
+dotnet run --project Fleans.Aspire
+```
+
+Open `https://localhost:7124` → expect a 302 to `http://localhost:8081/realms/fleans/protocol/openid-connect/auth?...`. Log in as `alice` / `alice`. After the IdP redirects back through `/signin-oidc`, the NavMenu chip reads `Signed in as alice`.
+
+## Sample user
+
+The realm JSON ships one user: `alice` with password `alice`. Add more via the Keycloak admin UI at `http://localhost:8081/admin` (admin / admin).
+
+## Cleanup
+
+```bash
+docker rm -f fleans-keycloak
+```
+
+## Why a confidential client?
+
+Server-side Blazor uses the OIDC Authorization Code flow with PKCE and a client secret — it is the canonical pattern for server-side web apps. The secret is read from configuration (user-secrets in dev, Aspire `auth-client-secret` parameter in prod) and never committed to source control. Public clients are reserved for browser SPAs and mobile apps; they are wrong for a server-side admin UI.

--- a/tests/manual/30-web-auth/keycloak-fleans-realm.json
+++ b/tests/manual/30-web-auth/keycloak-fleans-realm.json
@@ -1,0 +1,53 @@
+{
+  "realm": "fleans",
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": false,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": false,
+  "clients": [
+    {
+      "clientId": "fleans-web",
+      "enabled": true,
+      "publicClient": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "fleans-web-dev-secret",
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "redirectUris": [
+        "https://localhost:7124/signin-oidc"
+      ],
+      "postLogoutRedirectUris": [
+        "https://localhost:7124/signout-callback-oidc",
+        "https://localhost:7124/"
+      ],
+      "webOrigins": [
+        "https://localhost:7124"
+      ],
+      "attributes": {
+        "pkce.code.challenge.method": "S256"
+      }
+    }
+  ],
+  "users": [
+    {
+      "username": "alice",
+      "enabled": true,
+      "email": "alice@example.com",
+      "emailVerified": true,
+      "firstName": "Alice",
+      "lastName": "Anderson",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "alice",
+          "temporary": false
+        }
+      ]
+    }
+  ]
+}

--- a/tests/manual/30-web-auth/test-plan.md
+++ b/tests/manual/30-web-auth/test-plan.md
@@ -1,0 +1,108 @@
+# Management UI Authentication — Manual Test Plan
+
+## Scenario
+
+Verify that opt-in OIDC cookie auth for the `Fleans.Web` Blazor admin UI is configuration-driven: absent config preserves today's open access, while a populated `Authentication` block forces every page (and the Orleans Dashboard) through the configured IdP, surfaces a "Signed in as …" chip with antiforgery-protected logout, and rejects open-redirect attempts on `/Account/Login?returnUrl=…`.
+
+## Prerequisites
+
+- Aspire stack running: `dotnet run --project Fleans.Aspire` (from `src/Fleans/`)
+- For **Scenario 1** (no auth): default `appsettings.json` with no `Authentication` section
+- For **Scenarios 2–6** (auth enabled): a running OIDC provider — see `keycloak-dev.md` for a copy-paste local setup
+- Web UI reachable at `https://localhost:7124`
+
+## Scenario 1 — Auth disabled (default)
+
+Confirms the opt-in default is unchanged.
+
+1. Ensure `appsettings.json` contains no `Authentication` section, and no `Authentication__Authority` / `Authentication__ClientId` env vars or user-secrets are set on `Fleans.Web`.
+2. Launch Aspire and open `https://localhost:7124/workflows`.
+3. **Expect:** the page renders directly (HTTP 200), no redirect to any IdP. The NavMenu shows Workflows + Editor only — no "Signed in as …" chip.
+4. Visit `https://localhost:7124/dashboard` → Orleans Dashboard renders without a redirect.
+5. Visit `https://localhost:7124/health` and `/alive` → both return 200 (anonymous health probes still work).
+
+Checklist:
+- [ ] `/workflows` returns 200 with no redirect
+- [ ] `/dashboard` renders without auth
+- [ ] `/health` and `/alive` return 200
+- [ ] NavMenu has no user/logout chip
+
+## Scenario 2 — Auth enabled, successful login
+
+Confirms the OIDC handshake round-trip and post-login destination preservation.
+
+1. Configure `Fleans.Web` with the secrets listed in `keycloak-dev.md` (user-secrets or env vars).
+2. Launch Aspire and open `https://localhost:7124/workflows?filter=active` in a fresh incognito window.
+3. **Expect:** browser is redirected to `http://localhost:8081/realms/fleans/protocol/openid-connect/auth?...` (the Keycloak login form).
+4. Sign in as `alice` / `alice`.
+5. **Expect:** browser bounces back through `/signin-oidc` and lands on `/workflows?filter=active` (deep-link preserved).
+6. **Expect:** the NavMenu's user chip reads `Signed in as alice` and includes a `Sign out` button.
+7. Open `https://localhost:7124/dashboard` in the same session → Orleans Dashboard loads without an additional login prompt.
+
+Checklist:
+- [ ] Anonymous request to `/workflows?filter=active` returns 302 → IdP
+- [ ] Successful login lands on `/workflows?filter=active` (query string intact)
+- [ ] NavMenu shows `Signed in as alice`
+- [ ] `/dashboard` accessible after login
+
+## Scenario 3 — Orleans Dashboard guard
+
+Confirms the dashboard requires a session even though the underlying middleware ignores `[Authorize]`.
+
+1. With auth enabled, open a fresh incognito window and visit `https://localhost:7124/dashboard`.
+2. **Expect:** HTTP 302 to the IdP login page (NOT 200 with cluster data).
+3. Log in as `alice` and confirm the dashboard renders.
+
+Checklist:
+- [ ] Anonymous `/dashboard` request → 302 to IdP
+- [ ] `/dashboard` renders only after login
+
+## Scenario 4 — Open-redirect guard on `/Account/Login`
+
+Confirms the D6 `IsLocalUrl` predicate rejects every canonical attack input and accepts only well-formed local paths.
+
+For each row, request the URL anonymously and confirm the post-auth `RedirectUri` field of the issued `Set-Cookie` / `Location` header is `/` (or another local path), never the attacker target.
+
+| `?returnUrl=` value | How to send it             | Expected `safe` |
+|---------------------|----------------------------|-----------------|
+| (omitted)           | `/Account/Login`           | `/`             |
+| (empty)             | `/Account/Login?returnUrl=`| `/`             |
+| `/\evil.com`        | `/Account/Login?returnUrl=/%5Cevil.com` | `/`  |
+| `//evil.com`        | `/Account/Login?returnUrl=//evil.com`   | `/`  |
+| `https://evil.com`  | `/Account/Login?returnUrl=https://evil.com` | `/` |
+| ` /workflows`       | `/Account/Login?returnUrl=%20/workflows` | `/`   |
+| `/workflows?filter=active` | `/Account/Login?returnUrl=%2Fworkflows%3Ffilter%3Dactive` | `/workflows?filter=active` |
+
+Checklist:
+- [ ] Every attack-string row redirects to `/` post-auth, not the attacker host
+- [ ] The legitimate deep-link row redirects to `/workflows?filter=active`
+
+## Scenario 5 — Logout via antiforgery-protected POST
+
+Confirms the bare-POST logout is rejected and the form-bound POST signs out cleanly.
+
+1. Logged in as `alice`, open browser devtools → Network.
+2. Run from the URL bar / shell: `curl -X POST https://localhost:7124/Account/Logout -k --cookie "<session cookie>"`.
+3. **Expect:** HTTP 400 (antiforgery rejection) — the bare POST has no token.
+4. In the UI, click the `Sign out` button in the NavMenu.
+5. **Expect:** HTTP 302 → IdP end-session endpoint → callback → `/`. Both the auth cookie and the OIDC session are cleared (a subsequent `/workflows` request re-challenges).
+
+Checklist:
+- [ ] Bare `POST /Account/Logout` returns 400 (antiforgery missing)
+- [ ] Form-bound `Sign out` button signs out and clears both cookie and IdP session
+- [ ] Post-logout `/workflows` request redirects back to IdP login
+
+## Scenario 6 — Health endpoints stay anonymous
+
+Confirms operator/orchestrator probes are unaffected by auth.
+
+1. With auth enabled and no session cookie, request `https://localhost:7124/health` and `/alive`.
+2. **Expect:** both return HTTP 200 with no redirect.
+
+Checklist:
+- [ ] `/health` returns 200 even when auth is on
+- [ ] `/alive` returns 200 even when auth is on
+
+## Known limitation (not a defect)
+
+When the cookie expires while a Blazor circuit is still open, the framework's "Could not reconnect" overlay appears (the SignalR `/_blazor` endpoint cannot redirect). Reloading the page triggers the normal redirect-to-IdP flow. A future slice may add a `CircuitHandler` that surfaces a re-auth modal proactively; out of scope here.

--- a/website/src/content/docs/reference/authentication.md
+++ b/website/src/content/docs/reference/authentication.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication
-description: Opt-in JWT bearer authentication for the Fleans REST API.
+description: Opt-in OIDC authentication for the Fleans REST API and Management UI.
 sidebar:
   order: 2
 ---
@@ -130,12 +130,89 @@ builder.Services.AddHttpClient<IFleansClient, FleansClient>(client =>
 .AddHttpMessageHandler<BearerTokenHandler>();
 ```
 
+## Management UI
+
+The `Fleans.Web` Blazor admin UI supports the same opt-in pattern via OIDC Authorization Code flow with PKCE, persisting the resulting identity in a session cookie. **Disabled by default** — when no `Authentication` section is present, the UI runs unauthenticated, identical to today's behaviour.
+
+### Why a different flow than the API?
+
+Browser users don't hold raw JWTs. The canonical pattern for server-side web apps is OIDC Authorization Code flow with PKCE, which exchanges the authorization code for tokens server-side and persists the identity in an encrypted session cookie. The API uses bearer JWTs because its callers are scripts and services that *do* hold tokens; the UI uses cookies because its callers are humans in browsers.
+
+### Config block (Management UI)
+
+```json
+{
+  "Authentication": {
+    "Authority":             "https://your-idp.example.com/realms/fleans",
+    "ClientId":              "fleans-web",
+    "ClientSecret":          "<from-IdP>",
+    "RequireHttpsMetadata":  true,
+    "CookieExpireMinutes":   60,
+    "KnownProxies":          [],
+    "KnownNetworks":         []
+  }
+}
+```
+
+Auth on iff **both** `Authority` AND `ClientId` are non-empty (single source of truth — same key namespace as the API). The shipped `appsettings.json` carries no `Authentication` block; a documented copy lives at [`src/Fleans/Fleans.Web/appsettings.example.jsonc`](https://github.com/nightBaker/fleans/blob/main/src/Fleans/Fleans.Web/appsettings.example.jsonc) and is not loaded at runtime.
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `Authority` | Yes (to enable auth) | *(absent — auth disabled)* | OIDC issuer URL. |
+| `ClientId` | Yes (to enable auth) | *(absent)* | OAuth client id registered with the IdP. Must be a confidential client. |
+| `ClientSecret` | Yes when auth on | — | Confidential-client secret. Use `dotnet user-secrets` in dev; Aspire `auth-client-secret` parameter (`secret: true`) or env var `Authentication__ClientSecret` in prod. **Never commit.** |
+| `RequireHttpsMetadata` | No | `true` | Set to `false` only for local Keycloak dev mode (HTTP). |
+| `CookieExpireMinutes` | No | `60` | Sliding session cookie lifetime. Mirror the IdP's access-token / management-page session lifetime so admin sessions in the UI and tokens used against the API don't drift apart. |
+| `KnownProxies` | No | `[]` | Reverse-proxy IP addresses trusted to set `X-Forwarded-For` / `X-Forwarded-Proto`. Empty list = headers ignored. |
+| `KnownNetworks` | No | `[]` | Same as above but accepts CIDR ranges (e.g. `10.0.0.0/8`). |
+
+### Aspire wiring
+
+`Fleans.Aspire/Program.cs` declares three optional parameters (always present, defaulting to empty strings) that are forwarded to `Fleans.Web` as env vars:
+
+```csharp
+var authAuthority    = builder.AddParameter("auth-authority", () => "");
+var authClientId     = builder.AddParameter("auth-client-id", () => "");
+var authClientSecret = builder.AddParameter("auth-client-secret", () => "", secret: true);
+
+builder.AddProject<Projects.Fleans_Web>("fleans-management")
+    .WithEnvironment("Authentication__Authority",   authAuthority)
+    .WithEnvironment("Authentication__ClientId",    authClientId)
+    .WithEnvironment("Authentication__ClientSecret", authClientSecret)
+    /* ... */;
+```
+
+Operators set the parameters at run-time (Aspire CLI prompt, env vars, deployment manifest). When unset, `Fleans.Web` sees empty strings and falls into auth-disabled mode automatically.
+
+### Behaviour when enabled
+
+- **Every page** is wrapped in `<AuthorizeRouteView>`. Unauthenticated requests trigger an OIDC challenge → IdP login → callback to `/signin-oidc` → session cookie issued → bounce to the originally-requested URL (deep links preserved).
+- **Orleans Dashboard at `/dashboard`** is gated by an explicit middleware branch — Orleans' dashboard middleware does not honour `[Authorize]`, so the guard fires before `MapOrleansDashboard`.
+- **NavMenu** renders a `Signed in as <preferred_username>` chip with a `Sign out` button. The button submits an antiforgery-protected POST to `/Account/Logout` that clears both the cookie and the IdP session.
+- **`/health`, `/alive`** stay anonymous (operator probes are unaffected).
+- **`/Account/Login?returnUrl=…`** validates `returnUrl` against an inline `IsLocalUrl` predicate (same shape as `IUrlHelper.IsLocalUrl`). Open-redirect attacks (`/\evil.com`, `//evil.com`, absolute URLs, leading whitespace) collapse to `/`; well-formed local paths pass through.
+
+### Multi-instance deployments
+
+When `Fleans.Web` runs as more than one replica, ASP.NET Data Protection keys are persisted to the existing `orleans-redis` Aspire resource so cookies issued by replica A decrypt on replica B. Single-replica deployments use the same path (it's a no-op on key cardinality, not behaviour).
+
+### Reverse proxies
+
+If `Fleans.Web` sits behind a reverse proxy that terminates TLS, populate `KnownProxies` (or `KnownNetworks` for CIDR ranges) so `X-Forwarded-For` / `X-Forwarded-Proto` are honoured when constructing OIDC redirect URIs. Empty defaults are deliberately strict — without an explicit allowlist the framework discards the headers, preventing host-spoofing from untrusted networks.
+
+### Local dev
+
+A copy-paste Keycloak quickstart (Docker run, realm JSON, `dotnet user-secrets` commands, sample user) lives at [`tests/manual/30-web-auth/keycloak-dev.md`](https://github.com/nightBaker/fleans/blob/main/tests/manual/30-web-auth/keycloak-dev.md). The full manual test plan (login round-trip, dashboard guard, open-redirect attack table, antiforgery on logout) is at [`tests/manual/30-web-auth/test-plan.md`](https://github.com/nightBaker/fleans/blob/main/tests/manual/30-web-auth/test-plan.md).
+
+### Roles (deferred)
+
+This slice authenticates only — every signed-in user has the same access. Role-based policies (`Admin`, `Operator`, `Viewer`) and per-page `[Authorize(Roles=…)]` are deliberately a separate slice, mirroring the same staging used for the API in [#341](https://github.com/nightBaker/fleans/issues/341). The OIDC handler already maps the `roles` claim from the token; the follow-up slice adds policy registration and component-level enforcement.
+
 ## Testing & troubleshooting
 
-The manual regression test plan for authentication lives in [`tests/manual/28-api-auth/test-plan.md`](https://github.com/nightBaker/fleans/blob/main/tests/manual/28-api-auth/test-plan.md). It verifies:
-- API works unauthenticated by default
-- Returns `401` when auth is configured and no token is provided
-- Accepts valid tokens
+The manual regression test plans for authentication live at:
+- API: [`tests/manual/28-api-auth/test-plan.md`](https://github.com/nightBaker/fleans/blob/main/tests/manual/28-api-auth/test-plan.md) — verifies the API works unauthenticated by default, returns `401` when auth is on and no token is provided, and accepts valid tokens.
+- Management UI: [`tests/manual/30-web-auth/test-plan.md`](https://github.com/nightBaker/fleans/blob/main/tests/manual/30-web-auth/test-plan.md) — verifies anonymous browse is allowed when no `Authentication` section is present, every page (and `/dashboard`) returns 302 → IdP when auth is on, login round-trip preserves deep-link query strings, the open-redirect guard rejects every canonical attack input, and `/Account/Logout` is antiforgery-protected.
 
 **Common errors:**
 
@@ -147,4 +224,4 @@ The manual regression test plan for authentication lives in [`tests/manual/28-ap
 
 ## Related
 
-- Web admin authorization — tracked separately in [#370](https://github.com/nightBaker/fleans/issues/370).
+- Role-based authorization for both API and Management UI — tracked in [#341](https://github.com/nightBaker/fleans/issues/341).


### PR DESCRIPTION
## Summary

Implements **Slice 3 of #341** — opt-in OIDC Authorization Code flow with PKCE + cookie session for the `Fleans.Web` Blazor admin UI. Mirrors the opt-in pattern shipped for the API in #355: when no `Authentication` section is present, the UI runs unauthenticated exactly as today; setting `Authentication:Authority` AND `Authentication:ClientId` (single source of truth) flips on the full middleware stack.

Closes #370.

## What's in here

- `Security/AuthOptions.cs` — singleton record (`Enabled`, `Authority`, `ClientId`) consumed by `Routes.razor` to gate the cascading auth state and `<AuthorizeRouteView>`.
- `Program.cs` — D2 cookie + OIDC schemes, D3 fallback `[Authorize]`, D4 explicit `/dashboard` guard before `MapOrleansDashboard`, D6 login/logout endpoints with an inline `IsLocalUrl` open-redirect predicate (same shape as `IUrlHelper.IsLocalUrl`, expressed as a free static so the minimal-API delegate compiles without an MVC dependency), D10 keyed-Redis Data Protection key ring (multi-instance safe — configured via `KeyManagementOptions` because `PersistKeysToStackExchangeRedis` lacks an `IServiceProvider`-aware overload for keyed Redis), D12 forwarded-headers gated by `KnownProxies`/`KnownNetworks` allowlists.
- `Routes.razor` + `Security/RedirectToLogin.razor` — auth-aware router that wraps every page in `<AuthorizeRouteView>` when enabled (and falls back to today's plain `<RouteView>` when disabled).
- `NavMenu.razor` — `<AuthorizeView>` user chip with `Signed in as <preferred_username>` and an antiforgery-protected `Sign out` form.
- `Fleans.Aspire/Program.cs` — three optional `auth-authority`/`auth-client-id`/`auth-client-secret` parameters declared unconditionally with empty defaults, forwarded to `Fleans.Web` as env vars (D2a).
- `appsettings.example.jsonc` — documented config block (not loaded at runtime).
- `tests/manual/30-web-auth/` — full manual test plan + Keycloak Docker quickstart + importable realm JSON.
- `CLAUDE.md` — regression entry **#34** (last entry on `main` was `33. Editor Tabs`; `30-cancel-event/` is not on `main`, so the v7 Step-0 contingency does not fire).
- `website/.../authentication.md` — extended with a Management UI section covering config, Aspire wiring, behaviour when enabled, multi-instance Data Protection, reverse-proxy guidance, and pointers to the local-dev quickstart.

## Key decisions / deviations from v7 spec

- **Data Protection wiring** uses `KeyManagementOptions` + `RedisXmlRepository` rather than the `Func<IServiceProvider, IConnectionMultiplexer>` overload shown in v3 — that overload does not exist in `Microsoft.AspNetCore.DataProtection.StackExchangeRedis` 10.0 (only `IConnectionMultiplexer`/`Func<IDatabase>` overloads are public). The substituted form preserves the keyed-`orleans-redis` resolution semantics and is the canonical .NET 10 idiom for this case.
- **`KnownIPNetworks`** used instead of the obsolete `KnownNetworks` (per `ASPDEPR005`). Same effect, future-proof.

## How to test

- `dotnet build` — clean, 0 errors.
- `dotnet test` — 951/951 passing (1 pre-existing skip in `Fleans.Application.Tests` for `TimerEventSubProcess_NestedInsideSubProcess_CompletesScope`).
- Manual regression: follow [`tests/manual/30-web-auth/test-plan.md`](tests/manual/30-web-auth/test-plan.md). Quickstart for the local Keycloak in [`tests/manual/30-web-auth/keycloak-dev.md`](tests/manual/30-web-auth/keycloak-dev.md).

## Test plan

- [ ] `dotnet build` from `src/Fleans/` (clean, 0 errors)
- [ ] `dotnet test` from `src/Fleans/` (existing 950+ tests still green)
- [ ] Manual regression scenario 1 (auth disabled by default — no redirects, dashboard open, NavMenu has no chip)
- [ ] Manual regression scenario 2 (auth enabled — login round-trip preserves `?filter=active` deep link, NavMenu shows `Signed in as alice`)
- [ ] Manual regression scenario 3 (Orleans dashboard returns 302 → IdP when anonymous)
- [ ] Manual regression scenario 4 (every open-redirect attack input collapses to `/`; legitimate deep-link is honoured)
- [ ] Manual regression scenario 5 (bare `POST /Account/Logout` → 400; form-bound `Sign out` clears both schemes and re-challenges on next page load)
- [ ] Manual regression scenario 6 (`/health` and `/alive` stay anonymous when auth is on)

🤖 Generated with [Claude Code](https://claude.com/claude-code)