### PR TITLE
fix: unblock local Docker-Compose load test (migration + nginx + k6 JSON loader)

### DIFF
--- a/src/Fleans/Fleans.Persistence.PostgreSql/Migrations/Command/20260428141009_SyncModelDrift.Designer.cs
+++ b/src/Fleans/Fleans.Persistence.PostgreSql/Migrations/Command/20260428141009_SyncModelDrift.Designer.cs
@@ -3,54 +3,61 @@ using System;
 using Fleans.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace Fleans.Persistence.Sqlite.Migrations.Command
+namespace Fleans.Persistence.PostgreSql.Migrations.Command
 {
     [DbContext(typeof(FleanCommandDbContext))]
-    partial class FleanCommandDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260428141009_SyncModelDrift")]
+    partial class SyncModelDrift
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder.HasAnnotation("ProductVersion", "10.0.5");
+            modelBuilder
+                .HasAnnotation("ProductVersion", "10.0.5")
+                .HasAnnotation("Relational:MaxIdentifierLength", 63);
+
+            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
             modelBuilder.Entity("Fleans.Domain.ProcessDefinition", b =>
                 {
                     b.Property<string>("ProcessDefinitionId")
                         .HasMaxLength(512)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(512)");
 
                     b.Property<string>("BpmnXml")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
-                    b.Property<string>("DeployedAt")
-                        .IsRequired()
-                        .HasColumnType("TEXT");
+                    b.Property<DateTimeOffset>("DeployedAt")
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("ETag")
                         .HasMaxLength(64)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<bool>("IsActive")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("boolean")
                         .HasDefaultValue(true);
 
                     b.Property<string>("ProcessDefinitionKey")
                         .IsRequired()
                         .HasMaxLength(256)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(256)");
 
                     b.Property<int>("Version")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<string>("Workflow")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("Workflow");
 
                     b.HasKey("ProcessDefinitionId");
@@ -64,69 +71,69 @@ namespace Fleans.Persistence.Sqlite.Migrations.Command
                 {
                     b.Property<Guid>("ActivityInstanceId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("ActivityId")
                         .IsRequired()
                         .HasMaxLength(256)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(256)");
 
                     b.Property<string>("ActivityType")
                         .HasMaxLength(256)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(256)");
 
                     b.Property<string>("CancellationReason")
                         .HasMaxLength(2000)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(2000)");
 
                     b.Property<Guid?>("ChildWorkflowInstanceId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTimeOffset?>("CompletedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTimeOffset?>("CreatedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int?>("ErrorCode")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<string>("ErrorMessage")
                         .HasMaxLength(2000)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(2000)");
 
                     b.Property<DateTimeOffset?>("ExecutionStartedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<bool>("IsCancelled")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsCompensationHandler")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsCompleted")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsExecuting")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<int?>("MultiInstanceIndex")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<int?>("MultiInstanceTotal")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<Guid?>("ScopeId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<Guid?>("TokenId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<Guid>("VariablesId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<Guid>("WorkflowInstanceId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.HasKey("ActivityInstanceId");
 
@@ -138,24 +145,24 @@ namespace Fleans.Persistence.Sqlite.Migrations.Command
             modelBuilder.Entity("Fleans.Domain.States.ComplexGatewayJoinState", b =>
                 {
                     b.Property<Guid>("WorkflowInstanceId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("GatewayActivityId")
                         .HasMaxLength(256)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(256)");
 
                     b.Property<string>("ActivationCondition")
                         .HasMaxLength(1024)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(1024)");
 
                     b.Property<Guid>("FirstActivityInstanceId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<bool>("HasFired")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<int>("WaitingTokenCount")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.HasKey("WorkflowInstanceId", "GatewayActivityId");
 
@@ -165,20 +172,20 @@ namespace Fleans.Persistence.Sqlite.Migrations.Command
             modelBuilder.Entity("Fleans.Domain.States.ConditionSequenceState", b =>
                 {
                     b.Property<Guid>("GatewayActivityInstanceId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("ConditionalSequenceFlowId")
                         .HasMaxLength(256)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(256)");
 
                     b.Property<bool>("IsEvaluated")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("Result")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<Guid>("WorkflowInstanceId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.HasKey("GatewayActivityInstanceId", "ConditionalSequenceFlowId");
 
@@ -191,16 +198,16 @@ namespace Fleans.Persistence.Sqlite.Migrations.Command
                 {
                     b.Property<string>("ProcessDefinitionKey")
                         .HasMaxLength(256)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(256)");
 
                     b.Property<string>("ActivityId")
                         .HasMaxLength(256)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(256)");
 
                     b.Property<string>("ConditionExpression")
                         .IsRequired()
                         .HasMaxLength(4000)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(4000)");
 
                     b.HasKey("ProcessDefinitionKey", "ActivityId");
 
@@ -211,29 +218,29 @@ namespace Fleans.Persistence.Sqlite.Migrations.Command
                 {
                     b.Property<string>("Key")
                         .HasMaxLength(512)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(512)");
 
                     b.Property<string>("ActivityId")
                         .IsRequired()
                         .HasMaxLength(256)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(256)");
 
                     b.Property<string>("ConditionExpression")
                         .IsRequired()
                         .HasMaxLength(4000)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(4000)");
 
                     b.Property<string>("ETag")
                         .HasMaxLength(64)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<bool>("IsRegistered")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("ProcessDefinitionKey")
                         .IsRequired()
                         .HasMaxLength(256)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(256)");
 
                     b.HasKey("Key");
 
@@ -244,17 +251,17 @@ namespace Fleans.Persistence.Sqlite.Migrations.Command
                 {
                     b.Property<Guid>("ForkInstanceId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<Guid?>("ConsumedTokenId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("CreatedTokenIds")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<Guid>("WorkflowInstanceId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.HasKey("ForkInstanceId");
 
@@ -267,11 +274,11 @@ namespace Fleans.Persistence.Sqlite.Migrations.Command
                 {
                     b.Property<string>("Key")
                         .HasMaxLength(1024)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(1024)");
 
                     b.Property<string>("ETag")
                         .HasMaxLength(64)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(64)");
 
                     b.HasKey("Key");
 
@@ -282,11 +289,11 @@ namespace Fleans.Persistence.Sqlite.Migrations.Command
                 {
                     b.Property<string>("Key")
                         .HasMaxLength(512)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(512)");
 
                     b.Property<string>("ETag")
                         .HasMaxLength(64)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(64)");
 
                     b.HasKey("Key");
 
@@ -297,11 +304,11 @@ namespace Fleans.Persistence.Sqlite.Migrations.Command
                 {
                     b.Property<string>("MessageName")
                         .HasMaxLength(512)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(512)");
 
                     b.Property<string>("ProcessDefinitionKey")
                         .HasMaxLength(256)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(256)");
 
                     b.HasKey("MessageName", "ProcessDefinitionKey");
 
@@ -312,23 +319,23 @@ namespace Fleans.Persistence.Sqlite.Migrations.Command
                 {
                     b.Property<string>("MessageName")
                         .HasMaxLength(1024)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(1024)");
 
                     b.Property<string>("ActivityId")
                         .IsRequired()
                         .HasMaxLength(256)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(256)");
 
                     b.Property<string>("CorrelationKey")
                         .IsRequired()
                         .HasMaxLength(512)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(512)");
 
                     b.Property<Guid>("HostActivityInstanceId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<Guid>("WorkflowInstanceId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.HasKey("MessageName");
 
@@ -339,11 +346,11 @@ namespace Fleans.Persistence.Sqlite.Migrations.Command
                 {
                     b.Property<string>("Key")
                         .HasMaxLength(512)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(512)");
 
                     b.Property<string>("ETag")
                         .HasMaxLength(64)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(64)");
 
                     b.HasKey("Key");
 
@@ -354,11 +361,11 @@ namespace Fleans.Persistence.Sqlite.Migrations.Command
                 {
                     b.Property<string>("Key")
                         .HasMaxLength(512)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(512)");
 
                     b.Property<string>("ETag")
                         .HasMaxLength(64)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(64)");
 
                     b.HasKey("Key");
 
@@ -369,11 +376,11 @@ namespace Fleans.Persistence.Sqlite.Migrations.Command
                 {
                     b.Property<string>("SignalName")
                         .HasMaxLength(512)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(512)");
 
                     b.Property<string>("ProcessDefinitionKey")
                         .HasMaxLength(256)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(256)");
 
                     b.HasKey("SignalName", "ProcessDefinitionKey");
 
@@ -384,17 +391,17 @@ namespace Fleans.Persistence.Sqlite.Migrations.Command
                 {
                     b.Property<string>("SignalName")
                         .HasMaxLength(512)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(512)");
 
                     b.Property<Guid>("WorkflowInstanceId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("ActivityId")
                         .HasMaxLength(256)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(256)");
 
                     b.Property<Guid>("HostActivityInstanceId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.HasKey("SignalName", "WorkflowInstanceId", "ActivityId");
 
@@ -404,22 +411,22 @@ namespace Fleans.Persistence.Sqlite.Migrations.Command
             modelBuilder.Entity("Fleans.Domain.States.TimerCycleTrackingState", b =>
                 {
                     b.Property<Guid>("HostActivityInstanceId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("TimerActivityId")
                         .HasMaxLength(256)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(256)");
 
                     b.Property<string>("TimerExpression")
                         .IsRequired()
                         .HasMaxLength(512)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(512)");
 
                     b.Property<int>("TimerType")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<Guid>("WorkflowInstanceId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.HasKey("HostActivityInstanceId", "TimerActivityId");
 
@@ -432,21 +439,21 @@ namespace Fleans.Persistence.Sqlite.Migrations.Command
                 {
                     b.Property<string>("Key")
                         .HasMaxLength(256)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(256)");
 
                     b.Property<string>("ETag")
                         .HasMaxLength(64)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<int>("FireCount")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<int?>("MaxFireCount")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<string>("ProcessDefinitionId")
                         .HasMaxLength(512)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(512)");
 
                     b.HasKey("Key");
 
@@ -457,49 +464,48 @@ namespace Fleans.Persistence.Sqlite.Migrations.Command
                 {
                     b.Property<Guid>("ActivityInstanceId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("ActivityId")
                         .IsRequired()
                         .HasMaxLength(256)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(256)");
 
                     b.Property<string>("Assignee")
                         .HasMaxLength(256)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(256)");
 
                     b.Property<string>("CandidateGroups")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("CandidateUsers")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTimeOffset?>("ClaimedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("ClaimedBy")
                         .HasMaxLength(256)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(256)");
 
-                    b.Property<string>("CreatedAt")
-                        .IsRequired()
-                        .HasColumnType("TEXT");
+                    b.Property<DateTimeOffset>("CreatedAt")
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("ETag")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("ExpectedOutputVariables")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<int>("TaskState")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<Guid>("WorkflowInstanceId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.HasKey("ActivityInstanceId");
 
@@ -512,39 +518,39 @@ namespace Fleans.Persistence.Sqlite.Migrations.Command
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
-                    b.Property<string>("CompletedAt")
-                        .HasColumnType("TEXT");
+                    b.Property<DateTimeOffset?>("CompletedAt")
+                        .HasColumnType("timestamp with time zone");
 
-                    b.Property<string>("CreatedAt")
-                        .HasColumnType("TEXT");
+                    b.Property<DateTimeOffset?>("CreatedAt")
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("ETag")
                         .HasMaxLength(64)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(64)");
 
-                    b.Property<string>("ExecutionStartedAt")
-                        .HasColumnType("TEXT");
+                    b.Property<DateTimeOffset?>("ExecutionStartedAt")
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<bool>("IsCancelled")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsCompleted")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsStarted")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("ParentActivityId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<Guid?>("ParentWorkflowInstanceId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("ProcessDefinitionId")
                         .HasMaxLength(512)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(512)");
 
                     b.HasKey("Id");
 
@@ -557,18 +563,18 @@ namespace Fleans.Persistence.Sqlite.Migrations.Command
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<Guid?>("ParentVariablesId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Variables")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("Variables");
 
                     b.Property<Guid>("WorkflowInstanceId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.HasKey("Id");
 
@@ -581,27 +587,29 @@ namespace Fleans.Persistence.Sqlite.Migrations.Command
                 {
                     b.Property<long>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
 
                     b.Property<string>("EventType")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("GrainId")
                         .IsRequired()
                         .HasMaxLength(256)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(256)");
 
                     b.Property<string>("Payload")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTimeOffset>("Timestamp")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int>("Version")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.HasKey("Id");
 
@@ -615,13 +623,13 @@ namespace Fleans.Persistence.Sqlite.Migrations.Command
                 {
                     b.Property<string>("GrainId")
                         .HasMaxLength(256)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("character varying(256)");
 
                     b.Property<DateTimeOffset>("Timestamp")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int>("Version")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.HasKey("GrainId");
 

--- a/src/Fleans/Fleans.Persistence.PostgreSql/Migrations/Command/20260428141009_SyncModelDrift.cs
+++ b/src/Fleans/Fleans.Persistence.PostgreSql/Migrations/Command/20260428141009_SyncModelDrift.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Fleans.Persistence.PostgreSql.Migrations.Command
+{
+    /// <inheritdoc />
+    public partial class SyncModelDrift : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsCancelled",
+                table: "WorkflowInstances",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsCompensationHandler",
+                table: "WorkflowActivityInstanceEntries",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsCancelled",
+                table: "WorkflowInstances");
+
+            migrationBuilder.DropColumn(
+                name: "IsCompensationHandler",
+                table: "WorkflowActivityInstanceEntries");
+        }
+    }
+}

--- a/src/Fleans/Fleans.Persistence.PostgreSql/Migrations/Command/FleanCommandDbContextModelSnapshot.cs
+++ b/src/Fleans/Fleans.Persistence.PostgreSql/Migrations/Command/FleanCommandDbContextModelSnapshot.cs
@@ -105,6 +105,9 @@ namespace Fleans.Persistence.PostgreSql.Migrations.Command
                     b.Property<bool>("IsCancelled")
                         .HasColumnType("boolean");
 
+                    b.Property<bool>("IsCompensationHandler")
+                        .HasColumnType("boolean");
+
                     b.Property<bool>("IsCompleted")
                         .HasColumnType("boolean");
 
@@ -526,6 +529,9 @@ namespace Fleans.Persistence.PostgreSql.Migrations.Command
 
                     b.Property<DateTimeOffset?>("ExecutionStartedAt")
                         .HasColumnType("timestamp with time zone");
+
+                    b.Property<bool>("IsCancelled")
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsCompleted")
                         .HasColumnType("boolean");

--- a/src/Fleans/Fleans.Persistence.Sqlite/Migrations/Command/20260428141041_SyncModelDrift.Designer.cs
+++ b/src/Fleans/Fleans.Persistence.Sqlite/Migrations/Command/20260428141041_SyncModelDrift.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Fleans.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Fleans.Persistence.Sqlite.Migrations.Command
 {
     [DbContext(typeof(FleanCommandDbContext))]
-    partial class FleanCommandDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260428141041_SyncModelDrift")]
+    partial class SyncModelDrift
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.5");

--- a/src/Fleans/Fleans.Persistence.Sqlite/Migrations/Command/20260428141041_SyncModelDrift.cs
+++ b/src/Fleans/Fleans.Persistence.Sqlite/Migrations/Command/20260428141041_SyncModelDrift.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Fleans.Persistence.Sqlite.Migrations.Command
+{
+    /// <inheritdoc />
+    public partial class SyncModelDrift : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsCancelled",
+                table: "WorkflowInstances",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsCompensationHandler",
+                table: "WorkflowActivityInstanceEntries",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsCancelled",
+                table: "WorkflowInstances");
+
+            migrationBuilder.DropColumn(
+                name: "IsCompensationHandler",
+                table: "WorkflowActivityInstanceEntries");
+        }
+    }
+}

--- a/tests/load/nginx.conf
+++ b/tests/load/nginx.conf
@@ -1,18 +1,22 @@
-resolver 127.0.0.11 valid=5s;
+events {}
 
-upstream fleans_api {
-    server fleans-core:8080;
-}
+http {
+    resolver 127.0.0.11 valid=5s;
 
-server {
-    listen 80;
+    upstream fleans_api {
+        server fleans-core:8080;
+    }
 
-    location / {
-        proxy_pass         http://fleans_api;
-        proxy_set_header   Host              $host;
-        proxy_set_header   X-Real-IP         $remote_addr;
-        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
-        proxy_set_header   X-Forwarded-Proto $scheme;
-        proxy_read_timeout 120s;
+    server {
+        listen 80;
+
+        location / {
+            proxy_pass         http://fleans_api;
+            proxy_set_header   Host              $host;
+            proxy_set_header   X-Real-IP         $remote_addr;
+            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+            proxy_read_timeout 120s;
+        }
     }
 }

--- a/tests/load/scripts/events.js
+++ b/tests/load/scripts/events.js
@@ -24,7 +24,7 @@ import {
   pollStallsRate,
   correlationMissRate,
 } from './metrics.js';
-import thresholds from '../thresholds.json';
+const thresholds = JSON.parse(open('../thresholds.json'));
 
 const int = (name, def) => {
   const n = Number(__ENV[name]);

--- a/tests/load/scripts/linear.js
+++ b/tests/load/scripts/linear.js
@@ -17,7 +17,7 @@
 import http             from 'k6/http';
 import { check, sleep } from 'k6';
 import { workflowStartDuration } from './metrics.js';
-import thresholds       from '../thresholds.json';
+const thresholds = JSON.parse(open('../thresholds.json'));
 
 const BASE_URL = __ENV.K6_TARGET_URL || 'https://localhost:7140';
 const HEADERS  = { 'Content-Type': 'application/json' };

--- a/tests/load/scripts/parallel.js
+++ b/tests/load/scripts/parallel.js
@@ -29,7 +29,7 @@
 import http             from 'k6/http';
 import { check, sleep } from 'k6';
 import { workflowStartDuration } from './metrics.js';
-import thresholds       from '../thresholds.json';
+const thresholds = JSON.parse(open('../thresholds.json'));
 
 const BASE_URL = __ENV.K6_TARGET_URL || 'https://localhost:7140';
 const HEADERS  = { 'Content-Type': 'application/json' };


### PR DESCRIPTION
## Summary

Three independent bugs gated the local Docker-Compose load-test run end-to-end. Bundled into one PR because each by itself leaves the stack non-functional and they're all `tests/load/` infrastructure (the Postgres migration is the only one that touches non-load-test code, and it's load-bearing for any Postgres deployment, not just load tests.

- **Postgres migration drift** —  (BPMN cancel-event work in #230 / #360) and  were on the EF model with no migration.  in  rejects model drift via , so any Postgres-backed silo crashed at startup. SQLite was unaffected (it uses ), but per project policy migrations are kept in sync per provider — added  to both  and .
- **nginx config** —  is mounted as the *main* , but had  /  /  at root scope. nginx died with . Wrapped the whole config in  + .
- **k6 JSON loader** — , ,  imported  via bare ESM (). The current k6 / Sobek runtime parses JSON files as JavaScript and fails on the first . Import-attribute syntax () is also unsupported. Switched to the portable  init-context loader.

## Validation

Ran the Docker-Compose stack from a clean state () and exercised both scripts end-to-end:

| Scenario | iterations | starts/sec | http_req_failed | p(95) workflow_start_duration |
|---|---|---|---|---|
|  | 500 / 50 VUs | 218/s | 0% | 668 ms |
|  | 500 / 50 VUs | 307/s | 0% | 109 ms |

All thresholds in  passed; all 500 checks green per scenario. Stack: 2 silos behind nginx LB (port 80) + Postgres + Redis.

## Known follow-up (not in this PR)

When N silos start simultaneously against an unmigrated Postgres they race on  — first wins, others crash with . Restarting the loser is enough (it sees  and skips), and the failure is first-time-only, but a  around  would prevent it. Worth a separate issue.

## Test plan

- [ ] #1 [internal] load local bake definitions
#1 reading from stdin 601B done
#1 DONE 0.0s

#2 [internal] load build definition from Dockerfile
#2 transferring dockerfile: 774B done
#2 DONE 0.0s

#3 [internal] load metadata for mcr.microsoft.com/dotnet/sdk:10.0
#3 DONE 0.8s

#4 [internal] load metadata for mcr.microsoft.com/dotnet/aspnet:10.0
#4 DONE 0.8s

#5 [internal] load .dockerignore
#5 transferring context: 358B done
#5 DONE 0.0s

#6 [build 1/7] FROM mcr.microsoft.com/dotnet/sdk:10.0@sha256:8a90a473da5205a16979de99d2fc20975e922c68304f5c79d564e666dc3982fc
#6 resolve mcr.microsoft.com/dotnet/sdk:10.0@sha256:8a90a473da5205a16979de99d2fc20975e922c68304f5c79d564e666dc3982fc done
#6 DONE 0.0s

#7 [base 1/2] FROM mcr.microsoft.com/dotnet/aspnet:10.0@sha256:55e37c7795bfaf6b9cc5d77c155811d9569f529d86e20647704bc1d7dd9741d4
#7 resolve mcr.microsoft.com/dotnet/aspnet:10.0@sha256:55e37c7795bfaf6b9cc5d77c155811d9569f529d86e20647704bc1d7dd9741d4 0.0s done
#7 DONE 0.0s

#8 [internal] load build context
#8 transferring context: 151.28kB 0.2s done
#8 DONE 0.2s

#9 [final 1/2] WORKDIR /app
#9 CACHED

#10 [build 4/7] RUN dotnet restore "Fleans.Api/Fleans.Api.csproj"
#10 CACHED

#11 [build 7/7] RUN dotnet build "Fleans.Api.csproj" -c Release -o /app/build
#11 CACHED

#12 [base 2/2] WORKDIR /app
#12 CACHED

#13 [build 5/7] COPY . .
#13 CACHED

#14 [build 2/7] WORKDIR /src
#14 CACHED

#15 [build 3/7] COPY [Fleans.Api/Fleans.Api.csproj, Fleans.Api/]
#15 CACHED

#16 [build 6/7] WORKDIR /src/Fleans.Api
#16 CACHED

#17 [publish 1/1] RUN dotnet publish "Fleans.Api.csproj" -c Release -o /app/publish /p:UseAppHost=false
#17 CACHED

#18 [final 2/2] COPY --from=publish /app/publish .
#18 CACHED

#19 exporting to image
#19 exporting layers done
#19 exporting manifest sha256:be845fba0c015c07f4a9c7d4ac2bc9db0c3d86b971f70e27f0b8c1777e5eba73 done
#19 exporting config sha256:30bb8c2be1ba5429fe5f4a55d451b5ba31a806d65cb24638209f8b2f295cf179 done
#19 exporting attestation manifest sha256:8bea111d05e30bee07d1d28e039168454e232a1ff0db60fde5e8a66760904890 done
#19 exporting manifest list sha256:91f285ea3b36aa81d01f9d9e238014a701eeef1ac10b64e566fab4828155f4c8
#19 exporting manifest list sha256:91f285ea3b36aa81d01f9d9e238014a701eeef1ac10b64e566fab4828155f4c8 done
#19 naming to docker.io/library/generated-fleans-core:latest done
#19 unpacking to docker.io/library/generated-fleans-core:latest done
#19 DONE 0.1s

#20 resolving provenance for metadata file
#20 DONE 0.0s — all 5 containers reach , nginx binds 0.0.0.0:80
- [ ] 
         /\      Grafana   /‾‾/  
    /\  /  \     |\  __   /  /   
   /  \/    \    | |/ /  /   ‾‾\ 
  /          \   |   (  |  (‾)  |
 / __________ \  |_|\_\  \_____/ 

     execution: local
        script: tests/load/scripts/setup.js
        output: -

     scenarios: (100.00%) 1 scenario, 1 max VUs, 10m30s max duration (incl. graceful stop):
              * default: 1 iterations shared among 1 VUs (maxDuration: 10m0s, gracefulStop: 30s)


running (00m01.0s), 1/1 VUs, 0 complete and 0 interrupted iterations
default   [   0% ] 1 VUs  00m01.0s/10m0s  0/1 shared iters

     ✓ definitions list: status 200

     checks.........................: 100.00% 1 out of 1
     data_received..................: 2.3 kB  2.2 kB/s
     data_sent......................: 11 kB   11 kB/s
     http_req_blocked...............: avg=186.25µs min=7µs     med=11.5µs   max=715µs    p(90)=505.29µs p(95)=610.14µs
     http_req_connecting............: avg=49.75µs  min=0s      med=0s       max=199µs    p(90)=139.3µs  p(95)=169.15µs
     http_req_duration..............: avg=262.05ms min=24.13ms med=264.25ms max=495.58ms p(90)=489.44ms p(95)=492.51ms
       { expected_response:true }...: avg=262.05ms min=24.13ms med=264.25ms max=495.58ms p(90)=489.44ms p(95)=492.51ms
   ✓ http_req_failed................: 0.00%   0 out of 4
     http_req_receiving.............: avg=146µs    min=74µs    med=127µs    max=256µs    p(90)=225.1µs  p(95)=240.55µs
     http_req_sending...............: avg=160.25µs min=19µs    med=92.5µs   max=437µs    p(90)=339.8µs  p(95)=388.4µs 
     http_req_tls_handshaking.......: avg=0s       min=0s      med=0s       max=0s       p(90)=0s       p(95)=0s      
     http_req_waiting...............: avg=261.74ms min=23.98ms med=264.05ms max=494.89ms p(90)=488.88ms p(95)=491.88ms
     http_reqs......................: 4       3.786269/s
     iteration_duration.............: avg=1.05s    min=1.05s   med=1.05s    max=1.05s    p(90)=1.05s    p(95)=1.05s   
     iterations.....................: 1       0.946567/s
     vus............................: 1       min=1      max=1
     vus_max........................: 1       min=1      max=1


running (00m01.1s), 0/1 VUs, 1 complete and 0 interrupted iterations
default ✓ [ 100% ] 1 VUs  00m01.1s/10m0s  1/1 shared iters — fixtures deploy
- [ ] 
         /\      Grafana   /‾‾/  
    /\  /  \     |\  __   /  /   
   /  \/    \    | |/ /  /   ‾‾\ 
  /          \   |   (  |  (‾)  |
 / __________ \  |_|\_\  \_____/ 

     execution: local
        script: tests/load/scripts/linear.js
        output: -

     scenarios: (100.00%) 1 scenario, 50 max VUs, 10m30s max duration (incl. graceful stop):
              * default: 500 iterations shared among 50 VUs (maxDuration: 10m0s, gracefulStop: 30s)


running (00m01.0s), 50/50 VUs, 101 complete and 0 interrupted iterations
default   [  20% ] 50 VUs  00m01.0s/10m0s  101/500 shared iters

running (00m02.0s), 50/50 VUs, 402 complete and 0 interrupted iterations
default   [  80% ] 50 VUs  00m02.0s/10m0s  402/500 shared iters

     ✓ workflow start: status 200

     checks.........................: 100.00% 500 out of 500
   ✓ correlation_miss...............: 0.00%   0 out of 0
     data_received..................: 125 kB  56 kB/s
     data_sent......................: 87 kB   39 kB/s
     http_req_blocked...............: avg=251.45µs   min=1µs      med=5µs      max=2.95ms   p(90)=393.8µs  p(95)=2.56ms   
     http_req_connecting............: avg=184.54µs   min=0s       med=0s       max=2.13ms   p(90)=94.6µs   p(95)=1.92ms   
   ✓ http_req_duration..............: avg=117.67ms   min=17.33ms  med=55.38ms  max=639.64ms p(90)=208.24ms p(95)=573.82ms 
       { expected_response:true }...: avg=117.67ms   min=17.33ms  med=55.38ms  max=639.64ms p(90)=208.24ms p(95)=573.82ms 
   ✓ http_req_failed................: 0.00%   0 out of 500
     http_req_receiving.............: avg=67.58µs    min=14µs     med=51µs     max=2.42ms   p(90)=99.1µs   p(95)=130.29µs 
     http_req_sending...............: avg=75.32µs    min=4µs      med=18µs     max=13.92ms  p(90)=37µs     p(95)=87.14µs  
     http_req_tls_handshaking.......: avg=0s         min=0s       med=0s       max=0s       p(90)=0s       p(95)=0s       
     http_req_waiting...............: avg=117.53ms   min=17.26ms  med=55.27ms  max=639.6ms  p(90)=208.02ms p(95)=573.72ms 
     http_reqs......................: 500     222.98662/s
     iteration_duration.............: avg=218.81ms   min=117.66ms med=156.53ms max=741.92ms p(90)=313.63ms p(95)=676.95ms 
     iterations.....................: 500     222.98662/s
   ✓ message_accept_duration........: avg=0          min=0        med=0        max=0        p(90)=0        p(95)=0        
   ✓ poll_stalls....................: 0.00%   0 out of 0
   ✓ poll_until_catch_duration......: avg=0          min=0        med=0        max=0        p(90)=0        p(95)=0        
     vus............................: 50      min=50         max=50
     vus_max........................: 50      min=50         max=50
   ✓ workflow_start_duration........: avg=117.674306 min=17.338   med=55.38    max=639.645  p(90)=208.2425 p(95)=573.82315


running (00m02.2s), 00/50 VUs, 500 complete and 0 interrupted iterations
default ✓ [ 100% ] 50 VUs  00m02.2s/10m0s  500/500 shared iters — 0% failures, all thresholds green
- [ ] 
         /\      Grafana   /‾‾/  
    /\  /  \     |\  __   /  /   
   /  \/    \    | |/ /  /   ‾‾\ 
  /          \   |   (  |  (‾)  |
 / __________ \  |_|\_\  \_____/ 

     execution: local
        script: tests/load/scripts/parallel.js
        output: -

     scenarios: (100.00%) 1 scenario, 50 max VUs, 10m30s max duration (incl. graceful stop):
              * default: 500 iterations shared among 50 VUs (maxDuration: 10m0s, gracefulStop: 30s)


running (00m01.0s), 50/50 VUs, 231 complete and 0 interrupted iterations
default   [  46% ] 50 VUs  00m01.0s/10m0s  231/500 shared iters

     ✓ workflow start: status 200

     checks.........................: 100.00% 500 out of 500
   ✓ correlation_miss...............: 0.00%   0 out of 0
     data_received..................: 125 kB  66 kB/s
     data_sent......................: 88 kB   47 kB/s
     http_req_blocked...............: avg=223.88µs  min=1µs      med=5µs      max=2.78ms   p(90)=235.9µs  p(95)=2.23ms  
     http_req_connecting............: avg=150.22µs  min=0s       med=0s       max=1.99ms   p(90)=65.6µs   p(95)=1.52ms  
   ✓ http_req_duration..............: avg=80.4ms    min=23.05ms  med=73.16ms  max=173.48ms p(90)=127.37ms p(95)=152.57ms
       { expected_response:true }...: avg=80.4ms    min=23.05ms  med=73.16ms  max=173.48ms p(90)=127.37ms p(95)=152.57ms
   ✓ http_req_failed................: 0.00%   0 out of 500
     http_req_receiving.............: avg=73µs      min=16µs     med=52µs     max=2.22ms   p(90)=102µs    p(95)=160.84µs
     http_req_sending...............: avg=25.78µs   min=3µs      med=19µs     max=820µs    p(90)=32.1µs   p(95)=52.09µs 
     http_req_tls_handshaking.......: avg=0s        min=0s       med=0s       max=0s       p(90)=0s       p(95)=0s      
     http_req_waiting...............: avg=80.3ms    min=22.98ms  med=72.93ms  max=173.43ms p(90)=127.26ms p(95)=152.45ms
     http_reqs......................: 500     266.224379/s
     iteration_duration.............: avg=181.25ms  min=123.61ms med=173.98ms max=277.55ms p(90)=228.15ms p(95)=254.96ms
     iterations.....................: 500     266.224379/s
   ✓ message_accept_duration........: avg=0         min=0        med=0        max=0        p(90)=0        p(95)=0       
   ✓ poll_stalls....................: 0.00%   0 out of 0
   ✓ poll_until_catch_duration......: avg=0         min=0        med=0        max=0        p(90)=0        p(95)=0       
     vus............................: 50      min=50         max=50
     vus_max........................: 50      min=50         max=50
   ✓ workflow_start_duration........: avg=80.401052 min=23.059   med=73.1615  max=173.486  p(90)=127.3758 p(95)=152.5788


running (00m01.9s), 00/50 VUs, 500 complete and 0 interrupted iterations
default ✓ [ 100% ] 50 VUs  00m01.9s/10m0s  500/500 shared iters — 0% failures, all thresholds green
- [ ] MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file. from  — existing tests still pass with new migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)