### PR TITLE
docs: correct Web UI port to :7124 in CLAUDE.md and test plans

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,8 @@ The full regression suite is the union of every plan under `tests/manual/`. Each
 **Universal prerequisites for every step:**
 - Aspire stack running: `dotnet run --project Fleans.Aspire` (from `src/Fleans/`).
 - A clean dev DB (delete the SQLite file or set a fresh `FLEANS_SQLITE_CONNECTION`) so prior runs don't leave stale instances.
-- Web UI reachable at `https://localhost:7140` (also the API origin used in step bodies).
+- Web UI reachable at `https://localhost:7124`.
+- API origin used in step bodies: `https://localhost:7140`.
 
 **Reporting convention:** each numbered entry below is one regression "step". For each one, follow the linked `test-plan.md` end-to-end and report `PASSED`, `FAILED`, `BUG` (new regression — file an issue), or `KNOWN BUG` (matches a `> **KNOWN BUG:** …` note inside the linked plan; counts as PASSED for promotion purposes).
 

--- a/tests/manual/18-start-event-undeploy/test-plan.md
+++ b/tests/manual/18-start-event-undeploy/test-plan.md
@@ -5,7 +5,7 @@ Verify that disabling a process definition stops its start event listeners and e
 
 ## Prerequisites
 - Aspire stack running: `dotnet run --project Fleans.Aspire`
-- Web UI at https://localhost:7175
+- Web UI at https://localhost:7124
 - API at https://localhost:7140
 
 ## Steps

--- a/tests/manual/24-compensation-event/test-plan.md
+++ b/tests/manual/24-compensation-event/test-plan.md
@@ -15,7 +15,7 @@ This plan covers:
 
 - Aspire stack running: `dotnet run --project Fleans.Aspire` (from `src/Fleans/`)
 - Clean dev DB (delete the SQLite file or set a fresh `FLEANS_SQLITE_CONNECTION`)
-- Web UI reachable at `https://localhost:7140`
+- Web UI reachable at `https://localhost:7124`
 
 ## BPMN Fixtures
 
@@ -27,7 +27,7 @@ This plan covers:
 
 ### Step 1 — Deploy the BPMN
 
-1. Open the Web UI at `https://localhost:7140`.
+1. Open the Web UI at `https://localhost:7124`.
 2. Navigate to **Process Definitions** → **Upload**.
 3. Upload `compensation-broadcast.bpmn`.
 4. Confirm the process `compensation-broadcast-process` appears in the definitions list with status **Active**.

--- a/tests/manual/24-conditional-event/test-plan.md
+++ b/tests/manual/24-conditional-event/test-plan.md
@@ -7,7 +7,7 @@ Tests BPMN Conditional Events: a workflow with a **conditional intermediate catc
 ## Prerequisites
 
 - Aspire stack running (`dotnet run --project Fleans.Aspire`)
-- Web UI accessible at `https://localhost:7140`
+- Web UI accessible at `https://localhost:7124`
 
 ## Fixture
 

--- a/tests/manual/27-instance-state-endpoint/test-plan.md
+++ b/tests/manual/27-instance-state-endpoint/test-plan.md
@@ -7,7 +7,7 @@ Verify `GET /Workflow/instances/{instanceId}/state` returns per-instance state w
 ## Prerequisites
 
 - Aspire stack running: `dotnet run --project Fleans.Aspire` (from `src/Fleans/`)
-- Deploy `tests/load/fixtures/events-workflow.bpmn` via the Workflows UI at `https://localhost:7140/workflows`
+- Deploy `tests/load/fixtures/events-workflow.bpmn` via the Workflows UI at `https://localhost:7124/workflows`
 
 ## Steps
 

--- a/tests/manual/29-editor-tabs/test-plan.md
+++ b/tests/manual/29-editor-tabs/test-plan.md
@@ -11,9 +11,9 @@ and have tabs persisted across browser refreshes via `localStorage`.
 
 - Aspire stack running: `dotnet run --project Fleans.Aspire` (from `src/Fleans/`).
 - Chrome / Chromium (the test relies on `localStorage`).
-- Web UI reachable at `https://localhost:7140`.
+- Web UI reachable at `https://localhost:7124`.
 - A clean browser profile (or an **Application → Storage → Clear site data**
-  on `https://localhost:7140`) so the prior run's tabs don't bleed in.
+  on `https://localhost:7124`) so the prior run's tabs don't bleed in.
 
 ## Two sample BPMN fixtures
 

--- a/tests/manual/35-kafka-streaming/test-plan.md
+++ b/tests/manual/35-kafka-streaming/test-plan.md
@@ -26,7 +26,7 @@ client-side topic-ensure logic in `Fleans.Streaming.Kafka`.
 - [ ] Kafka UI is reachable from the dashboard link.
 
 ### 2. Deploy the workflow
-- Navigate to the Workflows page in the Web UI (`https://localhost:7140`).
+- Navigate to the Workflows page in the Web UI (`https://localhost:7124`).
 - Click "Create New", import `kafka-streams.bpmn`.
 - Click Deploy, confirm `kafka-streams` v1 is registered.
 


### PR DESCRIPTION
## Summary

- Closes #379
- `CLAUDE.md` regression-test header listed `:7140` (the API port) as the Web UI address — the Blazor admin UI (`Fleans.Web`) actually runs at `:7124` per `launchSettings.json`
- Fixed all 8 affected sites across `CLAUDE.md` and 6 test-plan files (edit-sets A–D from the approved v2 design plan)
- Split CLAUDE.md line so API port `:7140` and Web UI port `:7124` are on separate bullets — avoids false-positive in the acceptance-check grep

## Files changed

| File | Change |
|---|---|
| `CLAUDE.md:139` | `:7140` → `:7124` for Web UI; API `:7140` kept on its own bullet |
| `tests/manual/18-start-event-undeploy/test-plan.md:8` | `:7175` → `:7124` |
| `tests/manual/24-compensation-event/test-plan.md:18,30` | `:7140` → `:7124` |
| `tests/manual/24-conditional-event/test-plan.md:10` | `:7140` → `:7124` |
| `tests/manual/27-instance-state-endpoint/test-plan.md:10` | `:7140` → `:7124` (Workflows UI) |
| `tests/manual/29-editor-tabs/test-plan.md:14,16` | `:7140` → `:7124` |
| `tests/manual/35-kafka-streaming/test-plan.md:29` | `:7140` → `:7124` |

## Acceptance checks

- `grep -rn ':7140' tests/manual/ CLAUDE.md | grep -iE '(web|workflows) ui'` → zero matches ✅
- `grep -rn ':7175' tests/manual/ CLAUDE.md` → zero matches ✅

## Test plan

No code changes — docs-only fix. CI runs standard `dotnet build` + `dotnet test` which don't depend on port references in markdown.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)