### PR TITLE
feat(#357): typed CustomTaskParameterSchema + List/Map for plugins

### DIFF
--- a/src/Fleans/Fleans.Api/Controllers/CustomTasksController.cs
+++ b/src/Fleans/Fleans.Api/Controllers/CustomTasksController.cs
@@ -24,9 +24,7 @@ public sealed class CustomTasksController : ControllerBase
     {
         var catalog = _grainFactory.GetGrain<ICustomTaskCatalogGrain>(0);
         var entries = await catalog.GetAll();
-        return entries
-            .Select(e => new CustomTaskCatalogEntryDto(e.TaskType, e.DisplayName, e.ParameterSchemaJson, e.SiloNames))
-            .ToList();
+        return entries.Select(CustomTaskCatalogMappers.ToDto).ToList();
     }
 
     /// <summary>Returns the entry for one task type, 404 if no plugin claims it.</summary>
@@ -37,6 +35,19 @@ public sealed class CustomTasksController : ControllerBase
         var entry = await catalog.Get(taskType);
         if (entry is null)
             return NotFound();
-        return new CustomTaskCatalogEntryDto(entry.TaskType, entry.DisplayName, entry.ParameterSchemaJson, entry.SiloNames);
+        return entry.ToDto();
     }
+}
+
+internal static class CustomTaskCatalogMappers
+{
+    public static CustomTaskCatalogEntryDto ToDto(this CustomTaskCatalogEntry entry) =>
+        new(entry.TaskType, entry.DisplayName, entry.ParameterSchema?.ToDto(), entry.SiloNames);
+
+    public static CustomTaskParameterSchemaDto ToDto(this CustomTaskParameterSchema schema) =>
+        new(schema.Parameters.Select(p => p.ToDto()).ToList());
+
+    public static CustomTaskParameterSpecDto ToDto(this CustomTaskParameterSpec spec) =>
+        new(spec.Name, spec.DisplayName, spec.Type, spec.Required,
+            spec.Description, spec.DefaultValue, spec.ItemType);
 }

--- a/src/Fleans/Fleans.Application.Tests/CustomTasks/CustomTaskCatalogGrainTests.cs
+++ b/src/Fleans/Fleans.Application.Tests/CustomTasks/CustomTaskCatalogGrainTests.cs
@@ -65,16 +65,71 @@ public class CustomTaskCatalogGrainTests : WorkflowTestBase
     public async Task Get_KnownTaskType_ReturnsAggregatedEntry()
     {
         var catalog = GetCatalog();
+        var schema = new CustomTaskParameterSchema(new[]
+        {
+            new CustomTaskParameterSpec("to", "Recipient", CustomTaskParameterType.String,
+                Required: true, Description: "Email address", DefaultValue: null),
+            new CustomTaskParameterSpec("body", "Body", CustomTaskParameterType.MultilineString,
+                Required: false, Description: null, DefaultValue: ""),
+        });
 
-        await catalog.Register(new CustomTaskRegistration("email-send", "Email Sender", "{}", "worker-X"));
+        await catalog.Register(new CustomTaskRegistration("email-send", "Email Sender", schema, "worker-X"));
 
         var entry = await catalog.Get("email-send");
 
         Assert.IsNotNull(entry);
         Assert.AreEqual("email-send", entry!.TaskType);
         Assert.AreEqual("Email Sender", entry.DisplayName);
-        Assert.AreEqual("{}", entry.ParameterSchemaJson);
+        Assert.IsNotNull(entry.ParameterSchema);
+        Assert.HasCount(2, entry.ParameterSchema!.Parameters);
+        Assert.AreEqual("to", entry.ParameterSchema.Parameters[0].Name);
+        Assert.AreEqual(CustomTaskParameterType.String, entry.ParameterSchema.Parameters[0].Type);
+        Assert.IsTrue(entry.ParameterSchema.Parameters[0].Required);
+        Assert.AreEqual(CustomTaskParameterType.MultilineString, entry.ParameterSchema.Parameters[1].Type);
         Assert.AreEqual("worker-X", entry.SiloNames.Single());
+    }
+
+    [TestMethod]
+    public async Task Get_PluginWithoutSchema_ReturnsNullParameterSchema()
+    {
+        var catalog = GetCatalog();
+
+        await catalog.Register(new CustomTaskRegistration("opaque-task", null, null, "worker-Y"));
+
+        var entry = await catalog.Get("opaque-task");
+
+        Assert.IsNotNull(entry);
+        Assert.IsNull(entry!.ParameterSchema);
+    }
+
+    [TestMethod]
+    public async Task Get_PluginWithMapAndListParameters_RoundTripsItemType()
+    {
+        var catalog = GetCatalog();
+        var schema = new CustomTaskParameterSchema(new[]
+        {
+            new CustomTaskParameterSpec("url", "URL", CustomTaskParameterType.String,
+                Required: true, Description: null, DefaultValue: null),
+            new CustomTaskParameterSpec("headers", "HTTP Headers", CustomTaskParameterType.Map,
+                Required: false, Description: "Repeat for each header.", DefaultValue: null,
+                ItemType: CustomTaskParameterType.String),
+            new CustomTaskParameterSpec("successCodes", "Success Codes", CustomTaskParameterType.List,
+                Required: false, Description: "HTTP codes treated as success.", DefaultValue: null,
+                ItemType: CustomTaskParameterType.Integer),
+        });
+
+        await catalog.Register(new CustomTaskRegistration("rest-call", "REST Caller", schema, "worker-Z"));
+
+        var entry = await catalog.Get("rest-call");
+
+        Assert.IsNotNull(entry);
+        Assert.IsNotNull(entry!.ParameterSchema);
+        var headers = entry.ParameterSchema!.Parameters.Single(p => p.Name == "headers");
+        Assert.AreEqual(CustomTaskParameterType.Map, headers.Type);
+        Assert.AreEqual(CustomTaskParameterType.String, headers.ItemType);
+        var codes = entry.ParameterSchema.Parameters.Single(p => p.Name == "successCodes");
+        Assert.AreEqual(CustomTaskParameterType.List, codes.Type);
+        Assert.AreEqual(CustomTaskParameterType.Integer, codes.ItemType);
     }
 
     [TestMethod]

