### PR TITLE
feat(#357): pluggable custom-task framework — v12 (sub-issue A)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,22 @@ The splash page (`website/src/content/docs/index.mdx`) loads an interactive Thre
    - **Fail tests:** error state set with correct code/message (500 for generic Exception, 400 for BadRequestActivityException), failed activity still transitions to next activity, no variables merged on failure
 4. Update the BPMN elements table in `README.md`
 
+## How to Add a Custom Task Plugin
+
+A *custom task* is a `<bpmn:serviceTask type="…">` whose execution is supplied by a user-written plugin grain on a Worker silo. Use this — **not** "Add a New BPMN Activity" — when the new behavior is plugin-shaped (REST call, email, custom external system).
+
+1. Add a new project (e.g. `Fleans.Plugins.MyThing`) referencing `Fleans.Worker`. Inside it, write a class deriving from `Fleans.Worker.CustomTasks.CustomTaskHandlerBase`. Override `TaskType` and `ExecuteAsync(...)`. The base class carries `[ImplicitStreamSubscription("events")]` and `[WorkerPlacement]` — subclasses inherit both.
+2. Throw `Fleans.Domain.Errors.CustomTaskFailedActivityException(int code, string message)` from `ExecuteAsync` to fail with a typed error; any other thrown exception fails with code 500.
+3. The plugin's `ExecuteAsync` returns an `IDictionary<string, object?>`. Output mappings (`<zeebe:output source="=__response.body" target="…"/>`) walk that dictionary.
+4. Expose a DI extension method on the plugin assembly:
+   ```csharp
+   public static IServiceCollection AddMyThingPlugin(this IServiceCollection services) =>
+       services.AddCustomTaskPlugin<MyThingHandler>(taskType: "my-thing", displayName: "My Thing");
+   ```
+   Plugin authors who want their plugin to live in the catalog UI must call this from the Worker silo's host registration.
+5. Tests: write unit tests for the plugin's logic (call `ExecuteAsync` directly with stub inputs); end-to-end TestCluster integration is exercised by manual test plan #37 once a real plugin ships.
+6. Documentation: update `website/src/content/docs/concepts/custom-tasks.md` with the plugin's parameter schema and any limitations.
+
 ## How to Add a New API Endpoint
 
 Add it to `Fleans.Api/Controllers/WorkflowController.cs`. DTOs go in `Fleans.ServiceDefaults/`.
@@ -179,6 +195,7 @@ The full regression suite is the union of every plan under `tests/manual/`. Each
 34. **Management UI Authentication** — `tests/manual/30-web-auth/test-plan.md`. Opt-in OIDC for the Blazor Server admin UI; verifies (a) anonymous browse is allowed when no `Authentication` config is present, (b) `/dashboard` and any cascading-`AuthorizeView` page return 302 → IdP when auth is enabled, (c) login round-trip lands on the requested page (including `?query` parameters), (d) `/Account/Logout` is antiforgery-protected (bare POST is rejected, form-bound POST signs out and clears both schemes).
 35. **Kafka Streaming Provider** — `tests/manual/35-kafka-streaming/test-plan.md` (`kafka-streams.bpmn`). Opt-in Kafka stream provider via `FLEANS_STREAMING_PROVIDER=Kafka`; verifies (a) Aspire dashboard provisions a `fleans-kafka` resource and forwards `Fleans__Streaming__Provider`/`Fleans__Streaming__Kafka__Brokers` env vars to the silo, (b) chained-script-task workflow completes after the silo is killed and restarted between tasks (at-least-once delivery), (c) the client-side `AdminClient.CreateTopicsAsync` ensure step auto-creates topics with the configured prefix.
 36. **Cancel Event (Transaction Cancellation)** — `tests/manual/30-cancel-event/test-plan.md` (`cancel-transaction.bpmn`). Cancel End Event inside a Transaction triggers: active scope activities cancelled, Cancel Boundary Event fires, recovery flow runs to completion. Verifies transaction outcome is Cancelled.
+37. **Custom Task Framework** — `tests/manual/37-custom-task-framework/test-plan.md` (`stub-custom-task.bpmn`). `<serviceTask type="...">` parses to `CustomTaskActivity`; with no plugin registered the activity stays Active indefinitely (manual `complete-activity` API call resumes it); registered plugin via `services.AddCustomTaskPlugin<T>()` claims the event, runs, and completes the activity; `GET /custom-tasks` reflects registered/dropped plugins as silos join/leave.
 
 > When adding a new manual test folder under `tests/manual/`, append a numbered entry here so the regression skill picks it up.
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ For now, next elements are implemented
 | **Activities**       |                                                                             |             |
 | Task                 | A single unit of work.                                                      |     [x]     |
 | Script Task          | A task that executes an inline script.                                       |     [x]     |
+| Service Task         | A task whose execution is supplied by a custom plugin (`<serviceTask type="…">`); plain `<serviceTask>` (no `type`) is a no-op. | [x] custom-task framework |
 | Sub-Process          | A group of tasks that are treated as a single unit.                         |     [x]     |
 | Call Activity        | A type of sub-process that calls another process.                            |     [x]     |
 | User Task            | A task that requires human interaction with claim lifecycle.                 |     [x]     |

--- a/src/Fleans/Fleans.Api/Controllers/CustomTasksController.cs
+++ b/src/Fleans/Fleans.Api/Controllers/CustomTasksController.cs
@@ -1,0 +1,42 @@
+using Fleans.Application.CustomTasks;
+using Fleans.ServiceDefaults.DTOs;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Fleans.Api.Controllers;
+
+/// <summary>
+/// Surfaces the <see cref="ICustomTaskCatalogGrain"/> contents to the management UI.
+/// </summary>
+[ApiController]
+[Route("custom-tasks")]
+public sealed class CustomTasksController : ControllerBase
+{
+    private readonly IGrainFactory _grainFactory;
+
+    public CustomTasksController(IGrainFactory grainFactory)
+    {
+        _grainFactory = grainFactory;
+    }
+
+    /// <summary>Returns one entry per registered task type with the silos hosting it.</summary>
+    [HttpGet]
+    public async Task<IReadOnlyList<CustomTaskCatalogEntryDto>> GetAll()
+    {
+        var catalog = _grainFactory.GetGrain<ICustomTaskCatalogGrain>(0);
+        var entries = await catalog.GetAll();
+        return entries
+            .Select(e => new CustomTaskCatalogEntryDto(e.TaskType, e.DisplayName, e.ParameterSchemaJson, e.SiloNames))
+            .ToList();
+    }
+
+    /// <summary>Returns the entry for one task type, 404 if no plugin claims it.</summary>
+    [HttpGet("{taskType}")]
+    public async Task<ActionResult<CustomTaskCatalogEntryDto>> Get(string taskType)
+    {
+        var catalog = _grainFactory.GetGrain<ICustomTaskCatalogGrain>(0);
+        var entry = await catalog.Get(taskType);
+        if (entry is null)
+            return NotFound();
+        return new CustomTaskCatalogEntryDto(entry.TaskType, entry.DisplayName, entry.ParameterSchemaJson, entry.SiloNames);
+    }
+}

--- a/src/Fleans/Fleans.Application.Tests/CustomTasks/CustomTaskCatalogGrainTests.cs
+++ b/src/Fleans/Fleans.Application.Tests/CustomTasks/CustomTaskCatalogGrainTests.cs
@@ -1,0 +1,94 @@
+using Fleans.Application.CustomTasks;
+
+namespace Fleans.Application.Tests.CustomTasks;
+
+[TestClass]
+public class CustomTaskCatalogGrainTests : WorkflowTestBase
+{
+    private ICustomTaskCatalogGrain GetCatalog() =>
+        Cluster.GrainFactory.GetGrain<ICustomTaskCatalogGrain>(0);
+
+    [TestMethod]
+    public async Task Register_NewEntry_AppearsInGetAll()
+    {
+        var catalog = GetCatalog();
+
+        await catalog.Register(new CustomTaskRegistration("rest-call", "REST Caller", null, "worker-A"));
+
+        var entries = await catalog.GetAll();
+        var rest = entries.SingleOrDefault(e => e.TaskType == "rest-call");
+        Assert.IsNotNull(rest);
+        Assert.AreEqual("REST Caller", rest!.DisplayName);
+        Assert.HasCount(1, rest.SiloNames);
+        Assert.AreEqual("worker-A", rest.SiloNames[0]);
+    }
+
+    [TestMethod]
+    public async Task Register_SameTaskTypeAndSilo_IsIdempotent()
+    {
+        var catalog = GetCatalog();
+
+        await catalog.Register(new CustomTaskRegistration("rest-call", null, null, "worker-A"));
+        await catalog.Register(new CustomTaskRegistration("rest-call", "Updated Display", null, "worker-A"));
+
+        var entries = await catalog.GetAll();
+        var rest = entries.Single(e => e.TaskType == "rest-call");
+        Assert.HasCount(1, rest.SiloNames);
+        Assert.AreEqual("Updated Display", rest.DisplayName);
+    }
+
+    [TestMethod]
+    public async Task Register_SameTaskTypeDifferentSilos_AggregatesIntoOneEntry()
+    {
+        var catalog = GetCatalog();
+
+        await catalog.Register(new CustomTaskRegistration("rest-call", null, null, "worker-1"));
+        await catalog.Register(new CustomTaskRegistration("rest-call", null, null, "worker-2"));
+
+        var entries = await catalog.GetAll();
+        var rest = entries.Single(e => e.TaskType == "rest-call");
+        Assert.HasCount(2, rest.SiloNames);
+        CollectionAssert.AreEquivalent(new[] { "worker-1", "worker-2" }, rest.SiloNames.ToList());
+    }
+
+    [TestMethod]
+    public async Task Get_UnknownTaskType_ReturnsNull()
+    {
+        var catalog = GetCatalog();
+
+        var result = await catalog.Get("never-registered");
+
+        Assert.IsNull(result);
+    }
+
+    [TestMethod]
+    public async Task Get_KnownTaskType_ReturnsAggregatedEntry()
+    {
+        var catalog = GetCatalog();
+
+        await catalog.Register(new CustomTaskRegistration("email-send", "Email Sender", "{}", "worker-X"));
+
+        var entry = await catalog.Get("email-send");
+
+        Assert.IsNotNull(entry);
+        Assert.AreEqual("email-send", entry!.TaskType);
+        Assert.AreEqual("Email Sender", entry.DisplayName);
+        Assert.AreEqual("{}", entry.ParameterSchemaJson);
+        Assert.AreEqual("worker-X", entry.SiloNames.Single());
+    }
+
+    [TestMethod]
+    public async Task Get_IsCaseInsensitiveOnTaskType()
+    {
+        var catalog = GetCatalog();
+
+        await catalog.Register(new CustomTaskRegistration("rest-call", null, null, "worker-A"));
+
+        var lower = await catalog.Get("rest-call");
+        var upper = await catalog.Get("REST-CALL");
+
+        Assert.IsNotNull(lower);
+        Assert.IsNotNull(upper);
+        Assert.AreEqual(lower!.TaskType, upper!.TaskType);
+    }
+}

--- a/src/Fleans/Fleans.Application.Tests/CustomTasks/MappingResolverTests.cs
+++ b/src/Fleans/Fleans.Application.Tests/CustomTasks/MappingResolverTests.cs
@@ -1,0 +1,79 @@
+using System.Dynamic;
+using Fleans.Application.CustomTasks;
+using Fleans.Domain.Errors;
+
+namespace Fleans.Application.Tests.CustomTasks;
+
+[TestClass]
+public class MappingResolverTests
+{
+    [TestMethod]
+    public void BareString_ReturnedAsLiteral()
+    {
+        var scope = new Dictionary<string, object?> { ["x"] = 42 };
+        var result = MappingResolver.Resolve("hello", scope);
+        Assert.AreEqual("hello", result);
+    }
+
+    [TestMethod]
+    public void TopLevelPath_ReturnsScopeValue()
+    {
+        var scope = new Dictionary<string, object?> { ["userId"] = 123 };
+        var result = MappingResolver.Resolve("=userId", scope);
+        Assert.AreEqual(123, result);
+    }
+
+    [TestMethod]
+    public void NestedPath_WalksDictionariesAndExpandos()
+    {
+        var inner = new ExpandoObject();
+        ((IDictionary<string, object?>)inner)["status"] = "ok";
+        var response = new Dictionary<string, object?> { ["body"] = inner };
+        var scope = new Dictionary<string, object?> { ["__response"] = response };
+
+        var result = MappingResolver.Resolve("=__response.body.status", scope);
+        Assert.AreEqual("ok", result);
+    }
+
+    [TestMethod]
+    public void MissingPathSegment_ReturnsNull()
+    {
+        var scope = new Dictionary<string, object?>();
+        var result = MappingResolver.Resolve("=missing.value", scope);
+        Assert.IsNull(result);
+    }
+
+    [TestMethod]
+    public void QuotedStringLiteral_ReturnsInnerString()
+    {
+        var scope = new Dictionary<string, object?>();
+        var result = MappingResolver.Resolve("=\"explicit literal\"", scope);
+        Assert.AreEqual("explicit literal", result);
+    }
+
+    [TestMethod]
+    public void IntegerLiteral_ReturnsLong()
+    {
+        var scope = new Dictionary<string, object?>();
+        var result = MappingResolver.Resolve("=42", scope);
+        Assert.AreEqual(42L, result);
+    }
+
+    [TestMethod]
+    public void BooleanAndNullLiterals_Recognized()
+    {
+        var scope = new Dictionary<string, object?>();
+        Assert.AreEqual(true, MappingResolver.Resolve("=true", scope));
+        Assert.AreEqual(false, MappingResolver.Resolve("=false", scope));
+        Assert.IsNull(MappingResolver.Resolve("=null", scope));
+    }
+
+    [TestMethod]
+    public void EmptyExpressionAfterEquals_ThrowsCustomTaskFailedActivityException()
+    {
+        var scope = new Dictionary<string, object?>();
+        var ex = Assert.ThrowsExactly<CustomTaskFailedActivityException>(
+            () => MappingResolver.Resolve("=", scope));
+        Assert.AreEqual("400", ex.GetActivityErrorState().Code);
+    }
+}

--- a/src/Fleans/Fleans.Application/CustomTasks/CustomTaskCatalogEntry.cs
+++ b/src/Fleans/Fleans.Application/CustomTasks/CustomTaskCatalogEntry.cs
@@ -1,0 +1,12 @@
+namespace Fleans.Application.CustomTasks;
+
+/// <summary>
+/// What the catalog returns to API/UI consumers. Aggregates registrations across silos
+/// for a given task type, so the UI can render "rest-call — 2 silos: worker-A, worker-B".
+/// </summary>
+[GenerateSerializer]
+public sealed record CustomTaskCatalogEntry(
+    [property: Id(0)] string TaskType,
+    [property: Id(1)] string? DisplayName,
+    [property: Id(2)] string? ParameterSchemaJson,
+    [property: Id(3)] IReadOnlyList<string> SiloNames);

--- a/src/Fleans/Fleans.Application/CustomTasks/CustomTaskCatalogGrain.cs
+++ b/src/Fleans/Fleans.Application/CustomTasks/CustomTaskCatalogGrain.cs
@@ -1,0 +1,134 @@
+using Fleans.Application.Placement;
+using Microsoft.Extensions.Logging;
+using Orleans.Runtime;
+
+namespace Fleans.Application.CustomTasks;
+
+/// <summary>
+/// In-memory catalog of custom-task plugin registrations announced by Worker silos.
+/// Membership-reconciliation timer prunes entries whose silo has left the cluster.
+///
+/// State is intentionally ephemeral in this v1: on Core silo restart the catalog is
+/// rebuilt as Worker silos restart and re-register. EF-backed persistence is a v2
+/// follow-up — design v12 originally specified <c>IPersistentState</c>, deferred here
+/// because the per-entry table + migrations dwarf the rest of sub-issue A and the
+/// in-memory model is sufficient for the dev/aspire path where Core and Worker silos
+/// share a process.
+/// </summary>
+[CorePlacement]
+public sealed partial class CustomTaskCatalogGrain : Grain, ICustomTaskCatalogGrain
+{
+    private readonly Dictionary<(string TaskType, string SiloName), CustomTaskRegistration> _entries = new();
+    private readonly IGrainFactory _grainFactory;
+    private readonly ILogger<CustomTaskCatalogGrain> _logger;
+
+    private static readonly TimeSpan ReconcileInterval = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan ReconcileFirstDelay = TimeSpan.FromSeconds(30);
+
+    private static readonly HashSet<SiloStatus> KeepStatuses =
+    [
+        SiloStatus.Joining,
+        SiloStatus.Active,
+        SiloStatus.ShuttingDown,
+    ];
+
+    public CustomTaskCatalogGrain(IGrainFactory grainFactory, ILogger<CustomTaskCatalogGrain> logger)
+    {
+        _grainFactory = grainFactory;
+        _logger = logger;
+    }
+
+    public override Task OnActivateAsync(CancellationToken cancellationToken)
+    {
+        this.RegisterGrainTimer(_ => ReconcileWithMembership(),
+            new GrainTimerCreationOptions
+            {
+                DueTime = ReconcileFirstDelay,
+                Period = ReconcileInterval,
+            });
+        return base.OnActivateAsync(cancellationToken);
+    }
+
+    public Task Register(CustomTaskRegistration entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        var key = (entry.TaskType, entry.SiloName);
+        _entries[key] = entry;
+        LogRegistered(entry.TaskType, entry.SiloName);
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<CustomTaskCatalogEntry>> GetAll()
+    {
+        var aggregated = _entries.Values
+            .GroupBy(e => e.TaskType, StringComparer.OrdinalIgnoreCase)
+            .Select(g =>
+            {
+                var first = g.First();
+                return new CustomTaskCatalogEntry(
+                    first.TaskType,
+                    first.DisplayName,
+                    first.ParameterSchemaJson,
+                    g.Select(e => e.SiloName).Distinct(StringComparer.Ordinal).ToList());
+            })
+            .ToList();
+        return Task.FromResult<IReadOnlyList<CustomTaskCatalogEntry>>(aggregated);
+    }
+
+    public Task<CustomTaskCatalogEntry?> Get(string taskType)
+    {
+        ArgumentNullException.ThrowIfNull(taskType);
+        var matches = _entries.Values
+            .Where(e => string.Equals(e.TaskType, taskType, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        if (matches.Count == 0)
+            return Task.FromResult<CustomTaskCatalogEntry?>(null);
+
+        var first = matches[0];
+        var entry = new CustomTaskCatalogEntry(
+            first.TaskType,
+            first.DisplayName,
+            first.ParameterSchemaJson,
+            matches.Select(e => e.SiloName).Distinct(StringComparer.Ordinal).ToList());
+        return Task.FromResult<CustomTaskCatalogEntry?>(entry);
+    }
+
+    private async Task ReconcileWithMembership()
+    {
+        try
+        {
+            var management = _grainFactory.GetGrain<IManagementGrain>(0);
+            var hosts = await management.GetDetailedHosts(onlyActive: false);
+            var aliveSilos = hosts
+                .Where(h => KeepStatuses.Contains(h.Status))
+                .Select(h => h.SiloName)
+                .Where(n => !string.IsNullOrEmpty(n))
+                .ToHashSet(StringComparer.Ordinal);
+
+            var stale = _entries.Keys
+                .Where(k => !aliveSilos.Contains(k.SiloName))
+                .ToList();
+            foreach (var key in stale)
+                _entries.Remove(key);
+
+            if (stale.Count > 0)
+                LogReconciled(stale.Count);
+        }
+        catch (Exception ex)
+        {
+            LogReconcileFailed(ex);
+        }
+    }
+
+    [LoggerMessage(EventId = 9320, Level = LogLevel.Information,
+        Message = "Registered custom-task plugin '{TaskType}' on silo '{SiloName}'")]
+    private partial void LogRegistered(string taskType, string siloName);
+
+    [LoggerMessage(EventId = 9321, Level = LogLevel.Information,
+        Message = "Reconciled custom-task catalog: removed {Count} entries for silos no longer in cluster")]
+    private partial void LogReconciled(int count);
+
+    [LoggerMessage(EventId = 9322, Level = LogLevel.Warning,
+        Message = "Custom-task catalog reconcile failed; will retry next tick")]
+    private partial void LogReconcileFailed(Exception ex);
+}

--- a/src/Fleans/Fleans.Application/CustomTasks/CustomTaskRegistration.cs
+++ b/src/Fleans/Fleans.Application/CustomTasks/CustomTaskRegistration.cs
@@ -1,0 +1,12 @@
+namespace Fleans.Application.CustomTasks;
+
+/// <summary>
+/// What a Worker silo announces about a custom-task plugin it hosts. Sent to the
+/// catalog at silo startup by the per-silo <c>CustomTaskPluginRegistrar</c>.
+/// </summary>
+[GenerateSerializer]
+public sealed record CustomTaskRegistration(
+    [property: Id(0)] string TaskType,
+    [property: Id(1)] string? DisplayName,
+    [property: Id(2)] string? ParameterSchemaJson,
+    [property: Id(3)] string SiloName);

--- a/src/Fleans/Fleans.Application/CustomTasks/ICustomTaskCatalogGrain.cs
+++ b/src/Fleans/Fleans.Application/CustomTasks/ICustomTaskCatalogGrain.cs
@@ -1,0 +1,24 @@
+using Orleans.Concurrency;
+
+namespace Fleans.Application.CustomTasks;
+
+/// <summary>
+/// Singleton grain on Core silos that records which custom-task plugins are deployed
+/// on which Worker silos. Workers register themselves at silo startup; the catalog
+/// reconciles entries against cluster membership periodically and drops entries
+/// whose silo has left the cluster. Read by the management UI via
+/// <c>GET /custom-tasks</c>.
+/// </summary>
+public interface ICustomTaskCatalogGrain : IGrainWithIntegerKey
+{
+    /// <summary>Idempotent upsert keyed by (TaskType, SiloName).</summary>
+    Task Register(CustomTaskRegistration entry);
+
+    /// <summary>Returns one row per task type, aggregating silos.</summary>
+    [ReadOnly]
+    Task<IReadOnlyList<CustomTaskCatalogEntry>> GetAll();
+
+    /// <summary>Returns the entry for one task type, or <c>null</c> if no plugin claims it.</summary>
+    [ReadOnly]
+    Task<CustomTaskCatalogEntry?> Get(string taskType);
+}

--- a/src/Fleans/Fleans.Application/CustomTasks/MappingResolver.cs
+++ b/src/Fleans/Fleans.Application/CustomTasks/MappingResolver.cs
@@ -1,0 +1,86 @@
+using System.Dynamic;
+using Fleans.Domain.Errors;
+
+namespace Fleans.Application.CustomTasks;
+
+/// <summary>
+/// Resolves an input/output mapping <c>source</c> string against a dictionary-shaped scope.
+///
+/// Source grammar (validated at deploy time by BpmnConverter):
+/// <list type="bullet">
+///   <item><description><c>=identifier</c> — top-level lookup, returns <c>scope[identifier]</c></description></item>
+///   <item><description><c>=identifier.path.to.field</c> — dot-walk through nested dictionaries / ExpandoObjects</description></item>
+///   <item><description><c>=&quot;literal&quot;</c> — quoted string literal</description></item>
+///   <item><description><c>=42</c> / <c>=true</c> / <c>=false</c> / <c>=null</c> — primitive literal</description></item>
+///   <item><description><c>bare-string</c> (no leading <c>=</c>) — string literal</description></item>
+/// </list>
+/// </summary>
+public static class MappingResolver
+{
+    public static object? Resolve(string source, IDictionary<string, object?> scope)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(scope);
+
+        if (source.Length == 0 || source[0] != '=')
+            return source; // bare string literal
+
+        var expr = source.Substring(1);
+
+        if (expr.Length == 0)
+            throw new CustomTaskFailedActivityException("400", "Mapping source '=' is empty after the leading '='.");
+
+        // Quoted string: ="..."
+        if (expr[0] == '"')
+        {
+            if (expr.Length < 2 || expr[expr.Length - 1] != '"')
+                throw new CustomTaskFailedActivityException("400", $"Mapping source has unmatched quote: '{source}'");
+            return expr.Substring(1, expr.Length - 2);
+        }
+
+        // Primitive literals
+        if (expr == "true") return true;
+        if (expr == "false") return false;
+        if (expr == "null") return null;
+        if (long.TryParse(expr, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var longVal))
+            return longVal;
+        if (double.TryParse(expr, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var doubleVal))
+            return doubleVal;
+
+        // Path expression: identifier(.identifier)*
+        return WalkPath(expr, scope, source);
+    }
+
+    private static object? WalkPath(string expr, IDictionary<string, object?> scope, string fullSource)
+    {
+        var segments = expr.Split('.');
+        object? current = scope;
+
+        foreach (var segment in segments)
+        {
+            if (segment.Length == 0)
+                throw new CustomTaskFailedActivityException("400", $"Mapping source has empty path segment: '{fullSource}'");
+
+            if (current is null)
+                return null;
+
+            if (current is IDictionary<string, object?> dict)
+            {
+                if (!dict.TryGetValue(segment, out current))
+                    return null;
+            }
+            else if (current is ExpandoObject expando)
+            {
+                var expandoDict = (IDictionary<string, object?>)expando;
+                if (!expandoDict.TryGetValue(segment, out current))
+                    return null;
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        return current;
+    }
+}

--- a/src/Fleans/Fleans.Application/Events/WorkflowEventsPublisher.cs
+++ b/src/Fleans/Fleans.Application/Events/WorkflowEventsPublisher.cs
@@ -52,6 +52,12 @@ public partial class WorkflowEventsPublisher : Grain, IEventPublisher
                 var scriptStream = _streamProvider.GetStream<ExecuteScriptEvent>(scriptStreamId);
                 await scriptStream.OnNextAsync(executeScriptEvent);
                 break;
+            case ExecuteCustomTaskEvent executeCustomTaskEvent:
+
+                var customTaskStreamId = StreamId.Create(StreamNameSpace, nameof(ExecuteCustomTaskEvent));
+                var customTaskStream = _streamProvider.GetStream<ExecuteCustomTaskEvent>(customTaskStreamId);
+                await customTaskStream.OnNextAsync(executeCustomTaskEvent);
+                break;
             default:
                 var defaultStreamId = StreamId.Create(StreamNameSpace, nameof(IDomainEvent));
                 var defaultStream = _streamProvider.GetStream<IDomainEvent>(defaultStreamId);

--- a/src/Fleans/Fleans.Application/Logging/WorkflowLoggingContext.cs
+++ b/src/Fleans/Fleans.Application/Logging/WorkflowLoggingContext.cs
@@ -3,7 +3,7 @@ using Orleans.Runtime;
 
 namespace Fleans.Application.Logging;
 
-internal static class WorkflowLoggingContext
+public static class WorkflowLoggingContext
 {
     public static IDisposable? BeginWorkflowScope(
         ILogger logger, string workflowId, string? processDefinitionId,

--- a/src/Fleans/Fleans.Domain.Tests/CustomTaskActivityTests.cs
+++ b/src/Fleans/Fleans.Domain.Tests/CustomTaskActivityTests.cs
@@ -1,0 +1,54 @@
+using Fleans.Domain.Activities;
+using Fleans.Domain.Errors;
+
+namespace Fleans.Domain.Tests;
+
+[TestClass]
+public class CustomTaskActivityTests
+{
+    [TestMethod]
+    public void Ctor_StoresAllProperties()
+    {
+        var inputs = new[] { new InputMapping("=orderId", "id") };
+        var outputs = new[] { new OutputMapping("=__response.body", "result") };
+
+        var task = new CustomTaskActivity("ct1", "rest-call", inputs, outputs);
+
+        Assert.AreEqual("ct1", task.ActivityId);
+        Assert.AreEqual("rest-call", task.TaskType);
+        Assert.HasCount(1, task.InputMappings);
+        Assert.AreEqual("=orderId", task.InputMappings[0].Source);
+        Assert.AreEqual("id", task.InputMappings[0].Target);
+        Assert.HasCount(1, task.OutputMappings);
+        Assert.AreEqual("=__response.body", task.OutputMappings[0].Source);
+        Assert.AreEqual("result", task.OutputMappings[0].Target);
+    }
+
+    [TestMethod]
+    public void Ctor_AllowsNullMappings_DefaultsToEmptyLists()
+    {
+        var task = new CustomTaskActivity("ct1", "rest-call", null, null);
+
+        Assert.IsNotNull(task.InputMappings);
+        Assert.IsNotNull(task.OutputMappings);
+        Assert.HasCount(0, task.InputMappings);
+        Assert.HasCount(0, task.OutputMappings);
+    }
+
+    [TestMethod]
+    public void Ctor_ThrowsOnNullTaskType()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() => new CustomTaskActivity("ct1", null!, null, null));
+    }
+
+    [TestMethod]
+    public void CustomTaskFailedActivityException_MapsCodeAndMessage()
+    {
+        var ex = new CustomTaskFailedActivityException("503", "executor unreachable");
+
+        var state = ex.GetActivityErrorState();
+
+        Assert.AreEqual("503", state.Code);
+        Assert.AreEqual("executor unreachable", state.Message);
+    }
+}

--- a/src/Fleans/Fleans.Domain/Activities/CustomTaskActivity.cs
+++ b/src/Fleans/Fleans.Domain/Activities/CustomTaskActivity.cs
@@ -1,0 +1,50 @@
+using Fleans.Domain.Events;
+
+namespace Fleans.Domain.Activities;
+
+[GenerateSerializer]
+public record CustomTaskActivity : TaskActivity
+{
+    [Id(1)]
+    public string TaskType { get; init; }
+
+    [Id(2)]
+    public List<InputMapping> InputMappings { get; init; }
+
+    [Id(3)]
+    public List<OutputMapping> OutputMappings { get; init; }
+
+    public CustomTaskActivity(
+        string ActivityId,
+        string TaskType,
+        IEnumerable<InputMapping>? InputMappings,
+        IEnumerable<OutputMapping>? OutputMappings) : base(ActivityId)
+    {
+        ArgumentNullException.ThrowIfNull(TaskType);
+        this.TaskType = TaskType;
+        this.InputMappings = InputMappings is List<InputMapping> il ? il : InputMappings?.ToList() ?? new List<InputMapping>();
+        this.OutputMappings = OutputMappings is List<OutputMapping> ol ? ol : OutputMappings?.ToList() ?? new List<OutputMapping>();
+    }
+
+    internal override async Task<List<IExecutionCommand>> ExecuteAsync(
+        IWorkflowExecutionContext workflowContext,
+        IActivityExecutionContext activityContext,
+        IWorkflowDefinition definition)
+    {
+        var commands = await base.ExecuteAsync(workflowContext, activityContext, definition);
+
+        var variablesId = await activityContext.GetVariablesStateId();
+        await activityContext.PublishEvent(new ExecuteCustomTaskEvent(
+            await workflowContext.GetWorkflowInstanceId(),
+            definition.WorkflowId,
+            definition.ProcessDefinitionId,
+            await activityContext.GetActivityInstanceId(),
+            ActivityId,
+            TaskType,
+            InputMappings,
+            OutputMappings,
+            variablesId));
+
+        return commands;
+    }
+}

--- a/src/Fleans/Fleans.Domain/Activities/Mappings.cs
+++ b/src/Fleans/Fleans.Domain/Activities/Mappings.cs
@@ -1,0 +1,7 @@
+namespace Fleans.Domain.Activities;
+
+[GenerateSerializer]
+public record InputMapping([property: Id(0)] string Source, [property: Id(1)] string Target);
+
+[GenerateSerializer]
+public record OutputMapping([property: Id(0)] string Source, [property: Id(1)] string Target);

--- a/src/Fleans/Fleans.Domain/Errors/CustomTaskFailedActivityException.cs
+++ b/src/Fleans/Fleans.Domain/Errors/CustomTaskFailedActivityException.cs
@@ -1,0 +1,23 @@
+namespace Fleans.Domain.Errors;
+
+[GenerateSerializer]
+[Alias("Fleans.Domain.Errors.CustomTaskFailedActivityException")]
+public class CustomTaskFailedActivityException : ActivityException
+{
+    [Id(0)]
+    private readonly string _code;
+
+    [Id(1)]
+    private readonly string _message;
+
+    public CustomTaskFailedActivityException(string code, string message)
+    {
+        _code = code;
+        _message = message;
+    }
+
+    public override ActivityErrorState GetActivityErrorState()
+    {
+        return new ActivityErrorState(_code, _message);
+    }
+}

--- a/src/Fleans/Fleans.Domain/Events/ExecuteCustomTaskEvent.cs
+++ b/src/Fleans/Fleans.Domain/Events/ExecuteCustomTaskEvent.cs
@@ -1,0 +1,15 @@
+using Fleans.Domain.Activities;
+
+namespace Fleans.Domain.Events;
+
+[GenerateSerializer]
+public record ExecuteCustomTaskEvent(
+    Guid WorkflowInstanceId,
+    string WorkflowId,
+    string? ProcessDefinitionId,
+    Guid ActivityInstanceId,
+    string ActivityId,
+    string TaskType,
+    List<InputMapping> InputMappings,
+    List<OutputMapping> OutputMappings,
+    Guid VariablesId) : IDomainEvent;

--- a/src/Fleans/Fleans.Domain/GrainStorageNames.cs
+++ b/src/Fleans/Fleans.Domain/GrainStorageNames.cs
@@ -15,4 +15,5 @@ public static class GrainStorageNames
     public const string UserTasks = "userTasks";
     public const string ConditionalStartEventListeners = "conditionalStartEventListeners";
     public const string ConditionalStartEventRegistry = "conditionalStartEventRegistry";
+    public const string CustomTaskCatalog = "customTaskCatalog";
 }

--- a/src/Fleans/Fleans.Infrastructure.Tests/BpmnConverter/CustomTaskRoutingTests.cs
+++ b/src/Fleans/Fleans.Infrastructure.Tests/BpmnConverter/CustomTaskRoutingTests.cs
@@ -1,0 +1,130 @@
+using Fleans.Domain.Activities;
+using System.Text;
+
+namespace Fleans.Infrastructure.Tests.BpmnConverter;
+
+[TestClass]
+public class CustomTaskRoutingTests : BpmnConverterTestBase
+{
+    private const string ZeebeNs = "xmlns:zeebe=\"http://camunda.org/schema/zeebe/1.0\"";
+    private const string BpmnNs = "xmlns=\"http://www.omg.org/spec/BPMN/20100524/MODEL\"";
+
+    private static string CreateBpmnWithCustomServiceTask(string taskType, string ioMappingXml = "")
+    {
+        return $@"<?xml version=""1.0"" encoding=""UTF-8""?>
+<definitions {BpmnNs} {ZeebeNs}>
+  <process id=""wf"">
+    <startEvent id=""start"" />
+    <serviceTask id=""ct1"" type=""{taskType}"">
+      <extensionElements>
+        <zeebe:ioMapping>{ioMappingXml}</zeebe:ioMapping>
+      </extensionElements>
+    </serviceTask>
+    <endEvent id=""end"" />
+    <sequenceFlow id=""f1"" sourceRef=""start"" targetRef=""ct1"" />
+    <sequenceFlow id=""f2"" sourceRef=""ct1"" targetRef=""end"" />
+  </process>
+</definitions>";
+    }
+
+    private async Task<CustomTaskActivity> ParseSingleCustomTask(string taskType, string ioMappingXml)
+    {
+        var bpmn = CreateBpmnWithCustomServiceTask(taskType, ioMappingXml);
+        var workflow = await _converter.ConvertFromXmlAsync(new MemoryStream(Encoding.UTF8.GetBytes(bpmn)));
+        return workflow.Activities.OfType<CustomTaskActivity>().Single();
+    }
+
+    [TestMethod]
+    public async Task ServiceTask_WithoutTypeAttribute_ParsesAsTaskActivity()
+    {
+        var bpmn = CreateBpmnWithServiceTask("wf", "st1");
+        var workflow = await _converter.ConvertFromXmlAsync(new MemoryStream(Encoding.UTF8.GetBytes(bpmn)));
+        Assert.IsNotNull(workflow.Activities.OfType<TaskActivity>().FirstOrDefault(a => a.ActivityId == "st1"));
+        Assert.IsNull(workflow.Activities.OfType<CustomTaskActivity>().FirstOrDefault());
+    }
+
+    [TestMethod]
+    public async Task ServiceTask_WithTypeAttribute_ParsesAsCustomTaskActivity()
+    {
+        var ct = await ParseSingleCustomTask("rest-call", "");
+        Assert.AreEqual("rest-call", ct.TaskType);
+        Assert.AreEqual(0, ct.InputMappings.Count);
+        Assert.AreEqual(0, ct.OutputMappings.Count);
+    }
+
+    [TestMethod]
+    public async Task ServiceTask_WithZeebeTaskDefinition_ParsesAsCustomTaskActivity()
+    {
+        var bpmn = $@"<?xml version=""1.0"" encoding=""UTF-8""?>
+<definitions {BpmnNs} {ZeebeNs}>
+  <process id=""wf"">
+    <startEvent id=""start"" />
+    <serviceTask id=""ct1"">
+      <extensionElements>
+        <zeebe:taskDefinition type=""rest-call"" />
+      </extensionElements>
+    </serviceTask>
+    <endEvent id=""end"" />
+    <sequenceFlow id=""f1"" sourceRef=""start"" targetRef=""ct1"" />
+    <sequenceFlow id=""f2"" sourceRef=""ct1"" targetRef=""end"" />
+  </process>
+</definitions>";
+        var workflow = await _converter.ConvertFromXmlAsync(new MemoryStream(Encoding.UTF8.GetBytes(bpmn)));
+        var ct = workflow.Activities.OfType<CustomTaskActivity>().Single();
+        Assert.AreEqual("rest-call", ct.TaskType);
+    }
+
+    [TestMethod]
+    public async Task ServiceTask_WithInputAndOutputMappings_ParsesBothLists()
+    {
+        var io = @"
+          <zeebe:input source=""=userId"" target=""user_id"" />
+          <zeebe:input source=""=&quot;literal&quot;"" target=""label"" />
+          <zeebe:output source=""=__response.body.id"" target=""created_id"" />";
+        var ct = await ParseSingleCustomTask("rest-call", io);
+        Assert.AreEqual(2, ct.InputMappings.Count);
+        Assert.AreEqual(1, ct.OutputMappings.Count);
+        Assert.AreEqual("user_id", ct.InputMappings[0].Target);
+        Assert.AreEqual("=userId", ct.InputMappings[0].Source);
+        Assert.AreEqual("created_id", ct.OutputMappings[0].Target);
+    }
+
+    // ---- Output mapping deploy-time validation (9 scenarios) ----
+
+    [TestMethod]
+    [DataRow("", "out_id", DisplayName = "Output: empty source")]
+    [DataRow("=", "out_id", DisplayName = "Output: bare = with no expression")]
+    [DataRow("=\"unmatched", "out_id", DisplayName = "Output: unmatched quote")]
+    [DataRow("=path.with-dash.x", "out_id", DisplayName = "Output: invalid path segment (hyphen)")]
+    [DataRow("=valid.path", "1invalid", DisplayName = "Output: target starts with digit")]
+    [DataRow("=valid.path", "", DisplayName = "Output: empty target")]
+    [DataRow("=valid.path", "with-dash", DisplayName = "Output: hyphen in target")]
+    [DataRow("=valid.path", "with space", DisplayName = "Output: space in target")]
+    [DataRow("=valid.path", "__response", DisplayName = "Output: __response is reserved")]
+    public async Task DeployTime_RejectsMalformedOutputMapping(string source, string target)
+    {
+        var io = $@"<zeebe:output source=""{System.Security.SecurityElement.Escape(source)}"" target=""{System.Security.SecurityElement.Escape(target)}"" />";
+        var bpmn = CreateBpmnWithCustomServiceTask("rest-call", io);
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(async () =>
+            await _converter.ConvertFromXmlAsync(new MemoryStream(Encoding.UTF8.GetBytes(bpmn))));
+    }
+
+    // ---- Input mapping deploy-time validation (8 scenarios) ----
+
+    [TestMethod]
+    [DataRow("", "out_id", DisplayName = "Input: empty source")]
+    [DataRow("=", "out_id", DisplayName = "Input: bare = with no expression")]
+    [DataRow("=\"unmatched", "out_id", DisplayName = "Input: unmatched quote")]
+    [DataRow("=path.with-dash.x", "out_id", DisplayName = "Input: invalid path segment (hyphen)")]
+    [DataRow("=valid.path", "1invalid", DisplayName = "Input: target starts with digit")]
+    [DataRow("=valid.path", "", DisplayName = "Input: empty target")]
+    [DataRow("=valid.path", "with-dash", DisplayName = "Input: hyphen in target")]
+    [DataRow("=valid.path", "with space", DisplayName = "Input: space in target")]
+    public async Task DeployTime_RejectsMalformedInputMapping(string source, string target)
+    {
+        var io = $@"<zeebe:input source=""{System.Security.SecurityElement.Escape(source)}"" target=""{System.Security.SecurityElement.Escape(target)}"" />";
+        var bpmn = CreateBpmnWithCustomServiceTask("rest-call", io);
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(async () =>
+            await _converter.ConvertFromXmlAsync(new MemoryStream(Encoding.UTF8.GetBytes(bpmn))));
+    }
+}

--- a/src/Fleans/Fleans.Infrastructure/Bpmn/BpmnConverter.cs
+++ b/src/Fleans/Fleans.Infrastructure/Bpmn/BpmnConverter.cs
@@ -327,11 +327,24 @@ public partial class BpmnConverter : IBpmnConverter
             activityMap[id] = activity;
         }
 
-        // Parse service tasks
+        // Parse service tasks. A serviceTask with a `type` attribute (or `<zeebe:taskDefinition type="…"/>`)
+        // routes to a CustomTaskActivity dispatched to a registered plugin handler on a Worker silo.
+        // Without a type discriminator it remains a plain TaskActivity (engine no-op for backwards compatibility).
         foreach (var serviceTask in scopeElement.Elements(Bpmn + "serviceTask"))
         {
             var id = GetId(serviceTask);
-            Activity activity = new TaskActivity(id);
+            var taskType = ResolveServiceTaskType(serviceTask);
+            Activity activity;
+            if (!string.IsNullOrEmpty(taskType))
+            {
+                var inputMappings = ParseInputMappings(serviceTask);
+                var outputMappings = ParseOutputMappings(serviceTask);
+                activity = new CustomTaskActivity(id, taskType, inputMappings, outputMappings);
+            }
+            else
+            {
+                activity = new TaskActivity(id);
+            }
             activity = TryWrapMultiInstance(serviceTask, activity) ?? activity;
             activities.Add(activity);
             activityMap[id] = activity;
@@ -1231,4 +1244,119 @@ public partial class BpmnConverter : IBpmnConverter
     [LoggerMessage(EventId = 9000, Level = LogLevel.Warning,
         Message = "Complex gateway '{GatewayId}' has activationCondition but is detected as a fork — activationCondition is ignored on fork gateways")]
     private partial void LogActivationConditionIgnoredOnFork(string gatewayId);
+
+    private static readonly System.Text.RegularExpressions.Regex IdentifierRegex =
+        new("^[a-zA-Z_][a-zA-Z0-9_]*$", System.Text.RegularExpressions.RegexOptions.Compiled);
+
+    private static string? ResolveServiceTaskType(XElement serviceTask)
+    {
+        var attr = serviceTask.Attribute("type")?.Value;
+        if (!string.IsNullOrWhiteSpace(attr))
+            return attr;
+
+        var taskDef = serviceTask.Element(Bpmn + "extensionElements")?.Element(Zeebe + "taskDefinition");
+        var zType = taskDef?.Attribute("type")?.Value;
+        if (!string.IsNullOrWhiteSpace(zType))
+            return zType;
+
+        return null;
+    }
+
+    private static List<InputMapping> ParseInputMappings(XElement serviceTask)
+    {
+        var mappings = new List<InputMapping>();
+        var ioMapping = serviceTask.Element(Bpmn + "extensionElements")?.Element(Zeebe + "ioMapping");
+        if (ioMapping is null) return mappings;
+
+        foreach (var input in ioMapping.Elements(Zeebe + "input"))
+            mappings.Add(ParseInputMapping(input));
+
+        return mappings;
+    }
+
+    private static List<OutputMapping> ParseOutputMappings(XElement serviceTask)
+    {
+        var mappings = new List<OutputMapping>();
+        var ioMapping = serviceTask.Element(Bpmn + "extensionElements")?.Element(Zeebe + "ioMapping");
+        if (ioMapping is null) return mappings;
+
+        foreach (var output in ioMapping.Elements(Zeebe + "output"))
+            mappings.Add(ParseOutputMapping(output));
+
+        return mappings;
+    }
+
+    private static InputMapping ParseInputMapping(XElement input)
+    {
+        var source = input.Attribute("source")?.Value
+            ?? throw new InvalidOperationException("<zeebe:input> missing required 'source' attribute");
+        var target = input.Attribute("target")?.Value
+            ?? throw new InvalidOperationException("<zeebe:input> missing required 'target' attribute");
+
+        if (string.IsNullOrWhiteSpace(target))
+            throw new InvalidOperationException("<zeebe:input> 'target' is empty or whitespace-only");
+
+        if (!IdentifierRegex.IsMatch(target))
+            throw new InvalidOperationException(
+                $"<zeebe:input target=\"{target}\"> target must be a valid identifier (^[a-zA-Z_][a-zA-Z0-9_]*$)");
+
+        ValidateMappingSource(source, $"<zeebe:input target=\"{target}\">");
+
+        return new InputMapping(source, target);
+    }
+
+    private static OutputMapping ParseOutputMapping(XElement output)
+    {
+        var source = output.Attribute("source")?.Value
+            ?? throw new InvalidOperationException("<zeebe:output> missing required 'source' attribute");
+        var target = output.Attribute("target")?.Value
+            ?? throw new InvalidOperationException("<zeebe:output> missing required 'target' attribute");
+
+        if (string.IsNullOrWhiteSpace(target))
+            throw new InvalidOperationException("<zeebe:output> 'target' is empty or whitespace-only");
+
+        if (!IdentifierRegex.IsMatch(target))
+            throw new InvalidOperationException(
+                $"<zeebe:output target=\"{target}\"> target must be a valid identifier (^[a-zA-Z_][a-zA-Z0-9_]*$)");
+
+        if (target == "__response")
+            throw new InvalidOperationException(
+                "<zeebe:output target=\"__response\"> is reserved — providers populate it during execution; output mapping cannot target it directly");
+
+        ValidateMappingSource(source, $"<zeebe:output target=\"{target}\">");
+
+        return new OutputMapping(source, target);
+    }
+
+    private static void ValidateMappingSource(string source, string errorPrefix)
+    {
+        if (string.IsNullOrEmpty(source))
+            throw new InvalidOperationException($"{errorPrefix} has empty 'source' attribute");
+
+        if (source[0] != '=')
+            return;
+
+        var expr = source.Substring(1);
+        if (expr.Length == 0)
+            throw new InvalidOperationException($"{errorPrefix} 'source' is bare '=' with no expression");
+
+        if (expr[0] == '"')
+        {
+            if (expr.Length < 2 || expr[expr.Length - 1] != '"')
+                throw new InvalidOperationException($"{errorPrefix} has unmatched quote in source: '{source}'");
+            return;
+        }
+
+        if (expr == "true" || expr == "false" || expr == "null") return;
+        if (long.TryParse(expr, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out _)) return;
+        if (double.TryParse(expr, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out _)) return;
+
+        var segments = expr.Split('.');
+        foreach (var seg in segments)
+        {
+            if (!IdentifierRegex.IsMatch(seg))
+                throw new InvalidOperationException(
+                    $"{errorPrefix} has invalid path segment '{seg}' in source: '{source}'");
+        }
+    }
 }

--- a/src/Fleans/Fleans.ServiceDefaults/DTOs/CustomTaskCatalogEntryDto.cs
+++ b/src/Fleans/Fleans.ServiceDefaults/DTOs/CustomTaskCatalogEntryDto.cs
@@ -1,0 +1,8 @@
+namespace Fleans.ServiceDefaults.DTOs;
+
+/// <summary>Wire DTO for <c>GET /custom-tasks</c>. One per registered task type.</summary>
+public sealed record CustomTaskCatalogEntryDto(
+    string TaskType,
+    string? DisplayName,
+    string? ParameterSchemaJson,
+    IReadOnlyList<string> SiloNames);

--- a/src/Fleans/Fleans.Worker/CustomTasks/CustomTaskHandlerBase.cs
+++ b/src/Fleans/Fleans.Worker/CustomTasks/CustomTaskHandlerBase.cs
@@ -1,0 +1,147 @@
+using System.Dynamic;
+using Fleans.Application.CustomTasks;
+using Fleans.Application.Events;
+using Fleans.Application.Grains;
+using Fleans.Application.Logging;
+using Fleans.Domain.Events;
+using Fleans.Worker.Placement;
+using Microsoft.Extensions.Logging;
+using Orleans.Runtime;
+using Orleans.Streams;
+
+namespace Fleans.Worker.CustomTasks;
+
+/// <summary>
+/// Base class for plugin-supplied custom-task handlers. Subscribes to the shared
+/// <c>events/ExecuteCustomTaskEvent</c> stream, filters incoming events by <c>TaskType</c>,
+/// resolves input mappings, invokes the plugin's <see cref="ExecuteAsync"/>, projects
+/// outputs, and calls <see cref="IWorkflowInstanceGrain.CompleteActivity"/> /
+/// <see cref="IWorkflowInstanceGrain.FailActivity"/> using the same shape as
+/// <c>WorkflowExecuteScriptEventHandler</c>.
+///
+/// Plugin authors override <see cref="TaskType"/> and <see cref="ExecuteAsync"/>; the
+/// stream subscription, filtering, error path, and completion callback are all owned
+/// by the base.
+/// </summary>
+[ImplicitStreamSubscription(WorkflowEventsPublisher.StreamNameSpace)]
+[WorkerPlacement]
+public abstract partial class CustomTaskHandlerBase : Grain, IAsyncObserver<ExecuteCustomTaskEvent>
+{
+    private readonly ILogger _logger;
+    private readonly IGrainFactory _grainFactory;
+
+    protected CustomTaskHandlerBase(ILogger logger, IGrainFactory grainFactory)
+    {
+        _logger = logger;
+        _grainFactory = grainFactory;
+    }
+
+    /// <summary>The BPMN <c>type="…"</c> discriminator this handler claims.</summary>
+    protected abstract string TaskType { get; }
+
+    /// <summary>
+    /// Executes the plugin's work. Inputs are resolved from the workflow scope per
+    /// <c>&lt;zeebe:input&gt;</c> mappings; the returned dictionary feeds output mapping
+    /// (so plugins should write fields the outputs reference, e.g. <c>__response</c>).
+    /// </summary>
+    protected abstract Task<IDictionary<string, object?>> ExecuteAsync(
+        IDictionary<string, object?> resolvedInputs,
+        ExpandoObject variables,
+        CancellationToken cancellationToken);
+
+    public override async Task OnActivateAsync(CancellationToken cancellationToken)
+    {
+        var streamProvider = this.GetStreamProvider(WorkflowEventsPublisher.StreamProvider);
+        var streamId = StreamId.Create(WorkflowEventsPublisher.StreamNameSpace, nameof(ExecuteCustomTaskEvent));
+        var stream = streamProvider.GetStream<ExecuteCustomTaskEvent>(streamId);
+
+        var handles = await stream.GetAllSubscriptionHandles();
+        if (handles is { Count: > 0 })
+        {
+            foreach (var handle in handles)
+                await handle.ResumeAsync(OnNextAsync, OnErrorAsync, OnCompletedAsync);
+        }
+        else
+        {
+            await stream.SubscribeAsync(OnNextAsync, OnErrorAsync, OnCompletedAsync);
+        }
+
+        await base.OnActivateAsync(cancellationToken);
+    }
+
+    public async Task OnNextAsync(ExecuteCustomTaskEvent item, StreamSequenceToken? token = null)
+    {
+        if (!string.Equals(item.TaskType, TaskType, StringComparison.OrdinalIgnoreCase))
+            return;
+
+        using var scope = WorkflowLoggingContext.BeginWorkflowScope(
+            _logger, item.WorkflowId, item.ProcessDefinitionId, item.WorkflowInstanceId, item.ActivityId);
+
+        LogHandling(item.ActivityId, item.TaskType);
+
+        var workflowInstance = _grainFactory.GetGrain<IWorkflowInstanceGrain>(item.WorkflowInstanceId);
+
+        try
+        {
+            var variables = await workflowInstance.GetVariables(item.VariablesId);
+
+            var resolved = new Dictionary<string, object?>(StringComparer.Ordinal);
+            foreach (var im in item.InputMappings)
+                resolved[im.Target] = MappingResolver.Resolve(im.Source, (IDictionary<string, object?>)variables);
+
+            var pluginResult = await ExecuteAsync(resolved, variables, CancellationToken.None);
+
+            var outputs = new ExpandoObject();
+            var outputsDict = (IDictionary<string, object?>)outputs;
+            foreach (var om in item.OutputMappings)
+                outputsDict[om.Target] = MappingResolver.Resolve(om.Source, pluginResult);
+
+            await workflowInstance.CompleteActivity(item.ActivityId, item.ActivityInstanceId, outputs);
+        }
+        catch (Exception ex)
+        {
+            LogExecuteFailed(ex, item.ActivityId, item.TaskType);
+            try
+            {
+                await workflowInstance.FailActivity(item.ActivityId, item.ActivityInstanceId, ex);
+            }
+            catch (Exception failEx)
+            {
+                LogFailActivityFailed(failEx, item.ActivityId);
+                throw; // let stream provider retry — domain idempotency guards handle duplicates
+            }
+        }
+    }
+
+    public Task OnCompletedAsync()
+    {
+        LogStreamCompleted();
+        return Task.CompletedTask;
+    }
+
+    public Task OnErrorAsync(Exception ex)
+    {
+        LogStreamError(ex);
+        return Task.CompletedTask;
+    }
+
+    [LoggerMessage(EventId = 4030, Level = LogLevel.Information,
+        Message = "Handling custom-task event for activity {ActivityId} (taskType={TaskType})")]
+    private partial void LogHandling(string activityId, string taskType);
+
+    [LoggerMessage(EventId = 4031, Level = LogLevel.Error,
+        Message = "Custom-task plugin execution failed for activity {ActivityId} (taskType={TaskType})")]
+    private partial void LogExecuteFailed(Exception ex, string activityId, string taskType);
+
+    [LoggerMessage(EventId = 4032, Level = LogLevel.Information,
+        Message = "Custom-task event stream completed")]
+    private partial void LogStreamCompleted();
+
+    [LoggerMessage(EventId = 4033, Level = LogLevel.Error,
+        Message = "Custom-task event stream error")]
+    private partial void LogStreamError(Exception ex);
+
+    [LoggerMessage(EventId = 4034, Level = LogLevel.Critical,
+        Message = "FailActivity call itself failed for activity {ActivityId} — workflow may be stalled")]
+    private partial void LogFailActivityFailed(Exception ex, string activityId);
+}

--- a/src/Fleans/Fleans.Worker/CustomTasks/CustomTaskPluginDescriptor.cs
+++ b/src/Fleans/Fleans.Worker/CustomTasks/CustomTaskPluginDescriptor.cs
@@ -1,0 +1,11 @@
+namespace Fleans.Worker.CustomTasks;
+
+/// <summary>
+/// Per-plugin descriptor registered into DI by <c>AddCustomTaskPlugin&lt;THandler&gt;()</c>
+/// and consumed by <c>CustomTaskPluginRegistrar</c> at silo startup to push the registration
+/// to the catalog.
+/// </summary>
+public sealed record CustomTaskPluginDescriptor(
+    string TaskType,
+    string? DisplayName,
+    string? ParameterSchemaJson);

--- a/src/Fleans/Fleans.Worker/CustomTasks/CustomTaskPluginRegistrar.cs
+++ b/src/Fleans/Fleans.Worker/CustomTasks/CustomTaskPluginRegistrar.cs
@@ -1,0 +1,94 @@
+using Fleans.Application.CustomTasks;
+using Microsoft.Extensions.Logging;
+using Orleans.Runtime;
+
+namespace Fleans.Worker.CustomTasks;
+
+/// <summary>
+/// Pushes Worker-side plugin registrations to the Core-side <see cref="ICustomTaskCatalogGrain"/>
+/// after the silo has fully joined the cluster (<see cref="ServiceLifecycleStage.Active"/>).
+/// One-shot at startup with bounded retry; departure is detected by the catalog's own
+/// membership-reconciliation timer rather than by silo shutdown signals.
+/// </summary>
+internal sealed partial class CustomTaskPluginRegistrar : ILifecycleParticipant<ISiloLifecycle>
+{
+    private readonly IGrainFactory _grainFactory;
+    private readonly ILocalSiloDetails _siloDetails;
+    private readonly IEnumerable<CustomTaskPluginDescriptor> _descriptors;
+    private readonly ILogger<CustomTaskPluginRegistrar> _logger;
+
+    private static readonly TimeSpan[] RetryDelays =
+    [
+        TimeSpan.FromSeconds(2),
+        TimeSpan.FromSeconds(5),
+        TimeSpan.FromSeconds(15),
+    ];
+
+    public CustomTaskPluginRegistrar(
+        IGrainFactory grainFactory,
+        ILocalSiloDetails siloDetails,
+        IEnumerable<CustomTaskPluginDescriptor> descriptors,
+        ILogger<CustomTaskPluginRegistrar> logger)
+    {
+        _grainFactory = grainFactory;
+        _siloDetails = siloDetails;
+        _descriptors = descriptors;
+        _logger = logger;
+    }
+
+    public void Participate(ISiloLifecycle observer) =>
+        observer.Subscribe(
+            nameof(CustomTaskPluginRegistrar),
+            ServiceLifecycleStage.Active,
+            OnStart);
+
+    private async Task OnStart(CancellationToken ct)
+    {
+        var catalog = _grainFactory.GetGrain<ICustomTaskCatalogGrain>(0);
+        foreach (var descriptor in _descriptors)
+            await RegisterWithRetry(catalog, descriptor, ct);
+    }
+
+    private async Task RegisterWithRetry(
+        ICustomTaskCatalogGrain catalog,
+        CustomTaskPluginDescriptor descriptor,
+        CancellationToken ct)
+    {
+        for (var attempt = 0; attempt <= RetryDelays.Length; attempt++)
+        {
+            try
+            {
+                await catalog.Register(new CustomTaskRegistration(
+                    descriptor.TaskType,
+                    descriptor.DisplayName,
+                    descriptor.ParameterSchemaJson,
+                    _siloDetails.Name));
+                LogRegistered(descriptor.TaskType, _siloDetails.Name);
+                return;
+            }
+            catch (Exception ex) when (attempt < RetryDelays.Length)
+            {
+                LogRetrying(ex, descriptor.TaskType, attempt + 1, RetryDelays.Length + 1, RetryDelays[attempt]);
+                try { await Task.Delay(RetryDelays[attempt], ct); }
+                catch (OperationCanceledException) { return; }
+            }
+            catch (Exception ex)
+            {
+                LogPermanentlyFailed(ex, descriptor.TaskType, _siloDetails.Name);
+                return; // warn-and-continue — handler still receives events; only catalog UI is blind
+            }
+        }
+    }
+
+    [LoggerMessage(EventId = 9330, Level = LogLevel.Information,
+        Message = "Registered custom-task plugin '{TaskType}' on silo '{SiloName}' with the catalog")]
+    private partial void LogRegistered(string taskType, string siloName);
+
+    [LoggerMessage(EventId = 9331, Level = LogLevel.Warning,
+        Message = "Catalog Register failed for '{TaskType}' (attempt {Attempt}/{Max}); retrying in {Delay}")]
+    private partial void LogRetrying(Exception ex, string taskType, int attempt, int max, TimeSpan delay);
+
+    [LoggerMessage(EventId = 9332, Level = LogLevel.Error,
+        Message = "Catalog Register permanently failed for '{TaskType}' on silo '{SiloName}' — plugin will be invisible to the catalog UI until next silo restart")]
+    private partial void LogPermanentlyFailed(Exception ex, string taskType, string siloName);
+}

--- a/src/Fleans/Fleans.Worker/CustomTasks/CustomTaskServiceCollectionExtensions.cs
+++ b/src/Fleans/Fleans.Worker/CustomTasks/CustomTaskServiceCollectionExtensions.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Orleans.Runtime;
+
+namespace Fleans.Worker.CustomTasks;
+
+/// <summary>
+/// Plugin authors call <see cref="AddCustomTaskPlugin{THandler}"/> from their
+/// <c>services.AddXxxPlugin(...)</c> extension to (a) bind the handler grain class
+/// into the silo (Orleans discovers it automatically via assembly scanning), and
+/// (b) register the plugin's metadata so <see cref="CustomTaskPluginRegistrar"/>
+/// announces it to the catalog at silo startup.
+/// </summary>
+public static class CustomTaskServiceCollectionExtensions
+{
+    public static IServiceCollection AddCustomTaskPlugin<THandler>(
+        this IServiceCollection services,
+        string taskType,
+        string? displayName = null,
+        string? parameterSchemaJson = null)
+        where THandler : CustomTaskHandlerBase
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(taskType);
+
+        services.AddSingleton(new CustomTaskPluginDescriptor(taskType, displayName, parameterSchemaJson));
+
+        // Register the lifecycle participant exactly once even if multiple plugins are added.
+        services.TryAddSingleton<CustomTaskPluginRegistrar>();
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<ILifecycleParticipant<ISiloLifecycle>>(
+            sp => sp.GetRequiredService<CustomTaskPluginRegistrar>()));
+
+        return services;
+    }
+}

--- a/tests/manual/37-custom-task-framework/stub-custom-task.bpmn
+++ b/tests/manual/37-custom-task-framework/stub-custom-task.bpmn
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="defs_stub_custom_task" targetNamespace="http://fleans.io/bpmn">
+  <bpmn:process id="stub-custom-task" isExecutable="true">
+    <bpmn:startEvent id="start" />
+    <bpmn:serviceTask id="ct1" type="stub-task">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input  source="hello"        target="greeting" />
+          <zeebe:output source="=__response"  target="echo" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="end" />
+    <bpmn:sequenceFlow id="f1" sourceRef="start" targetRef="ct1" />
+    <bpmn:sequenceFlow id="f2" sourceRef="ct1"   targetRef="end" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="diag">
+    <bpmndi:BPMNPlane id="plane" bpmnElement="stub-custom-task">
+      <bpmndi:BPMNShape id="s_start" bpmnElement="start"><dc:Bounds x="100" y="100" width="36" height="36" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="s_ct1"   bpmnElement="ct1"><dc:Bounds x="200" y="80"  width="100" height="80" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="s_end"   bpmnElement="end"><dc:Bounds x="350" y="100" width="36" height="36" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="e_f1" bpmnElement="f1"><di:waypoint x="136" y="118" /><di:waypoint x="200" y="118" /></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="e_f2" bpmnElement="f2"><di:waypoint x="300" y="118" /><di:waypoint x="350" y="118" /></bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/manual/37-custom-task-framework/test-plan.md
+++ b/tests/manual/37-custom-task-framework/test-plan.md
@@ -1,0 +1,85 @@
+# Manual Test Plan #37 — Custom Task Framework
+
+Verifies the custom-task framework end-to-end: BPMN parses to a `CustomTaskActivity`, the activity emits an event, the catalog reflects registered/dropped plugins, and a manual `complete-activity` API call resumes a workflow whose plugin is unregistered.
+
+## Prerequisites
+- Aspire stack running: `dotnet run --project Fleans.Aspire` (from `src/Fleans/`).
+- Clean dev DB (delete the SQLite file or set a fresh `FLEANS_SQLITE_CONNECTION`).
+- Web UI reachable at `https://localhost:7124`.
+- API origin: `https://localhost:7140`.
+- Fixture: `stub-custom-task.bpmn` (this folder).
+
+## Scenario 1 — Unregistered plugin: activity stays Active until manually completed
+
+1. **Deploy the workflow.**
+   ```bash
+   curl -k -X POST https://localhost:7140/Workflow/deploy \
+     -H "Content-Type: application/json" \
+     -d "{\"BpmnXml\": $(jq -Rs . < tests/manual/37-custom-task-framework/stub-custom-task.bpmn)}"
+   ```
+   Expect HTTP 200 with `{"ProcessDefinitionKey":"stub-custom-task","Version":1}`.
+
+2. **Confirm the catalog has no `stub-task` entry.**
+   ```bash
+   curl -k https://localhost:7140/custom-tasks
+   ```
+   Expect `[]` (or no entry with `taskType=stub-task`).
+
+3. **Start an instance.**
+   ```bash
+   curl -k -X POST https://localhost:7140/Workflow/start \
+     -H "Content-Type: application/json" \
+     -d '{"WorkflowId":"stub-custom-task"}'
+   ```
+   Capture the returned instance ID.
+
+4. **Confirm the activity is Active.**
+   ```bash
+   curl -k https://localhost:7140/Workflow/instances/<instance-id>/state
+   ```
+   Expect `activeActivityIds` contains `ct1`; `isCompleted: false`.
+
+5. **Manually complete the activity** (no plugin will, so this is the only way forward).
+   ```bash
+   curl -k -X POST https://localhost:7140/Workflow/complete-activity \
+     -H "Content-Type: application/json" \
+     -d '{"WorkflowInstanceId":"<instance-id>","ActivityId":"ct1","Variables":{"echo":"manual"}}'
+   ```
+
+6. **Confirm completion.** The state endpoint now returns `isCompleted: true` and `echo` shows up in the variable projection.
+
+## Scenario 2 — Registered plugin: end-to-end claim and complete
+
+A real plugin must exist in the silo's host. For this scenario, build a tiny in-tree stub plugin (e.g. `Fleans.Plugins.StubTask` referencing `Fleans.Worker`) that returns `{"__response":"hi from stub"}` from `ExecuteAsync`. Register it in `Fleans.Aspire`'s host setup with `services.AddCustomTaskPlugin<StubTaskHandler>("stub-task", "Stub task")`.
+
+1. **Restart the Aspire stack** so the registrar runs and announces the plugin.
+2. **Confirm the catalog now lists the plugin.**
+   ```bash
+   curl -k https://localhost:7140/custom-tasks
+   ```
+   Expect one entry with `taskType=stub-task` and at least one silo in `siloNames`.
+3. **Start an instance** (same body as Scenario 1 step 3).
+4. **Within ~1 s** the activity should auto-complete: state shows `isCompleted: true` and `echo == "hi from stub"`.
+
+## Scenario 3 — Catalog reconciliation drops a stopped silo
+
+Requires multi-silo setup (e.g. Docker Compose with two worker silos, each registered with the stub plugin).
+
+1. Start cluster, observe `GET /custom-tasks` returns one `stub-task` entry with two silos in `siloNames`.
+2. Stop one worker silo (`docker compose stop fleans-core-2`).
+3. Wait ≤ 30 s for the catalog reconcile timer.
+4. Re-query `GET /custom-tasks` — expect the entry now lists only the surviving silo.
+
+## Expected outcomes (checklist)
+
+- [ ] Scenario 1, step 1: deploy succeeds.
+- [ ] Scenario 1, step 2: catalog returns `[]`.
+- [ ] Scenario 1, step 4: activity is Active with `ct1`.
+- [ ] Scenario 1, step 5: complete-activity succeeds.
+- [ ] Scenario 1, step 6: workflow completes; `echo` variable holds `"manual"`.
+- [ ] Scenario 2: plugin handler runs automatically; workflow completes with `echo == "hi from stub"`.
+- [ ] Scenario 3: dropped silo disappears from `siloNames` within 30 s; surviving silo entry remains.
+
+## Known limitations (v1)
+- Catalog state is in-memory only; Core silo restart wipes it until Worker silos re-register at their own next startup. Persistence is a v2 follow-up.
+- Per-task-type stream partitioning is not implemented; every plugin handler receives every `ExecuteCustomTaskEvent` and discards mismatches with an early return.

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -34,6 +34,7 @@ export default defineConfig({
             { label: 'Architecture', slug: 'concepts/architecture' },
             { label: 'What is BPMN?', slug: 'concepts/bpmn-overview' },
             { label: 'BPMN Support', slug: 'concepts/bpmn-support' },
+            { label: 'Custom Tasks', slug: 'concepts/custom-tasks' },
           ],
         },
         {

--- a/website/src/content/docs/concepts/custom-tasks.md
+++ b/website/src/content/docs/concepts/custom-tasks.md
@@ -1,0 +1,116 @@
+---
+title: Custom Tasks
+description: Plug your own service tasks into Fleans by writing a worker-side handler that subscribes to ExecuteCustomTaskEvent and self-filters by task type.
+---
+
+A **custom task** is a `<bpmn:serviceTask type="...">` whose execution is supplied by a plugin you write. The plugin lives on a Worker silo as a grain that derives from `CustomTaskHandlerBase`; the engine does not need to know what your plugin does — only that *some* worker can claim the `type`.
+
+This is the recommended pattern for anything Fleans doesn't ship in the box: REST calls, email, Slack, custom database queries, file uploads, etc.
+
+## How it works
+
+1. **BPMN parsing.** The converter sees `<serviceTask type="rest-call">` (or the Camunda equivalent `<extensionElements><zeebe:taskDefinition type="rest-call"/></extensionElements>`) and produces a `CustomTaskActivity` carrying the task type and any `<zeebe:ioMapping>` declarations.
+2. **Activity emits an event.** When the workflow reaches the activity, it publishes `ExecuteCustomTaskEvent { TaskType, InputMappings, OutputMappings, VariablesId, … }` on the shared `events/ExecuteCustomTaskEvent` Orleans stream.
+3. **Plugin handlers fan out and self-filter.** Every plugin's `CustomTaskHandlerBase` subclass on every Worker silo receives the event via Orleans implicit-stream subscription. Each handler checks `if (item.TaskType != MyTaskType) return;` and only one plugin claims the event.
+4. **Plugin runs.** The base class resolves input mappings against the workflow's variable scope, calls your `ExecuteAsync(...)`, projects outputs against the result, then calls `IWorkflowInstanceGrain.CompleteActivity` (or `FailActivity` on exception).
+5. **Catalog tracks who's alive.** Each Worker silo announces its plugins to a Core-side `ICustomTaskCatalogGrain` at silo startup. The catalog reconciles every 30 s against `IManagementGrain.GetDetailedHosts()` and drops entries for silos no longer in the cluster. The management UI reads `GET /custom-tasks`.
+
+## Authoring a plugin
+
+A minimal "say hi" plugin:
+
+```csharp
+using Fleans.Worker.CustomTasks;
+
+public sealed class HiPluginHandler(
+    ILogger<HiPluginHandler> logger,
+    IGrainFactory grainFactory)
+    : CustomTaskHandlerBase(logger, grainFactory)
+{
+    protected override string TaskType => "hi";
+    protected override string? DisplayName => "Say hi";
+
+    protected override Task<IDictionary<string, object?>> ExecuteAsync(
+        IDictionary<string, object?> resolvedInputs,
+        ExpandoObject variables,
+        CancellationToken cancellationToken)
+    {
+        var name = resolvedInputs.TryGetValue("name", out var n) ? n?.ToString() : "world";
+        return Task.FromResult<IDictionary<string, object?>>(new Dictionary<string, object?>
+        {
+            ["__response"] = $"hi, {name}!",
+        });
+    }
+}
+```
+
+`[ImplicitStreamSubscription]` and `[WorkerPlacement]` are inherited from the base class — you do not need to repeat them on the subclass.
+
+Register the plugin in the Worker silo's host:
+
+```csharp
+services.AddCustomTaskPlugin<HiPluginHandler>(
+    taskType: "hi",
+    displayName: "Say hi");
+```
+
+Reference your plugin from BPMN:
+
+```xml
+<bpmn:serviceTask id="greet" type="hi">
+  <bpmn:extensionElements>
+    <zeebe:ioMapping>
+      <zeebe:input  source="=customerName" target="name" />
+      <zeebe:output source="=__response"   target="greeting" />
+    </zeebe:ioMapping>
+  </bpmn:extensionElements>
+</bpmn:serviceTask>
+```
+
+When the workflow reaches `greet`, the plugin runs, and the variable `greeting` ends up holding `"hi, alice!"` (assuming `customerName` was `"alice"`).
+
+## Mapping grammar
+
+Sources and targets in `<zeebe:input>` / `<zeebe:output>` follow this grammar (validated at BPMN deploy time):
+
+| Form | Example | Meaning |
+|------|---------|---------|
+| `=identifier(.path)*` | `=order.total` | Walk through the variable scope |
+| `="literal"` | `="GET"` | Quoted string literal |
+| `=42` / `=3.14` / `=true` / `=false` / `=null` | `=true` | Primitive literal |
+| Bare string | `application/json` | Treated as a string literal |
+
+Targets must be valid identifiers (`^[a-zA-Z_][a-zA-Z0-9_]*$`). The target `__response` is **reserved** on `<zeebe:output>` — plugins write their result under that key in the dictionary they return, and your output mappings reference it via `=__response.body` or similar.
+
+## What lives where
+
+| Piece | Project | Purpose |
+|-------|---------|---------|
+| `CustomTaskActivity`, `InputMapping`, `OutputMapping`, `ExecuteCustomTaskEvent`, `CustomTaskFailedActivityException` | `Fleans.Domain` | Pure data contracts crossing grain boundaries. |
+| `MappingResolver`, `ICustomTaskCatalogGrain`, `CustomTaskCatalogGrain`, `CustomTaskRegistration`, `CustomTaskCatalogEntry` | `Fleans.Application` | Core-side catalog grain; the only Core-hosted custom-task piece. |
+| `CustomTaskHandlerBase`, `CustomTaskPluginRegistrar`, `CustomTaskPluginDescriptor`, `AddCustomTaskPlugin<T>(…)` | `Fleans.Worker` | Worker-side base class your plugin extends, plus the lifecycle hook that announces plugins to the catalog. |
+| `CustomTasksController` (`GET /custom-tasks`, `GET /custom-tasks/{type}`) | `Fleans.Api` | Reads the catalog for the management UI. |
+
+## Failure semantics
+
+- Throw `CustomTaskFailedActivityException(int code, string message)` from `ExecuteAsync` to fail the activity with a typed error. The code surfaces in the activity's `ErrorState.Code`, so workflow authors can route via boundary error events on specific codes.
+- Any other exception fails the activity with code 500 (the standard `ActivityException` mapping).
+- If `FailActivity` itself fails (e.g. the workflow grain is unavailable), the handler rethrows so the Orleans stream provider retries — domain idempotency guards handle the duplicate.
+
+## Catalog & liveness (v1)
+
+- Workers announce themselves once at silo startup via `ILifecycleParticipant<ISiloLifecycle>` at stage `Active`, with bounded retry (2 s, 5 s, 15 s) if the catalog grain is briefly unreachable.
+- The catalog polls `IManagementGrain.GetDetailedHosts()` every 30 s and drops entries whose silo is no longer in `{Joining, Active, ShuttingDown}`. No heartbeats from workers.
+- Catalog state is in-memory only in v1. After a Core silo restart, the catalog repopulates as Worker silos restart and re-register; persistence (so the UI is correct immediately after Core restart) is a v2 follow-up.
+
+## Limitations
+
+- Plugins are .NET assemblies referenced from the Worker silo's host project. Hot-loading is out of scope.
+- Per-plugin placement filters (route `rest-call` only to silos with that plugin) are out of scope; today the Worker placement director routes any `[WorkerPlacement]` grain to any worker silo. Operators choose topology by DI-registering only the plugins they want on each worker.
+- Per-task-type stream partitioning (one Orleans stream per `taskType`) is deferred — for now every plugin handler receives every event and discards mismatches with an `if (...) return;` early-out.
+
+## Reference
+
+- [Issue #357](https://github.com/nightBaker/fleans/issues/357) — design history (v1–v12).
+- The script-task event handler (`Fleans.Application/Events/Handlers/WorkflowExecuteScriptEventHandler.cs`) is the structural model `CustomTaskHandlerBase` follows.
+- Manual test plan: `tests/manual/37-custom-task-framework/test-plan.md`.


### PR DESCRIPTION
## Summary

Closes part of #357 — sub-issue A (framework scaffold + catalog grain), per design v12.

This PR is a **hard-reset** of `feature/custom-task-framework` onto current `main`, replacing the v1–v9 provider-grain registry approach with the v12 architecture: per-plugin handler grains that subscribe to a shared event stream and self-filter by task type, plus a Core-side catalog grain that tracks which plugins are alive on which Worker silos.

Sub-issues B (REST plugin), C (UI page), and D (author guide) are tracked as follow-ups in #357.

## What's in the PR

### Architecture (v12)

```
[BPMN] <serviceTask type="..."> + <zeebe:ioMapping>
   ↓ BpmnConverter
[CustomTaskActivity]
   ↓ ExecuteAsync — publishes ExecuteCustomTaskEvent
[ExecuteCustomTaskEvent on stream "events/ExecuteCustomTaskEvent"]
   ↓ ↓ ↓ (fan-out, one activation per concrete plugin handler class)
[RestCallerHandler]   [EmailSenderHandler]   …  ← each [WorkerPlacement]
  taskType=rest-call    taskType=email
  if (!match) return;   if (!match) return;
   ↓ resolve inputs (MappingResolver), run plugin work, project outputs
   ↓ workflowInstance.CompleteActivity / FailActivity
```

Catalog flow:
```
[Worker silo boot]
  CustomTaskPluginRegistrar (ILifecycleParticipant<ISiloLifecycle>, stage=Active)
    foreach descriptor in DI:
      catalog.Register(taskType, siloName, schema)        ← one-shot, no heartbeat

[Core silo]
  CustomTaskCatalogGrain ([CorePlacement])
    RegisterTimer(period=30s, ReconcileWithMembership)    ← polls IManagementGrain
                                                            and drops entries for
                                                            departed silos
    GetAll() / Get(taskType) → /custom-tasks API
```

### Files

**Domain (`Fleans.Domain`)**
- `Activities/CustomTaskActivity.cs`, `Activities/Mappings.cs`
- `Errors/CustomTaskFailedActivityException.cs` — typed failure with `(code, message)`
- `Events/ExecuteCustomTaskEvent.cs`
- `GrainStorageNames.cs` — added `CustomTaskCatalog` constant

**Application (`Fleans.Application`)**
- `CustomTasks/ICustomTaskCatalogGrain.cs` + `CustomTaskCatalogGrain.cs` — `[CorePlacement]` singleton with 30s reconcile timer polling `IManagementGrain.GetDetailedHosts()`; keeps entries for silos in `{Joining, Active, ShuttingDown}`, drops the rest
- `CustomTasks/CustomTaskRegistration.cs` + `CustomTaskCatalogEntry.cs`
- `CustomTasks/MappingResolver.cs` — input/output mapping path walker
- `Events/WorkflowEventsPublisher.cs` — switch case for `ExecuteCustomTaskEvent`
- `Logging/WorkflowLoggingContext.cs` — visibility raised to `public` for cross-assembly use from the Worker handler base

**Worker (`Fleans.Worker`)**
- `CustomTasks/CustomTaskHandlerBase.cs` — abstract base; subclasses inherit `[WorkerPlacement]` + `[ImplicitStreamSubscription("events")]`. Subclasses override `TaskType` and `ExecuteAsync(...)` only; the base owns Orleans stream subscription, taskType filter, error path, and `IWorkflowInstanceGrain.CompleteActivity` / `FailActivity` callbacks (line-for-line analogue of `WorkflowExecuteScriptEventHandler`)
- `CustomTasks/CustomTaskPluginRegistrar.cs` — `ILifecycleParticipant<ISiloLifecycle>` at `ServiceLifecycleStage.Active` with bounded retry (2s, 5s, 15s) for catalog-cold-start resilience; warn-and-continue on terminal failure
- `CustomTasks/CustomTaskPluginDescriptor.cs`
- `CustomTasks/CustomTaskServiceCollectionExtensions.cs` — `services.AddCustomTaskPlugin<THandler>(taskType, displayName?, parameterSchemaJson?)` DI extension

**Infrastructure (`Fleans.Infrastructure`)**
- `Bpmn/BpmnConverter.cs` — `<serviceTask type="...">` and `<zeebe:taskDefinition type="...">` routing to `CustomTaskActivity`; `<zeebe:ioMapping><zeebe:input/output>` parsing with target identifier validation; mapping-source grammar validation at deploy time; `__response` reserved on output targets

**Api (`Fleans.Api`)**
- `Controllers/CustomTasksController.cs` — `GET /custom-tasks` (list), `GET /custom-tasks/{taskType}` (single)
- `Fleans.ServiceDefaults/DTOs/CustomTaskCatalogEntryDto.cs`

**Tests (39 new)**
- `Fleans.Domain.Tests/CustomTaskActivityTests.cs` — 4 (ctor / property / null / exception state-mapping)
- `Fleans.Application.Tests/CustomTasks/MappingResolverTests.cs` — 8 (carry-over: all four source forms + error paths)
- `Fleans.Application.Tests/CustomTasks/CustomTaskCatalogGrainTests.cs` — 6 (register / upsert / aggregate / case-insensitive / unknown-type)
- `Fleans.Infrastructure.Tests/BpmnConverter/CustomTaskRoutingTests.cs` — 21 (carry-over: routing + io-mapping deploy-time validation)

**Docs**
- `website/src/content/docs/concepts/custom-tasks.md` — rewritten for v12
- `website/astro.config.mjs` — sidebar entry under Concepts
- `README.md` — Service Task row in the BPMN elements table
- `CLAUDE.md` — "How to Add a Custom Task Plugin" section + regression list entry #37

**Manual test plan**
- `tests/manual/37-custom-task-framework/stub-custom-task.bpmn` + `test-plan.md` — three scenarios (unregistered plugin → manual complete-activity; registered plugin → end-to-end auto-complete; multi-silo reconcile drops stopped silo)

## Key decisions

1. **No edits to `WorkflowExecution.cs` / `WorkflowInstance.Infrastructure.cs`.** `CustomTaskActivity` mirrors `ScriptTask`'s publish-event-and-return-empty pattern verbatim. No new `IExecutionCommand` record; engine aggregate plays no role in the dispatch path.
2. **Per-plugin grain class, not a shared `ICustomTaskExecutorGrain`.** Each plugin has its own concrete grain. Orleans single-activation on a non-`[StatelessWorker]` `[ImplicitStreamSubscription]` grain gives one activation per plugin class cluster-wide; the in-base `if (TaskType != ...) return;` filter handles fan-out cheaply.
3. **Catalog uses cluster-membership polling, not heartbeats.** `IManagementGrain.GetDetailedHosts(onlyActive: false)` polled every 30 s — same precedent as `WorkerPlacementDirector.cs:36` and `CorePlacementDirector.cs:36`. No async-enumerable subscriptions, no fire-and-forget Tasks on the grain, no `IsAlive()` callbacks (which couldn't reach the implicit-subscription activation by `Guid` anyway).
4. **Registrar at `ServiceLifecycleStage.Active`, not `IHostedService`.** Guarantees the silo has finished joining the cluster before the Register call lands.
5. **Reconcile keeps `Joining|Active|ShuttingDown`.** Tolerant of in-flight silo state transitions; freshly-registered entries from a still-`Joining` peer survive the reconcile pass.

## Deviations from v12 design

1. **Catalog state is in-memory only in v1**, not `IPersistentState`. After a Core silo restart, the catalog repopulates as Worker silos restart and re-register. EF-backed persistence (so the UI is correct immediately after Core restart) is a v2 follow-up — the per-entry table + EF migrations for both SQLite and PostgreSQL providers are sub-issue A2 work; the in-memory model is sufficient for the dev/Aspire path where Core and Worker share a process. **Documented in the docs page and in the catalog grain's class summary.**
2. **End-to-end TestCluster integration test deferred to manual test plan #37.** Orleans assembly-part discovery for test-assembly-defined plugin handlers is non-trivial (the runtime walks production assemblies referenced by the silo, not the test assembly that defines stub handlers). The framework PR's coverage is 39 unit tests + the BPMN routing tests + the catalog grain tests; the dispatch path is structurally identical to `WorkflowExecuteScriptEventHandler` which already has full coverage.

## How to test

- [x] `dotnet test` — full suite passes (~600 tests, 0 failures, 5 pre-existing skips).
- [x] `cd website && npm run build` — clean (17 pages including new `/concepts/custom-tasks/`).
- [ ] Manual test plan #37 — three scenarios listed in `tests/manual/37-custom-task-framework/test-plan.md`.

## Follow-ups (filed against #357)

- **Sub-issue B** — `Fleans.Plugins.RestCaller` end-to-end with a Kestrel mock-server hermetic test.
- **Sub-issue C** — `CustomTasks.razor` admin page consuming `GET /custom-tasks`.
- **Sub-issue D** — plugin author guide on the website.
- **A2** — EF-backed catalog persistence (SQLite + Postgres migrations) so the UI is immediately correct after Core silo restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
