### PR TITLE
docs: scope load-test results page to current public release (v0.1.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,8 @@ The public docs site lives in `website/` — an Astro + Starlight project deploy
 
 **Documentation rule:** Any new feature, BPMN element, API endpoint, or user-facing behavior MUST be reflected in the docs site in the same PR. Update the relevant page under `website/src/content/docs/` (e.g. new BPMN activity → `concepts/bpmn-support.md`; new endpoint → `reference/api.md`; new workflow → add a guide). If no suitable page exists, create one and add it to the Starlight sidebar in `website/astro.config.mjs`. Documentation is part of "done", not a follow-up task.
 
+**Load-test results publishing rule:** `website/src/content/docs/reference/load-testing.md` publishes load-test results **only for the current public release version** of Fleans. Each result section MUST be headed with `### Fleans vX.Y.Z — YYYY-MM-DD — <stack description>` so readers can scope numbers to a release + run date. When a new release ships, REMOVE prior-version sections from the website page in the same release PR — do not let stale numbers accumulate publicly. The full historical reports stay in the repo at `tests/load/results/<run-id>/report.md` and are recoverable via the matching git tag; only the website page is curated.
+
 ### Hero BPMN Diagram
 
 The landing page includes a rendered BPMN workflow diagram between the hero and the "Why Fleans?" cards. Two themed SVG variants (light/dark) are pre-rendered from `tests/manual/04-parallel-gateway/fork-join.bpmn` using bpmn-js in a headless Playwright browser.

--- a/website/src/content/docs/reference/load-testing.md
+++ b/website/src/content/docs/reference/load-testing.md
@@ -7,6 +7,14 @@ Fleans ships a load-test suite under `tests/load/`. Two drivers are wired up: **
 primary suite) and **Locust** (port of the same scenarios for Azure Load Testing). This page
 summarises the most recent baseline measurements and the bottleneck profile they expose.
 
+:::note
+This page tracks load-test results for the **current public release** of Fleans only. Older
+runs are removed when a new version ships — for historical numbers, check the report files
+under `tests/load/results/` in the matching git tag.
+
+**Currently published:** Fleans **v0.1.0**.
+:::
+
 ## Scenarios
 
 Four scenario scripts live in parallel under `tests/load/scripts/` (k6) and `tests/load/locust/`
@@ -23,7 +31,8 @@ The suite is documented in detail in `tests/load/README.md`.
 
 ## Recent baselines
 
-Two reports exist in the repository:
+Two reports exist in the repository for the current release. Each is anchored to its driving
+hardware/SKU and the date it was run:
 
 - **Local Docker Compose** (`tests/load/results/local/report.md`) — 2 silos in `docker compose`,
   500 concurrent virtual users per scenario. Hardware: developer laptop. Originally produced for
@@ -35,7 +44,7 @@ Two reports exist in the repository:
 Both reports include per-scenario throughput / latency tables, peak container CPU, threshold compliance, and ranked recommendations. The summary below pulls the headline numbers; reach for the
 report files for raw CSVs and full bottleneck attribution.
 
-### Local Docker Compose @ 500 VU
+### Fleans v0.1.0 — 2026-04-28 — Local Docker Compose @ 500 VU
 
 | Scenario   | Max VUs | Iterations | Throughput (req/s) | p(95) duration | Error rate | First bottleneck |
 |------------|--------:|----------:|--------------------:|---------------:|:----------:|-----------------:|
@@ -47,7 +56,7 @@ report files for raw CSVs and full bottleneck attribution.
 The local laptop run is **db-bound**: PostgreSQL CPU peaks above 600 % across all scenarios. The error spikes are connection-pool exhaustion (`max_connections=100` default vs. 200+ EF Core
 connections under burst), not slow queries.
 
-### Azure Container Apps @ 500 VU (and a 2 000-VU scale test)
+### Fleans v0.1.0 — 2026-04-29 — Azure Container Apps @ 500 VU (and a 2 000-VU scale test)
 
 | Scenario | Reqs | RPS | HTTP fail % | p50 | p95 | max |
 |----------|-----:|----:|------------:|----:|----:|----:|


### PR DESCRIPTION
## Summary

Scope the load-test results page to a single public release at a time, with explicit version + date headers per measurement.

- Added `### Fleans v0.1.0 — YYYY-MM-DD — <stack>` headings to each result section in `website/src/content/docs/reference/load-testing.md`. Same numbers, just labelled.
- Added a Starlight admonition at the top of the page making the policy explicit: this page tracks the current public release only; older runs go away when a new version ships, and historical reports stay in the repo at `tests/load/results/<run-id>/report.md` keyed to the matching git tag.
- Added a corresponding policy line to `CLAUDE.md` so future release PRs prune stale result sections rather than letting them stack up.

## Why

PR #424 published two result sets on the same docs page (laptop Docker + Azure Container Apps). Without version + date scoping, future Fleans releases would either pile up new sections (page becomes unreadable) or silently overwrite older numbers (loss of context on which release the numbers describe). Scoping forces the next release PR to make a deliberate choice — replace the page with new numbers, anchored to the new tag.

## Test plan

- [ ] `cd website && npm run build` passes (verified locally — 16 pages built).
- [ ] Open `website/src/content/docs/reference/load-testing.md` in the rendered site and confirm:
  - the `:::note` admonition reads "Currently published: Fleans v0.1.0";
  - both result sections start with `### Fleans v0.1.0 — <date> — …`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)