--- a/src/Fleans/Fleans.Application/CustomTasks/CustomTaskCatalogEntry.cs
+++ b/src/Fleans/Fleans.Application/CustomTasks/CustomTaskCatalogEntry.cs
@@ -8,5 +8,5 @@ namespace Fleans.Application.CustomTasks;
 public sealed record CustomTaskCatalogEntry(
     [property: Id(0)] string TaskType,
     [property: Id(1)] string? DisplayName,
-    [property: Id(2)] string? ParameterSchemaJson,
+    [property: Id(2)] CustomTaskParameterSchema? ParameterSchema,
     [property: Id(3)] IReadOnlyList<string> SiloNames);

--- a/src/Fleans/Fleans.Application/CustomTasks/CustomTaskCatalogGrain.cs
+++ b/src/Fleans/Fleans.Application/CustomTasks/CustomTaskCatalogGrain.cs
@@ -68,7 +68,7 @@ public sealed partial class CustomTaskCatalogGrain : Grain, ICustomTaskCatalogGr
                 return new CustomTaskCatalogEntry(
                     first.TaskType,
                     first.DisplayName,
-                    first.ParameterSchemaJson,
+                    first.ParameterSchema,
                     g.Select(e => e.SiloName).Distinct(StringComparer.Ordinal).ToList());
             })
             .ToList();
@@ -88,7 +88,7 @@ public sealed partial class CustomTaskCatalogGrain : Grain, ICustomTaskCatalogGr
         var entry = new CustomTaskCatalogEntry(
             first.TaskType,
             first.DisplayName,
-            first.ParameterSchemaJson,
+            first.ParameterSchema,
             matches.Select(e => e.SiloName).Distinct(StringComparer.Ordinal).ToList());
         return Task.FromResult<CustomTaskCatalogEntry?>(entry);
     }

