### PR TITLE
feat(#240): k6 parallel branching load scenario

### DIFF
--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -14,6 +14,7 @@ k6 load test suite for the Fleans workflow engine.
 |--------|---------|---------|
 | `scripts/setup.js` | Deploy BPMN fixtures | `k6 run scripts/setup.js` (run once) |
 | `scripts/linear.js` | Scenario 1: linear throughput | `k6 run scripts/linear.js` |
+| `scripts/parallel.js` | Scenario 2: parallel branching (3-branch fork/join) | `k6 run scripts/parallel.js` |
 | `scripts/events.js` | Scenario 3 — event-driven with message correlation | `k6 run scripts/events.js` |
 | `scripts/mixed.js` | Mixed workload combining all scenarios | `k6 run scripts/mixed.js` |
 | `scripts/metrics.js` | Shared metric definitions | Imported by scenario scripts |
@@ -92,6 +93,20 @@ k6 run --vus 5 --iterations 20 --insecure-skip-tls-verify tests/load/scripts/lin
 
 > **Warning:** Do NOT run the full 500-VU scenario against a local single-node dev setup.
 > It generates ~5 000 workflow starts/second and will overwhelm a dev database.
+
+### 3. Run parallel branching scenario
+
+**Cloud / Docker Compose cluster (full load):**
+```bash
+k6 run --insecure-skip-tls-verify tests/load/scripts/parallel.js
+```
+
+**Local connectivity check (safe for dev):**
+```bash
+k6 run --vus 5 --iterations 20 --insecure-skip-tls-verify tests/load/scripts/parallel.js
+```
+
+`parallel.js` shares the same VU profile and `workflow_start_duration` metric as `linear.js`, so the two scripts can be compared directly. The fixture is a 3-branch fork/join (`branchA`/`branchB`/`branchC`); fork/join completion timing is asynchronous in Orleans and is **not** captured by `workflow_start_duration` — that metric records `POST /Workflow/start` HTTP latency only. End-to-end fork/join latency is covered by issue #244.
 
 ## Environment Variables
 

--- a/tests/load/scripts/parallel.js
+++ b/tests/load/scripts/parallel.js
@@ -1,0 +1,65 @@
+// tests/load/scripts/parallel.js
+//
+// Scenario 2 — parallel branching: ramp to 500 VUs, measuring workflow start latency
+// against a 3-branch fork/join fixture.
+//
+// TARGET INFRASTRUCTURE: cloud / multi-silo Docker Compose (see issue #237, issue #244).
+// Do NOT run at full VU count against a local single-node dev setup — it will overwhelm
+// the local database. For local connectivity checks use:
+//   k6 run --vus 5 --iterations 20 --insecure-skip-tls-verify tests/load/scripts/parallel.js
+//
+// Prerequisites:
+//   1. Target cluster running
+//   2. Fixtures deployed: k6 run --insecure-skip-tls-verify tests/load/scripts/setup.js
+//
+// Standalone:  k6 run --insecure-skip-tls-verify tests/load/scripts/parallel.js
+// Mixed run:   imported by mixed.js (issue #242) via the parallelWorkflow named export
+//
+// METRIC SCOPE: workflowStartDuration captures the synchronous latency of POST /Workflow/start
+// (instance creation), not fork/join completion. The fork/join coordination runs asynchronously
+// inside Orleans after the 200 is returned. Comparing this scenario to linear.js at equal VU
+// counts measures activation overhead under different downstream processing loads — parallel
+// instances spawn 3 concurrent grain activations per start, which can back-pressure the silo
+// scheduler and indirectly raise start latency. End-to-end fork/join completion timing is
+// out of scope here and is covered by cloud validation (issue #244).
+//
+// FIXTURE: tests/load/fixtures/parallel-workflow.bpmn (PR #323) — process id "load-parallel",
+// a 3-branch fork/join (branchA, branchB, branchC), each branch a single C# scriptTask.
+
+import http             from 'k6/http';
+import { check, sleep } from 'k6';
+import { workflowStartDuration } from './metrics.js';
+import thresholds       from '../thresholds.json';
+
+const BASE_URL = __ENV.K6_TARGET_URL || 'https://localhost:7140';
+const HEADERS  = { 'Content-Type': 'application/json' };
+
+export const options = {
+  stages: [
+    { duration: '1m', target: 500 },  // ramp up
+    { duration: '3m', target: 500 },  // sustained load
+    { duration: '1m', target:   0 },  // cool-down
+  ],
+  insecureSkipTLSVerify: true,
+  thresholds: {
+    ...thresholds,
+  },
+};
+
+// Named export required by mixed.js (exec: 'parallelWorkflow')
+export function parallelWorkflow() {
+  const payload = JSON.stringify({ WorkflowId: 'load-parallel' });
+  const res = http.post(`${BASE_URL}/Workflow/start`, payload, { headers: HEADERS });
+
+  workflowStartDuration.add(res.timings.duration);
+  check(res, { 'workflow start: status 200': (r) => r.status === 200 });
+
+  // 100ms think-time: paces each VU at ~10 req/s, matching linear.js so the two
+  // scenarios are directly comparable at the same VU count. At 500 VUs this yields
+  // ~5 000 starts/s sustained throughput — each start spawning a 3-branch fork/join,
+  // which exercises grain-scheduler contention without changing the request rate.
+  sleep(0.1);
+}
+
+// Default export for standalone k6 runs
+export default parallelWorkflow;


### PR DESCRIPTION
## Summary

Implements **Scenario 2** of the k6 load suite — `tests/load/scripts/parallel.js` — completing the contract that `mixed.js` (PR #321) already imports (`parallelWorkflow` named export). Closes #240.

The script mirrors `linear.js` line-for-line on every contract-bearing field so the two scenarios are directly comparable at equal VU counts. The fixture (`tests/load/fixtures/parallel-workflow.bpmn`, merged in PR #323) is a 3-branch fork/join (`branchA` / `branchB` / `branchC`).

## Design reference

Approved Design & Plan v2 + re-confirm under current `main` are in [issue #240](https://github.com/nightBaker/fleans/issues/240). All 7 review-analysis findings (v1 → v2) are addressed:

| Finding | Resolution in code |
|---|---|
| 🔴 1 metric rationale | Header comment "METRIC SCOPE" block clarifies `workflowStartDuration` measures activation latency, **not** fork/join completion |
| 🔴 2 missing boilerplate | `thresholds: { ...thresholds }`, `insecureSkipTLSVerify`, `K6_TARGET_URL`, `HEADERS` all present |
| 🔴 3 hard prereq ordering | Both prereqs (#324, #323) merged on `main`; branch created from `main` directly |
| 🟡 4 smoke verification | k6 not installed in this CI runner; contract validated by structural mirror to `linear.js` (see "Verification" below). Reviewer running locally: `k6 run --vus 5 --iterations 20 --insecure-skip-tls-verify tests/load/scripts/parallel.js` |
| 🟡 5 docs rule | N/A — internal developer tooling, not user-facing. README updated with Scripts-table row and a "Run parallel branching scenario" section |
| 🟢 6 fixture shape | "FIXTURE" header comment notes 3-branch fork/join from `parallel-workflow.bpmn` |
| 🟢 7 mixed.js contract | Header comment block mirrors `linear.js` style; named + default exports both present |

## Files changed

- `tests/load/scripts/parallel.js` *(new)* — 65 lines, 100% mirror of `linear.js` structure
- `tests/load/README.md` — Scripts table row + "Run parallel branching scenario" section

## Verification

- `node --check tests/load/scripts/parallel.js` → syntax OK
- Static contract diff against `linear.js`: only the per-scenario fields differ (header text, `WorkflowId: 'load-parallel'`, named-export rename, METRIC SCOPE / FIXTURE comment block). Imports, options shape, VU body shape, sleep duration, exports — all identical.
- Local k6 smoke (`k6 run --vus 5 --iterations 20 ...`) was **not** executed in this PR's environment because k6 is not installed on the worker host. The smoke step is documented in the script header for reviewers / cloud validation (#244).

## Test plan

- [ ] Reviewer runs `k6 run --vus 5 --iterations 20 --insecure-skip-tls-verify tests/load/scripts/parallel.js` against a live cluster (Aspire or docker-compose) with `setup.js` fixtures deployed
- [ ] Confirm all `workflow start: status 200` checks pass and the k6 summary shows non-zero `workflow_start_duration` count (k6 silently skips thresholds on unemitted metrics)
- [ ] Confirm `mixed.js` now resolves all three exports (`linearWorkflow`, `parallelWorkflow`, `eventDrivenWorkflow`) without `module not found`