### PR TITLE
docs(#433): plugin author guide — step-by-step custom-task tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ For now, next elements are implemented
 | **Activities**       |                                                                             |             |
 | Task                 | A single unit of work.                                                      |     [x]     |
 | Script Task          | A task that executes an inline script.                                       |     [x]     |
-| Service Task         | A task whose execution is supplied by a custom plugin (`<serviceTask type="…">`); plain `<serviceTask>` (no `type`) is a no-op. | [x] custom-task framework |
+| Service Task         | A task whose execution is supplied by a custom plugin (`<serviceTask type="…">`); plain `<serviceTask>` (no `type`) is a no-op. See the [plugin author guide](https://nightbaker.github.io/fleans/guides/writing-custom-tasks/). | [x] custom-task framework |
 | Sub-Process          | A group of tasks that are treated as a single unit.                         |     [x]     |
 | Call Activity        | A type of sub-process that calls another process.                            |     [x]     |
 | User Task            | A task that requires human interaction with claim lifecycle.                 |     [x]     |

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -24,6 +24,7 @@ export default defineConfig({
             { label: 'Introduction', slug: 'guides/introduction' },
             { label: 'Quick Start', slug: 'guides/quick-start' },
             { label: 'Service Tasks', slug: 'guides/service-tasks' },
+            { label: 'Writing Custom-Task Plugins', slug: 'guides/writing-custom-tasks' },
             { label: 'BPMN Editor', slug: 'guides/editor' },
             { label: 'Add to Existing Project', slug: 'guides/add-to-existing-project' },
           ],

--- a/website/src/content/docs/concepts/custom-tasks.md
+++ b/website/src/content/docs/concepts/custom-tasks.md
@@ -17,99 +17,30 @@ This is the recommended pattern for anything Fleans doesn't ship in the box: RES
 
 ## Authoring a plugin
 
-A minimal "say hi" plugin:
+A plugin is a .NET class library deriving from `CustomTaskHandlerBase`. The base class provides stream subscription, task-type filtering, and the success/failure callback paths; the author overrides `TaskType` and `ExecuteAsync` only. Plugin metadata is registered via `services.AddCustomTaskPlugin<THandler>(taskType, displayName?, parameterSchema?)` from the Worker silo's host.
 
-```csharp
-using Fleans.Worker.CustomTasks;
+For a step-by-step tutorial — project setup, handler, schema, DI wiring, BPMN authoring, and troubleshooting — see [Writing custom-task plugins](/guides/writing-custom-tasks/).
 
-public sealed class HiPluginHandler(
-    ILogger<HiPluginHandler> logger,
-    IGrainFactory grainFactory)
-    : CustomTaskHandlerBase(logger, grainFactory)
-{
-    protected override string TaskType => "hi";
-    protected override string? DisplayName => "Say hi";
+## Parameter types
 
-    protected override Task<IDictionary<string, object?>> ExecuteAsync(
-        IDictionary<string, object?> resolvedInputs,
-        ExpandoObject variables,
-        CancellationToken cancellationToken)
-    {
-        var name = resolvedInputs.TryGetValue("name", out var n) ? n?.ToString() : "world";
-        return Task.FromResult<IDictionary<string, object?>>(new Dictionary<string, object?>
-        {
-            ["__response"] = $"hi, {name}!",
-        });
-    }
-}
-```
+Parameter schemas drive what the management UI's BPMN editor renders for each `<zeebe:input>` row. The five primitive types map to typed widgets:
 
-`[ImplicitStreamSubscription]` and `[WorkerPlacement]` are inherited from the base class — you do not need to repeat them on the subclass.
+| Type | Widget | Notes |
+|---|---|---|
+| `String` | Single-line text | Accepts a literal value or `=variableName` for a workflow-variable reference. |
+| `Integer` | Number field | Whole numbers. |
+| `Boolean` | Checkbox | `"true"` / `"false"` written as the source. |
+| `Expression` | Multi-line text (monospace) | Always `=`-prefixed; evaluated against the workflow scope at dispatch time. |
+| `MultilineString` | Textarea | For JSON request bodies, etc. |
 
-Register the plugin in the Worker silo's host:
+Repeat-allowed parameters (e.g. REST headers — multiple `(key, value)` pairs) use:
 
-```csharp
-services.AddCustomTaskPlugin<HiPluginHandler>(
-    taskType: "hi",
-    displayName: "Say hi",
-    parameterSchema: new CustomTaskParameterSchema(new[]
-    {
-        new CustomTaskParameterSpec(
-            Name: "name",
-            DisplayName: "Recipient name",
-            Type: CustomTaskParameterType.String,
-            Required: false,
-            Description: "Greeting target; defaults to \"world\".",
-            DefaultValue: "world"),
-    }));
-```
+| Type | Editor | Notes |
+|---|---|---|
+| `List` (with `ItemType`) | Single-column list with "+ Add" / "remove" | `ItemType` must be a primitive. |
+| `Map` (with `ItemType`) | Two-column `(Key, Value)` table with "+ Add" / "remove" | Value column rendered per `ItemType`. |
 
-The `parameterSchema` is optional. When supplied, the management UI's BPMN editor (sub-issue C) renders a typed editor for each parameter (`String` → text field, `Boolean` → checkbox, `Expression` → multi-line `=`-prefixed input, etc.). Pass `CustomTaskParameterSchema.Empty` for plugins that take no inputs; omit the argument entirely to leave the editor opaque (UI falls back to a free-form key/value editor).
-
-### Repeat-allowed parameters: `List` and `Map`
-
-Parameters that accept multiple values (e.g. a REST plugin's HTTP headers, where each header is a separate `(key, value)` pair) use `Type = List` or `Type = Map` plus an `ItemType` describing each entry. `List` is "N values of `ItemType`"; `Map` is "N `(string-key, ItemType-value)` entries":
-
-```csharp
-services.AddCustomTaskPlugin<RestCallerHandler>(
-    taskType: "rest-call",
-    displayName: "REST Caller",
-    parameterSchema: new CustomTaskParameterSchema(new[]
-    {
-        new CustomTaskParameterSpec("url", "URL",
-            CustomTaskParameterType.String,
-            Required: true, Description: null, DefaultValue: null),
-
-        // multiple (header-name, header-value) pairs
-        new CustomTaskParameterSpec("headers", "HTTP Headers",
-            CustomTaskParameterType.Map,
-            Required: false, Description: "Repeat for each header.", DefaultValue: null,
-            ItemType: CustomTaskParameterType.String),
-
-        // multiple HTTP status codes treated as success
-        new CustomTaskParameterSpec("successCodes", "Success Codes",
-            CustomTaskParameterType.List,
-            Required: false, Description: "Defaults to 200..299.", DefaultValue: null,
-            ItemType: CustomTaskParameterType.Integer),
-    }));
-```
-
-The editor renders `Map` as a two-column table (Key, Value) with an "+ Add row" button; `List` as a single-column list with "+ Add" / "remove". The value column is rendered per `ItemType`. Nested `List`/`Map` (e.g. a list whose items are themselves objects with three fields) is **not** supported in v1 — keep `ItemType` to a primitive (`String | Integer | Boolean | Expression | MultilineString`).
-
-Reference your plugin from BPMN:
-
-```xml
-<bpmn:serviceTask id="greet" type="hi">
-  <bpmn:extensionElements>
-    <zeebe:ioMapping>
-      <zeebe:input  source="=customerName" target="name" />
-      <zeebe:output source="=__response"   target="greeting" />
-    </zeebe:ioMapping>
-  </bpmn:extensionElements>
-</bpmn:serviceTask>
-```
-
-When the workflow reaches `greet`, the plugin runs, and the variable `greeting` ends up holding `"hi, alice!"` (assuming `customerName` was `"alice"`).
+Nested `List`/`Map` (a list whose items are themselves objects with three fields) is **not** supported in v1 — keep `ItemType` to a primitive (`String | Integer | Boolean | Expression | MultilineString`).
 
 ## Mapping grammar
 

--- a/website/src/content/docs/guides/service-tasks.md
+++ b/website/src/content/docs/guides/service-tasks.md
@@ -3,6 +3,10 @@ title: Service Tasks
 description: How to complete service tasks in Fleans using external workers and the REST API.
 ---
 
+:::tip[Looking for in-process plugins?]
+This guide covers the **external completion** pattern — any-language workers complete tasks via REST. If your worker is .NET and you'd rather ship it in-process on a Worker silo (with typed parameter editor support in the management UI), see [Writing custom-task plugins](/guides/writing-custom-tasks/) instead.
+:::
+
 ## What are service tasks?
 
 A **service task** (`<bpmn:serviceTask>`) represents automated work in a BPMN process — calling an API, processing a payment, sending an email, etc.

--- a/website/src/content/docs/guides/writing-custom-tasks.md
+++ b/website/src/content/docs/guides/writing-custom-tasks.md
@@ -1,0 +1,297 @@
+---
+title: Writing custom-task plugins
+description: Step-by-step tutorial for shipping your own <serviceTask type="..."> plugin against the Fleans custom-task framework.
+---
+
+<!--
+  The HelloWorld example in this guide is intentionally NOT committed to the repo.
+  Code blocks are verified by building a scratch project against the matching
+  framework SHA. If a future framework PR changes a signature, this guide will
+  drift silently — re-verify against `git show HEAD:src/Fleans/Fleans.Worker/CustomTasks/`
+  before publishing changes.
+-->
+
+This tutorial walks an author from an empty class library to a working `<bpmn:serviceTask type="hello">` that runs a .NET plugin in-process on a Worker silo. End-to-end takes about 15 minutes the first time.
+
+## Choosing the right pattern
+
+Fleans gives you two ways to back a `<bpmn:serviceTask>`:
+
+| Need | Pattern |
+|---|---|
+| Worker is non-.NET (Python, Node, Go) | External completion ([Service Tasks](/guides/service-tasks/)) |
+| Worker pool needs to scale independently of the engine | External completion |
+| Queue or message bus between engine and worker (Kafka, RabbitMQ, etc.) | External completion |
+| Worker is .NET, runs in-process on a Worker silo | **Custom-task plugin (this guide)** |
+| Need a typed parameter editor in the management UI | **Custom-task plugin** |
+| Want per-task-type schema discoverable via `GET /custom-tasks` | **Custom-task plugin** |
+
+If your situation isn't on this list, lean toward external completion — it's the more decoupled option. Custom-task plugins are the right fit when you have a lot of small per-task-type behaviors that ship together with the engine and want first-class editor support for them.
+
+## Prerequisites
+
+- Fleans repo cloned locally and the Aspire stack runs (`dotnet run --project Fleans.Aspire` from `src/Fleans/`).
+- .NET 10 SDK.
+- An editor / IDE that handles C# (Rider, VS, VS Code).
+
+## What you'll build
+
+A trivial "say hello" plugin. The workflow author writes:
+
+```xml
+<bpmn:serviceTask id="greet" type="hello">
+  <bpmn:extensionElements>
+    <zeebe:taskDefinition type="hello" />
+    <zeebe:ioMapping>
+      <zeebe:input  source="=customerName"     target="name" />
+      <zeebe:input  source="true"              target="excitement" />
+      <zeebe:output source="=__response.text"  target="greeting" />
+    </zeebe:ioMapping>
+  </bpmn:extensionElements>
+</bpmn:serviceTask>
+```
+
+Your plugin reads `name` (`String`) and `excitement` (`Boolean`), and returns `{ "text": "Hello, alice!!" }`. The output mapping pulls `text` out and writes it to the workflow variable `greeting`.
+
+## Step 1 — Create the plugin project
+
+From `src/Fleans/`:
+
+```bash
+dotnet new classlib -n Fleans.Plugins.HelloWorld -f net10.0
+dotnet sln add Fleans.Plugins.HelloWorld/Fleans.Plugins.HelloWorld.csproj
+cd Fleans.Plugins.HelloWorld
+dotnet add reference ../Fleans.Worker/Fleans.Worker.csproj
+dotnet add package Microsoft.Orleans.Sdk --version 10.0.1
+```
+
+Your `.csproj` should now look like:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>14</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Orleans.Sdk" Version="10.0.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Fleans.Worker\Fleans.Worker.csproj" />
+  </ItemGroup>
+</Project>
+```
+
+## Step 2 — Write the handler
+
+Add `HelloWorldHandler.cs`:
+
+```csharp
+using System.Dynamic;
+using Fleans.Worker.CustomTasks;
+using Microsoft.Extensions.Logging;
+
+namespace Fleans.Plugins.HelloWorld;
+
+public sealed partial class HelloWorldHandler(
+    ILogger<HelloWorldHandler> logger,
+    IGrainFactory grainFactory)
+    : CustomTaskHandlerBase(logger, grainFactory)
+{
+    private readonly ILogger<HelloWorldHandler> _logger = logger;
+
+    protected override string TaskType => "hello";
+
+    protected override Task<IDictionary<string, object?>> ExecuteAsync(
+        IDictionary<string, object?> resolvedInputs,
+        ExpandoObject variables,
+        CancellationToken cancellationToken)
+    {
+        var name = resolvedInputs.TryGetValue("name", out var n) ? n?.ToString() : "world";
+        var excited = resolvedInputs.TryGetValue("excitement", out var e)
+            && string.Equals(e?.ToString(), "true", StringComparison.OrdinalIgnoreCase);
+
+        var text = excited ? $"Hello, {name}!!" : $"Hello, {name}.";
+
+        LogGreeted(name ?? "(null)", excited);
+
+        var response = new ExpandoObject();
+        ((IDictionary<string, object?>)response)["text"] = text;
+
+        return Task.FromResult<IDictionary<string, object?>>(new Dictionary<string, object?>
+        {
+            ["__response"] = response,
+        });
+    }
+
+    [LoggerMessage(EventId = 9400, Level = LogLevel.Information,
+        Message = "HelloWorld plugin greeted {Name} (excited={Excited})")]
+    private partial void LogGreeted(string name, bool excited);
+}
+```
+
+Things worth noticing:
+
+- `partial class` because of the `[LoggerMessage]` source generator.
+- `[ImplicitStreamSubscription]` and `[WorkerPlacement]` are inherited from `CustomTaskHandlerBase` — you don't repeat them.
+- The returned dictionary's `__response` key is what output mappings read. Plugins are free to put whatever shape they like under `__response` (string, primitive, or a nested object as shown).
+- Throw `Fleans.Domain.Errors.CustomTaskFailedActivityException(string code, string message)` to fail with a typed error code routable via boundary error events. Any other thrown exception fails with code `"500"`.
+
+## Step 3 — Declare the parameter schema
+
+Add `HelloWorldSchema.cs`:
+
+```csharp
+using Fleans.Application.CustomTasks;
+
+namespace Fleans.Plugins.HelloWorld;
+
+public static class HelloWorldSchema
+{
+    public static readonly CustomTaskParameterSchema Default = new(new[]
+    {
+        new CustomTaskParameterSpec(
+            Name: "name",
+            DisplayName: "Recipient name",
+            Type: CustomTaskParameterType.String,
+            Required: false,
+            Description: "Greeting target; defaults to \"world\".",
+            DefaultValue: "world"),
+
+        new CustomTaskParameterSpec(
+            Name: "excitement",
+            DisplayName: "Add exclamation",
+            Type: CustomTaskParameterType.Boolean,
+            Required: false,
+            Description: "If true, two exclamation points; if false, a period.",
+            DefaultValue: "false"),
+    });
+}
+```
+
+The schema is what the management UI's BPMN editor will read to render typed widgets. The five primitive types are `String`, `Integer`, `Boolean`, `Expression`, `MultilineString`. Repeat-allowed parameters use `List` or `Map` with an `ItemType` (see [Custom Tasks reference](/concepts/custom-tasks/) for the parameter table).
+
+## Step 4 — Wire DI
+
+Add `HelloWorldServiceCollectionExtensions.cs`:
+
+```csharp
+using Fleans.Worker.CustomTasks;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Fleans.Plugins.HelloWorld;
+
+public static class HelloWorldServiceCollectionExtensions
+{
+    public static IServiceCollection AddHelloWorldPlugin(this IServiceCollection services) =>
+        services.AddCustomTaskPlugin<HelloWorldHandler>(
+            taskType: "hello",
+            displayName: "Say hello",
+            parameterSchema: HelloWorldSchema.Default);
+}
+```
+
+Register the plugin from the Fleans API host. Open `src/Fleans/Fleans.Api/Fleans.Api.csproj` and add a project reference:
+
+```xml
+<ProjectReference Include="..\Fleans.Plugins.HelloWorld\Fleans.Plugins.HelloWorld.csproj" />
+```
+
+Then in `src/Fleans/Fleans.Api/Program.cs`, add the using and the registration:
+
+```csharp
+using Fleans.Plugins.HelloWorld;
+
+// … later, alongside the other AddXxx calls:
+builder.Services.AddHelloWorldPlugin();
+```
+
+## Step 5 — Restart Aspire
+
+`CustomTaskPluginRegistrar` runs once at silo startup, at Orleans's `ServiceLifecycleStage.Active`, and announces the plugin to the catalog grain. So after wiring DI you need to restart the silo before the plugin appears anywhere.
+
+```bash
+dotnet build
+dotnet run --project Fleans.Aspire
+```
+
+Once Aspire is up, hit the catalog API directly to confirm:
+
+```bash
+curl -k https://localhost:7140/custom-tasks
+```
+
+Expect a JSON entry with `taskType: "hello"`, `displayName: "Say hello"`, and `siloNames` listing your local silo. Or open `https://localhost:7124/admin/custom-tasks` in a browser for the same data rendered as a table.
+
+## Step 6 — Author the BPMN with the editor
+
+Open `https://localhost:7124/editor`. Drag a Service Task onto the canvas and click it.
+
+In the right-hand properties panel, find the "Plugin (custom task)" dropdown and pick **Say hello (hello)**. The editor seeds the defaults — your task now has `<zeebe:input source="world" target="name"/>` and `<zeebe:input source="false" target="excitement"/>` written under `<zeebe:ioMapping>`.
+
+Type `=customerName` into the `name` field. The help text under each primitive widget reminds you the field accepts either a literal value or `=variableName`. Toggle `excitement` on with the checkbox.
+
+Add an `<zeebe:output source="=__response.text" target="greeting"/>` row by editing the BPMN XML directly (the editor's UI for output mappings is shared with `expectedOutputs` on User Tasks; see [BPMN Editor](/guides/editor/)).
+
+Save the diagram. The BPMN XML now contains the snippet from the [What you'll build](#what-youll-build) section above.
+
+## Step 7 — Run a workflow that uses the plugin
+
+Deploy the BPMN:
+
+```bash
+curl -k -X POST https://localhost:7140/Workflow/deploy \
+  -H "Content-Type: application/json" \
+  -d "{\"BpmnXml\": $(jq -Rs . < /path/to/your.bpmn)}"
+```
+
+Start an instance:
+
+```bash
+curl -k -X POST https://localhost:7140/Workflow/start \
+  -H "Content-Type: application/json" \
+  -d '{"WorkflowId":"<your-process-id>","Variables":{"customerName":"alice"}}'
+```
+
+Inspect the result:
+
+```bash
+curl -k https://localhost:7140/Workflow/instances/<instance-id>/state
+```
+
+The variable projection includes `greeting: "Hello, alice!!"`. Watch the Aspire log for the `[9400] HelloWorld plugin greeted alice (excited=True)` entry your `[LoggerMessage]` writes.
+
+## Troubleshooting
+
+**The plugin doesn't appear in the catalog UI.**
+
+Check that `services.AddHelloWorldPlugin()` is wired in the API host's `Program.cs` — the registrar only runs for silos that have the descriptor in DI. If you're running a Core/Worker split topology, the registration must be on the Worker host that physically loads the handler.
+
+**`<serviceTask type="hello">` deploys but the activity hangs forever.**
+
+Two common causes:
+1. No silo with this plugin registered. `GET /custom-tasks` returns no entry for `"hello"` — fix the DI wiring per the previous bullet.
+2. The plugin handler crashed during stream subscription. Check Aspire logs for stack traces in `OnActivateAsync` or in the constructor (e.g. failed dependency injection). Implicit-stream subscriptions silently abort when the grain throws on activate.
+
+**Plugin throws `CustomTaskFailedActivityException` with the wrong code.**
+
+The exception's first argument is a string for the code (`"400"`, `"503"`, etc.). Boundary error events match by `errorCode` string equality, so authors typically choose HTTP-shaped codes. Codes outside `[100, 599]` will surface but won't be matched by HTTP-style boundary events.
+
+**`<zeebe:input>` not parsed at deploy time.**
+
+Two possible causes:
+1. The BPMN file is missing `xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"` on `<bpmn:definitions>`. Add the namespace declaration.
+2. The `target` attribute isn't a valid identifier (`^[a-zA-Z_][a-zA-Z0-9_]*$`). Rename or fix the typo.
+
+**Catalog shows the plugin on a stopped silo.**
+
+The catalog reconciles every 30 s against `IManagementGrain.GetDetailedHosts()` and drops entries for silos no longer in the cluster. Wait one tick.
+
+## Where to next
+
+- [Custom Tasks reference](/concepts/custom-tasks/) — parameter type table, mapping grammar, failure semantics, what-lives-where, catalog & liveness internals.
+- Manual test plans: `tests/manual/37-custom-task-framework/` (framework smoke), `tests/manual/38-custom-task-editor/` (editor UX).
+- Source: `src/Fleans/Fleans.Worker/CustomTasks/` for the framework; any merged plugin (`Fleans.Plugins.RestCaller` if it lands later) as a real-world example.
+- File a [feature request](https://github.com/nightBaker/fleans/issues) if you hit a limitation that isn't on the list above.


### PR DESCRIPTION
## Summary

Closes #433 (sub-issue D of #357) — fills the documentation gap between the framework reference and an author wanting to ship their own plugin.

## What landed

### New tutorial — `website/src/content/docs/guides/writing-custom-tasks.md`

Walks from empty class library to running `<serviceTask type="hello">` in seven steps:

1. Choosing the right pattern (decision matrix vs external completion).
2. Project setup (`dotnet new classlib`, `Microsoft.Orleans.Sdk`, project ref to `Fleans.Worker`).
3. Handler (`HelloWorldHandler : CustomTaskHandlerBase`).
4. Schema (`CustomTaskParameterSchema` with `String` + `Boolean` parameters).
5. DI wiring (`services.AddHelloWorldPlugin()` extension; project ref to API host).
6. **Restart Aspire** (the silo lifecycle stage `Active` runs the registrar — chicken-and-egg between authoring and editor surfacing).
7. BPMN authoring via the editor's plugin selector + run an instance.

Plus a 5-item troubleshooting section (catalog UI shows nothing, activity hangs forever, wrong error code, `<zeebe:input>` not parsed, stale catalog entry) and a "where to next" pointer to the reference page + manual test plans.

### Cross-links + cleanup

- **`concepts/custom-tasks.md`** — demoted the existing "Authoring a plugin" section (which had a duplicated `HiPluginHandler` example + `RestCallerHandler` registration snippet) to a one-paragraph teaser pointing at the new guide. Replaced the worked examples with a clean parameter-type reference table. **Concepts page is now reference; guide is how-to.** No more drift risk between two snippets.
- **`guides/service-tasks.md`** — top-of-page `:::tip:::` callout pointing in-process .NET plugin authors at the new guide. The existing external-completion content stays untouched.
- **`website/astro.config.mjs`** — sidebar entry "Writing Custom-Task Plugins" under Guides.
- **`README.md`** — Service Task row in the BPMN-elements table links to the new guide.

## Key decisions

1. **Fictional `HelloWorld` plugin, not committed to the repo.** Avoids polluting `main` with a non-functional demo project. The example is verified by building a scratch project against the current framework SHA; an HTML comment at the top of the guide's source warns future maintainers against "helpfully" committing the demo.

2. **Concepts page is reference, guide is how-to.** Removed the duplicated worked examples from the concepts page rather than keeping both — two snippets create drift risk every time the framework signature changes. The concepts page now keeps the parameter-type table, mapping grammar, what-lives-where, failure semantics, catalog & liveness — pure reference material.

3. **`HelloWorld` (not `RestCaller`) as the tutorial example.** The REST caller (#431/PR #435) isn't on `main` right now; the guide can't reference code that doesn't exist. HelloWorld is also intentionally trivial so authors focus on framework integration, not HTTP-call semantics.

4. **Step 6 "Restart Aspire" is explicit.** `CustomTaskPluginRegistrar` runs once at silo startup (`ServiceLifecycleStage.Active`) — without restarting, the editor's plugin dropdown stays empty even after wiring DI. Calling this out as a numbered step prevents a confusing first-author experience.

## Verification

Built a scratch `HelloWorld` plugin against commit `b69ef86` (current main):

```bash
$ dotnet new classlib -n Fleans.Plugins.HelloWorld -f net10.0
$ dotnet add reference src/Fleans/Fleans.Worker/Fleans.Worker.csproj
$ dotnet add package Microsoft.Orleans.Sdk --version 10.0.1
$ dotnet build
Build succeeded.  0 Error(s)
```

All code snippets in the guide compile against:
- `Fleans.Worker.CustomTasks.CustomTaskHandlerBase` (3-arg `ExecuteAsync`)
- `Fleans.Application.CustomTasks.CustomTaskParameterSchema` / `CustomTaskParameterSpec` / `CustomTaskParameterType`
- `Fleans.Worker.CustomTasks.CustomTaskServiceCollectionExtensions.AddCustomTaskPlugin<T>(taskType, displayName?, parameterSchema?)`

## How to test

- [x] `cd website && npm run build` — clean (18 pages, was 17 before this PR).
- [x] All code blocks verified against scratch project at `b69ef86`.
- [ ] Manual: read the new guide top-to-bottom; check that cross-links round-trip (`service-tasks.md` callout → `writing-custom-tasks.md` → "Where to next" → `concepts/custom-tasks.md`).

## Deviations from v1 design

None — every recommendation from the review (concept-page demotion, code-block verification mechanism, decision matrix, explicit restart-Aspire step, source comment about not committing the demo, editor-UI dependency note) is implemented as specified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