--- a/src/Fleans/Fleans.Application/CustomTasks/CustomTaskParameterSchema.cs
+++ b/src/Fleans/Fleans.Application/CustomTasks/CustomTaskParameterSchema.cs
@@ -1,0 +1,71 @@
+namespace Fleans.Application.CustomTasks;
+
+/// <summary>
+/// What kind of value a custom-task parameter accepts. Drives both the input-mapping
+/// validation (in v2) and the management-UI editor (sub-issue C).
+/// </summary>
+public enum CustomTaskParameterType
+{
+    /// <summary>Single-line text. Editor renders &lt;FluentTextField&gt;.</summary>
+    String,
+    /// <summary>Whole number. Editor renders &lt;FluentTextField type="number"&gt;.</summary>
+    Integer,
+    /// <summary>true / false. Editor renders &lt;FluentCheckbox&gt;.</summary>
+    Boolean,
+    /// <summary>
+    /// An <c>=</c>-prefixed mapping expression evaluated against the workflow scope at
+    /// dispatch time. Editor renders a multi-line input with the existing
+    /// <c>=</c>-prefix affordance from the sequence-flow condition editor.
+    /// </summary>
+    Expression,
+    /// <summary>Multi-line text (e.g. JSON request body). Editor renders &lt;FluentTextArea&gt;.</summary>
+    MultilineString,
+    /// <summary>
+    /// Multiple values of the same primitive type. Editor renders a single-column
+    /// list with "+ Add" / "remove" buttons; each row is rendered per
+    /// <see cref="CustomTaskParameterSpec.ItemType"/>. Use for things like
+    /// "list of allowed HTTP status codes".
+    /// </summary>
+    List,
+    /// <summary>
+    /// Multiple <c>(string key, value)</c> entries. Editor renders a two-column
+    /// table with "+ Add" / "remove" buttons; the value column is rendered per
+    /// <see cref="CustomTaskParameterSpec.ItemType"/>. Use for things like
+    /// "HTTP request headers" or "form fields".
+    /// </summary>
+    Map,
+}
+
+/// <summary>
+/// One parameter the plugin's <c>ExecuteAsync</c> reads from <c>resolvedInputs</c>.
+/// The <see cref="Name"/> is the same string a workflow author writes as the
+/// <c>&lt;zeebe:input target="…"/&gt;</c> on the BPMN service task.
+///
+/// When <see cref="Type"/> is <see cref="CustomTaskParameterType.List"/> or
+/// <see cref="CustomTaskParameterType.Map"/>, <see cref="ItemType"/> must be set
+/// to a primitive type (<c>String</c>, <c>Integer</c>, <c>Boolean</c>,
+/// <c>Expression</c>, or <c>MultilineString</c>) describing how each entry is
+/// rendered. Nested <c>List</c>/<c>Map</c> are not supported in v1.
+/// </summary>
+[GenerateSerializer]
+public sealed record CustomTaskParameterSpec(
+    [property: Id(0)] string Name,
+    [property: Id(1)] string? DisplayName,
+    [property: Id(2)] CustomTaskParameterType Type,
+    [property: Id(3)] bool Required,
+    [property: Id(4)] string? Description,
+    [property: Id(5)] string? DefaultValue,
+    [property: Id(6)] CustomTaskParameterType? ItemType = null);
+
+/// <summary>
+/// The set of parameters a plugin exposes. Surfaced in the catalog so the management UI
+/// can render a per-parameter editor when a workflow author drops a <c>&lt;serviceTask
+/// type="…"/&gt;</c> referencing this plugin.
+/// </summary>
+[GenerateSerializer]
+public sealed record CustomTaskParameterSchema(
+    [property: Id(0)] IReadOnlyList<CustomTaskParameterSpec> Parameters)
+{
+    /// <summary>Convenience constant for plugins that take no parameters.</summary>
+    public static readonly CustomTaskParameterSchema Empty = new(Array.Empty<CustomTaskParameterSpec>());
+}

--- a/src/Fleans/Fleans.Application/CustomTasks/CustomTaskRegistration.cs
+++ b/src/Fleans/Fleans.Application/CustomTasks/CustomTaskRegistration.cs
@@ -8,5 +8,5 @@ namespace Fleans.Application.CustomTasks;
 public sealed record CustomTaskRegistration(
     [property: Id(0)] string TaskType,
     [property: Id(1)] string? DisplayName,
-    [property: Id(2)] string? ParameterSchemaJson,
+    [property: Id(2)] CustomTaskParameterSchema? ParameterSchema,
     [property: Id(3)] string SiloName);

--- a/src/Fleans/Fleans.ServiceDefaults/DTOs/CustomTaskCatalogEntryDto.cs
+++ b/src/Fleans/Fleans.ServiceDefaults/DTOs/CustomTaskCatalogEntryDto.cs
@@ -1,8 +1,29 @@
+using System.Text.Json.Serialization;
+using Fleans.Application.CustomTasks;
+
 namespace Fleans.ServiceDefaults.DTOs;
 
 /// <summary>Wire DTO for <c>GET /custom-tasks</c>. One per registered task type.</summary>
 public sealed record CustomTaskCatalogEntryDto(
     string TaskType,
     string? DisplayName,
-    string? ParameterSchemaJson,
+    CustomTaskParameterSchemaDto? ParameterSchema,
     IReadOnlyList<string> SiloNames);
