### PR TITLE
fix(#432): /admin/custom-tasks should allow anonymous browse when auth is opt-in

### DIFF
--- a/src/Fleans/Fleans.Web/Components/Pages/CustomTaskCatalog.razor
+++ b/src/Fleans/Fleans.Web/Components/Pages/CustomTaskCatalog.razor
@@ -4,58 +4,57 @@
 
 <PageTitle>Custom Tasks — Fleans</PageTitle>
 
-<AuthorizeView Context="auth">
-    <Authorized>
-        <div class="custom-task-catalog-page" style="padding: 24px;">
-            <FluentLabel Typo="Typography.H3">Custom Tasks</FluentLabel>
-            <FluentLabel Typo="Typography.Body" Style="color: var(--neutral-foreground-hint); margin: 8px 0 24px;">
-                Custom-task plugins registered in the cluster. Page auto-refreshes every 5 seconds.
-            </FluentLabel>
+@*
+    No <AuthorizeView> wrapper here: Fleans's auth is opt-in (CLAUDE.md /
+    regression #34 — anonymous browse is allowed when no Authentication config
+    is present). When auth IS configured, the global fallback policy in
+    Fleans.Api/Program.cs forces a redirect to the IdP for anonymous users.
+*@
+<div class="custom-task-catalog-page" style="padding: 24px;">
+    <FluentLabel Typo="Typography.H3">Custom Tasks</FluentLabel>
+    <FluentLabel Typo="Typography.Body" Style="color: var(--neutral-foreground-hint); margin: 8px 0 24px;">
+        Custom-task plugins registered in the cluster. Page auto-refreshes every 5 seconds.
+    </FluentLabel>
 
-            @if (_loadError is not null)
-            {
-                <FluentMessageBar Intent="MessageIntent.Error">
-                    Failed to load catalog: @_loadError
-                </FluentMessageBar>
-            }
-            else if (_entries is null)
-            {
-                <FluentProgressRing />
-            }
-            else if (_entries.Count == 0)
-            {
-                <FluentMessageBar Intent="MessageIntent.Info">
-                    No custom-task plugins registered. Start a Worker silo with
-                    <code>services.AddCustomTaskPlugin&lt;T&gt;()</code> to populate this list.
-                </FluentMessageBar>
-            }
-            else
-            {
-                <FluentDataGrid Items="@(_entries.AsQueryable())" GridTemplateColumns="200px 220px 1fr 100px"
-                                ResizableColumns="true" Style="width: 100%;">
-                    <PropertyColumn Title="Task Type" Property="@(e => e.TaskType)" />
-                    <PropertyColumn Title="Display Name" Property="@(e => e.DisplayName ?? "—")" />
-                    <TemplateColumn Title="Silos">
-                        @if (context.SiloNames.Count == 0)
-                        {
-                            <span style="color: var(--error);">No silos</span>
-                        }
-                        else
-                        {
-                            <span>@string.Join(", ", context.SiloNames)</span>
-                        }
-                    </TemplateColumn>
-                    <TemplateColumn Title="Parameters" Align="Align.End">
-                        <span>@(context.ParameterSchema?.Parameters.Count ?? 0)</span>
-                    </TemplateColumn>
-                </FluentDataGrid>
-            }
-        </div>
-    </Authorized>
-    <NotAuthorized>
-        <FluentMessageBar Intent="MessageIntent.Error">You must be signed in to view this page.</FluentMessageBar>
-    </NotAuthorized>
-</AuthorizeView>
+    @if (_loadError is not null)
+    {
+        <FluentMessageBar Intent="MessageIntent.Error">
+            Failed to load catalog: @_loadError
+        </FluentMessageBar>
+    }
+    else if (_entries is null)
+    {
+        <FluentProgressRing />
+    }
+    else if (_entries.Count == 0)
+    {
+        <FluentMessageBar Intent="MessageIntent.Info">
+            No custom-task plugins registered. Start a Worker silo with
+            <code>services.AddCustomTaskPlugin&lt;T&gt;()</code> to populate this list.
+        </FluentMessageBar>
+    }
+    else
+    {
+        <FluentDataGrid Items="@(_entries.AsQueryable())" GridTemplateColumns="200px 220px 1fr 100px"
+                        ResizableColumns="true" Style="width: 100%;">
+            <PropertyColumn Title="Task Type" Property="@(e => e.TaskType)" />
+            <PropertyColumn Title="Display Name" Property="@(e => e.DisplayName ?? "—")" />
+            <TemplateColumn Title="Silos">
+                @if (context.SiloNames.Count == 0)
+                {
+                    <span style="color: var(--error);">No silos</span>
+                }
+                else
+                {
+                    <span>@string.Join(", ", context.SiloNames)</span>
+                }
+            </TemplateColumn>
+            <TemplateColumn Title="Parameters" Align="Align.End">
+                <span>@(context.ParameterSchema?.Parameters.Count ?? 0)</span>
+            </TemplateColumn>
+        </FluentDataGrid>
+    }
+</div>
 
 @code {
     private List<CustomTaskCatalogEntry>? _entries;


### PR DESCRIPTION
## Symptom

Visiting \`/admin/custom-tasks\` on a Fleans instance running without authentication configured (the default Aspire dev path) shows:

> You must be signed in to view this page.

…instead of the catalog table. Reported by user.

## Root cause

Sub-issue C (PR #436) wrapped the page in:

\`\`\`razor
<AuthorizeView Context="auth">
    <Authorized>...table...</Authorized>
    <NotAuthorized>
        <FluentMessageBar Intent="MessageIntent.Error">You must be signed in to view this page.</FluentMessageBar>
    </NotAuthorized>
</AuthorizeView>
\`\`\`

\`<AuthorizeView>\` evaluates against the current \`AuthenticationStateProvider\`. With auth disabled, that provider returns an anonymous user — \`Authorized\` is false, \`NotAuthorized\` fires, and the user sees the error message regardless of how Fleans is configured.

But Fleans's auth is **opt-in** (per \`CLAUDE.md\` and manual regression #34): *"anonymous browse is allowed when no Authentication config is present"*. The other admin-style pages (\`/workflows\`, \`/editor\`) don't wrap content in \`<AuthorizeView>\` either — they let the global fallback policy in \`Fleans.Api/Program.cs\` handle redirects when auth IS configured.

## Fix

Drop the \`<AuthorizeView>\` wrapper. The page renders unconditionally. When auth IS configured, the global fallback policy still forces a redirect to the IdP for anonymous users — so the strict-mode behavior from regression #34 is unchanged.

Comment block above the body documents the choice so future contributors don't "helpfully" re-add the wrapper.

## Test plan

- [x] \`dotnet build\` clean.
- [ ] Manual: \`dotnet run --project Fleans.Aspire\` (no auth configured); navigate to \`https://localhost:7124/admin/custom-tasks\`. Expect the catalog table (or empty-state message) to render — NOT the auth error.
- [ ] Manual: with \`Authentication:Authority\` configured, repeat — expect a redirect to the IdP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)