### PR TITLE
fix(#357): AddCustomTaskPlugin throws on first registration

### DIFF
--- a/src/Fleans/Fleans.Worker/CustomTasks/CustomTaskServiceCollectionExtensions.cs
+++ b/src/Fleans/Fleans.Worker/CustomTasks/CustomTaskServiceCollectionExtensions.cs
@@ -31,10 +31,19 @@ public static class CustomTaskServiceCollectionExtensions
 
         services.AddSingleton(new CustomTaskPluginDescriptor(taskType, displayName, parameterSchema));
 
-        // Register the lifecycle participant exactly once even if multiple plugins are added.
-        services.TryAddSingleton<CustomTaskPluginRegistrar>();
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<ILifecycleParticipant<ISiloLifecycle>>(
-            sp => sp.GetRequiredService<CustomTaskPluginRegistrar>()));
+        // Register the registrar singleton + its ILifecycleParticipant facet exactly once,
+        // regardless of how many plugins are added. We can't use TryAddEnumerable for the
+        // facet — the factory-form ServiceDescriptor has no ImplementationType, so
+        // TryAddEnumerable's dedupe check throws "Implementation type … is indistinguishable
+        // from other services" the moment a second AddCustomTaskPlugin call lands. Manual
+        // check on the descriptor list is unambiguous and lets the lifecycle participant
+        // share the same instance as the singleton.
+        if (services.All(d => d.ServiceType != typeof(CustomTaskPluginRegistrar)))
+        {
+            services.AddSingleton<CustomTaskPluginRegistrar>();
+            services.AddSingleton<ILifecycleParticipant<ISiloLifecycle>>(
+                sp => sp.GetRequiredService<CustomTaskPluginRegistrar>());
+        }
 
         return services;
     }


### PR DESCRIPTION
## Symptom

Runtime crash at API startup the moment any plugin is registered:

\`\`\`
System.ArgumentException: Implementation type cannot be
  'Orleans.ILifecycleParticipant\`1[Orleans.Runtime.ISiloLifecycle]'
  because it is indistinguishable from other services registered for
  'Orleans.ILifecycleParticipant\`1[Orleans.Runtime.ISiloLifecycle]'.
   at ServiceCollectionDescriptorExtensions.TryAddEnumerable(...)
   at CustomTaskServiceCollectionExtensions.AddCustomTaskPlugin[THandler](...)
   at RestCallerServiceCollectionExtensions.AddRestCallerPlugin(...)
   at Program.<Main>$(String[] args)
\`\`\`

## Root cause

\`TryAddEnumerable\` dedupes \`ServiceDescriptor\`s by \`(ServiceType, ImplementationType)\`. The original registration used a factory-form descriptor:

\`\`\`csharp
ServiceDescriptor.Singleton<ILifecycleParticipant<ISiloLifecycle>>(
    sp => sp.GetRequiredService<CustomTaskPluginRegistrar>())
\`\`\`

A factory-form descriptor has \`ImplementationType = null\`. \`TryAddEnumerable\`'s fallback treats that as "implementation type = service type", which makes the descriptor "indistinguishable from other services" — and the method throws on the **first** call, before any duplicate even exists.

This is a long-standing \`TryAddEnumerable\` limitation: it requires an explicit \`ImplementationType\` (or a non-shared implementation instance) to compare against. Factory descriptors don't qualify.

## Fix

Skip \`TryAddEnumerable\`. Use a manual once-only check on the descriptor list to register the registrar singleton + its \`ILifecycleParticipant\` facet exactly once, regardless of how many plugins are added:

\`\`\`csharp
if (services.All(d => d.ServiceType != typeof(CustomTaskPluginRegistrar)))
{
    services.AddSingleton<CustomTaskPluginRegistrar>();
    services.AddSingleton<ILifecycleParticipant<ISiloLifecycle>>(
        sp => sp.GetRequiredService<CustomTaskPluginRegistrar>());
}
\`\`\`

The lifecycle participant resolves to the same singleton instance via the factory, so Orleans calls \`Participate\` exactly once and the registrar announces every descriptor in DI.

## Test plan

- [x] \`dotnet build\` clean.
- [x] \`dotnet test --filter "FullyQualifiedName~CustomTask|FullyQualifiedName~RestCaller"\` — 57/57 pass (4 Domain + 21 BPMN routing + 16 Application + 16 RestCaller).
- [ ] Manual: \`dotnet run --project Fleans.Aspire\` boots without the original \`ArgumentException\`.

Closes the boot crash. No design change to the framework otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)