+
+/// <summary>Wire DTO for the per-plugin parameter list rendered by the management UI editor.</summary>
+public sealed record CustomTaskParameterSchemaDto(
+    IReadOnlyList<CustomTaskParameterSpecDto> Parameters);
+
+/// <summary>
+/// Wire DTO for one parameter the plugin's <c>ExecuteAsync</c> reads.
+/// <see cref="Type"/> and <see cref="ItemType"/> serialize as their enum-name strings
+/// (not integers) so the wire format stays human-readable and resilient to enum reordering.
+/// </summary>
+public sealed record CustomTaskParameterSpecDto(
+    string Name,
+    string? DisplayName,
+    [property: JsonConverter(typeof(JsonStringEnumConverter))] CustomTaskParameterType Type,
+    bool Required,
+    string? Description,
+    string? DefaultValue,
+    [property: JsonConverter(typeof(JsonStringEnumConverter))] CustomTaskParameterType? ItemType);

--- a/src/Fleans/Fleans.Worker/CustomTasks/CustomTaskPluginDescriptor.cs
+++ b/src/Fleans/Fleans.Worker/CustomTasks/CustomTaskPluginDescriptor.cs
@@ -1,3 +1,5 @@
+using Fleans.Application.CustomTasks;
+
 namespace Fleans.Worker.CustomTasks;
 
 /// <summary>
@@ -8,4 +10,4 @@ namespace Fleans.Worker.CustomTasks;
 public sealed record CustomTaskPluginDescriptor(
     string TaskType,
     string? DisplayName,
-    string? ParameterSchemaJson);
+    CustomTaskParameterSchema? ParameterSchema);

--- a/src/Fleans/Fleans.Worker/CustomTasks/CustomTaskPluginRegistrar.cs
+++ b/src/Fleans/Fleans.Worker/CustomTasks/CustomTaskPluginRegistrar.cs
@@ -61,7 +61,7 @@ internal sealed partial class CustomTaskPluginRegistrar : ILifecycleParticipant<
                 await catalog.Register(new CustomTaskRegistration(
                     descriptor.TaskType,
                     descriptor.DisplayName,
-                    descriptor.ParameterSchemaJson,
+                    descriptor.ParameterSchema,
                     _siloDetails.Name));
                 LogRegistered(descriptor.TaskType, _siloDetails.Name);
                 return;

--- a/src/Fleans/Fleans.Worker/CustomTasks/CustomTaskServiceCollectionExtensions.cs
+++ b/src/Fleans/Fleans.Worker/CustomTasks/CustomTaskServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using Fleans.Application.CustomTasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Orleans.Runtime;
@@ -10,6 +11,12 @@ namespace Fleans.Worker.CustomTasks;
 /// into the silo (Orleans discovers it automatically via assembly scanning), and
 /// (b) register the plugin's metadata so <see cref="CustomTaskPluginRegistrar"/>
 /// announces it to the catalog at silo startup.
+///
+/// The <paramref name="parameterSchema"/> is what the management UI's BPMN editor
+/// (sub-issue C) uses to render a typed editor for each <c>&lt;zeebe:input&gt;</c>
+/// the plugin expects. Pass <see cref="CustomTaskParameterSchema.Empty"/> when the
+/// plugin takes no inputs; omit the argument when the plugin should remain
+/// editor-opaque (UI falls back to a free-form key/value editor).
 /// </summary>
 public static class CustomTaskServiceCollectionExtensions
 {
@@ -17,12 +24,12 @@ public static class CustomTaskServiceCollectionExtensions
         this IServiceCollection services,
         string taskType,
         string? displayName = null,
-        string? parameterSchemaJson = null)
+        CustomTaskParameterSchema? parameterSchema = null)
         where THandler : CustomTaskHandlerBase
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(taskType);
 
-        services.AddSingleton(new CustomTaskPluginDescriptor(taskType, displayName, parameterSchemaJson));
+        services.AddSingleton(new CustomTaskPluginDescriptor(taskType, displayName, parameterSchema));
 
         // Register the lifecycle participant exactly once even if multiple plugins are added.
         services.TryAddSingleton<CustomTaskPluginRegistrar>();

--- a/website/src/content/docs/concepts/custom-tasks.md
+++ b/website/src/content/docs/concepts/custom-tasks.md
@@ -51,8 +51,50 @@ Register the plugin in the Worker silo's host:
 ```csharp
 services.AddCustomTaskPlugin<HiPluginHandler>(
     taskType: "hi",
-    displayName: "Say hi");
+    displayName: "Say hi",
+    parameterSchema: new CustomTaskParameterSchema(new[]
+    {
+        new CustomTaskParameterSpec(
+            Name: "name",
+            DisplayName: "Recipient name",
+            Type: CustomTaskParameterType.String,
+            Required: false,
+            Description: "Greeting target; defaults to \"world\".",
+            DefaultValue: "world"),
+    }));
 ```
+
+The `parameterSchema` is optional. When supplied, the management UI's BPMN editor (sub-issue C) renders a typed editor for each parameter (`String` → text field, `Boolean` → checkbox, `Expression` → multi-line `=`-prefixed input, etc.). Pass `CustomTaskParameterSchema.Empty` for plugins that take no inputs; omit the argument entirely to leave the editor opaque (UI falls back to a free-form key/value editor).
+
+### Repeat-allowed parameters: `List` and `Map`
+
+Parameters that accept multiple values (e.g. a REST plugin's HTTP headers, where each header is a separate `(key, value)` pair) use `Type = List` or `Type = Map` plus an `ItemType` describing each entry. `List` is "N values of `ItemType`"; `Map` is "N `(string-key, ItemType-value)` entries":
+
+```csharp
+services.AddCustomTaskPlugin<RestCallerHandler>(
+    taskType: "rest-call",
+    displayName: "REST Caller",
+    parameterSchema: new CustomTaskParameterSchema(new[]
+    {
+        new CustomTaskParameterSpec("url", "URL",
+            CustomTaskParameterType.String,
+            Required: true, Description: null, DefaultValue: null),
+
+        // multiple (header-name, header-value) pairs
+        new CustomTaskParameterSpec("headers", "HTTP Headers",
+            CustomTaskParameterType.Map,
+            Required: false, Description: "Repeat for each header.", DefaultValue: null,
+            ItemType: CustomTaskParameterType.String),
+
+        // multiple HTTP status codes treated as success
+        new CustomTaskParameterSpec("successCodes", "Success Codes",
+            CustomTaskParameterType.List,
+            Required: false, Description: "Defaults to 200..299.", DefaultValue: null,
+            ItemType: CustomTaskParameterType.Integer),
+    }));
+```
+
+The editor renders `Map` as a two-column table (Key, Value) with an "+ Add row" button; `List` as a single-column list with "+ Add" / "remove". The value column is rendered per `ItemType`. Nested `List`/`Map` (e.g. a list whose items are themselves objects with three fields) is **not** supported in v1 — keep `ItemType` to a primitive (`String | Integer | Boolean | Expression | MultilineString`).
 
 Reference your plugin from BPMN:
 


### PR DESCRIPTION
## Summary

Follow-up to merged PR #384 (sub-issue A of #357 — custom-task framework v12).

PR #384 landed with `ParameterSchemaJson` as a free-form `string?` on `CustomTaskRegistration` / `CustomTaskCatalogEntry`. That left two real gaps:

1. **No contract for plugin authors** — "fill in some JSON" with no schema definition is not a usable API.
2. **Sub-issue C (UI editor) blocked** — without a defined schema shape, the upcoming management-UI BPMN editor for `<serviceTask type="…">` would have to invent the schema before it could render anything.

This PR closes both by introducing typed records that flow from the plugin's DI registration through the catalog grain to the API DTO, with first-class support for repeat-allowed parameters (e.g. REST headers).

## What plugin authors write

```csharp
services.AddCustomTaskPlugin<RestCallerHandler>(
    taskType: "rest-call",
    displayName: "REST Caller",
    parameterSchema: new CustomTaskParameterSchema(new[]
    {
        new CustomTaskParameterSpec("url", "URL",
            CustomTaskParameterType.String,
            Required: true, Description: null, DefaultValue: null),

        // multiple (header-name, header-value) pairs
        new CustomTaskParameterSpec("headers", "HTTP Headers",
            CustomTaskParameterType.Map,
            Required: false, Description: "Repeat for each header.",
            DefaultValue: null,
            ItemType: CustomTaskParameterType.String),

        // multiple HTTP status codes treated as success
        new CustomTaskParameterSpec("successCodes", "Success Codes",
            CustomTaskParameterType.List,
            Required: false, Description: "Defaults to 200..299.",
            DefaultValue: null,
            ItemType: CustomTaskParameterType.Integer),
    }));
```

## Type system

```csharp
public enum CustomTaskParameterType
{
    String,           // single-line text
    Integer,          // whole number
    Boolean,          // checkbox
    Expression,       // =-prefixed mapping expression evaluated against workflow scope
    MultilineString,  // textarea (e.g. JSON request body)
    List,             // N values of ItemType — single-column list with "+ Add"
    Map,              // N (string-key, ItemType-value) entries — two-column table with "+ Add"
}
```

`List` and `Map` carry an `ItemType` (must be a primitive — `String|Integer|Boolean|Expression|MultilineString`). Nested `List`/`Map` (e.g. a list whose items are themselves objects with three fields) is **not** supported in v1.

The user's example — REST headers, where each header is a `(name, value)` pair repeated N times — maps cleanly to `Map(ItemType: String)`.

## Wire format

DTOs in `Fleans.ServiceDefaults`:

```csharp
public sealed record CustomTaskCatalogEntryDto(
    string TaskType, string? DisplayName,
    CustomTaskParameterSchemaDto? ParameterSchema,
    IReadOnlyList<string> SiloNames);

public sealed record CustomTaskParameterSchemaDto(
    IReadOnlyList<CustomTaskParameterSpecDto> Parameters);

public sealed record CustomTaskParameterSpecDto(
    string Name, string? DisplayName,
    [JsonConverter(typeof(JsonStringEnumConverter))] CustomTaskParameterType Type,
    bool Required, string? Description, string? DefaultValue,
    [JsonConverter(typeof(JsonStringEnumConverter))] CustomTaskParameterType? ItemType);
```

Enum fields carry `[JsonStringEnumConverter]` so the wire format is human-readable enum-name strings (`"Map"`, `"String"`) — not opaque integers — while .NET consumers (Fleans.Web, Fleans.Mcp) get the typed enum directly via the existing transitive reference graph (Application → ServiceDefaults isn't needed because Persistence already pulls Application in transitively).

## File deltas

| File | Change |
|------|--------|
| `Fleans.Application/CustomTasks/CustomTaskParameterSchema.cs` | **new** — enum (7 values incl. List/Map) + records, [GenerateSerializer] |
| `Fleans.Application/CustomTasks/CustomTaskRegistration.cs`, `CustomTaskCatalogEntry.cs` | field `string? ParameterSchemaJson` → `CustomTaskParameterSchema? ParameterSchema` |
| `Fleans.Application/CustomTasks/CustomTaskCatalogGrain.cs` | propagates the new field through aggregation |
| `Fleans.Worker/CustomTasks/CustomTaskPluginDescriptor.cs`, `CustomTaskServiceCollectionExtensions.cs`, `CustomTaskPluginRegistrar.cs` | DI surface accepts the typed schema |
| `Fleans.Api/Controllers/CustomTasksController.cs` | record→DTO mappers (typed enums passed through) |
| `Fleans.ServiceDefaults/DTOs/CustomTaskCatalogEntryDto.cs` | adds `CustomTaskParameterSchemaDto` + `CustomTaskParameterSpecDto`; enum fields with `[JsonStringEnumConverter]` |
| `Fleans.Application.Tests/CustomTasks/CustomTaskCatalogGrainTests.cs` | `Get_KnownTaskType` rewritten to assert typed parameter list; new `Get_PluginWithoutSchema` (null-schema path); new `Get_PluginWithMapAndListParameters` (List+Map round-trip) |
| `website/src/content/docs/concepts/custom-tasks.md` | author guide updated with typed `AddCustomTaskPlugin` signature plus the REST-headers worked example |

## How to test

- [x] `dotnet build` — clean.
- [x] `dotnet test --filter "FullyQualifiedName~CustomTask"`: 4 Domain + 21 BPMN routing + **16 Application** (was 14 in PR #384 — added `Get_PluginWithoutSchema` and `Get_PluginWithMapAndListParameters`) all green.
- [x] `cd website && npm run build` — clean (17 pages including updated `/concepts/custom-tasks/`).

## Why a separate PR

Spotted by the reviewer immediately after #384 merged — and refined twice by the reviewer's feedback (typed records first, then `List`/`Map` for repeat-allowed parameters, then enum-on-the-wire instead of stringified enum names). The parameter schema was always part of v12's design intent (sub-issue C consumes it), but PR #384 distilled it down to a `string?` placeholder. This PR makes it real before sub-issue B (REST plugin) and sub-issue C (UI editor) start, so neither has to define the schema themselves or work against an unstable contract.

Refs #357.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
