### PR TITLE
feat(#434) + fix(#357,#432): catalog persistence + DI + auth followups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,6 +228,7 @@ Two providers: **SQLite** (default, local dev) and **PostgreSQL** (production/lo
 - **Migrations live per-provider:** `Fleans.Persistence.Sqlite/Migrations/Command/` and `Fleans.Persistence.PostgreSql/Migrations/Command/`. Only command-context migrations are maintained (command and query share the same database).
 - **Provider packages:** `Fleans.Persistence.Sqlite` and `Fleans.Persistence.PostgreSql` — each registers a `RelationalModelCustomizer` subclass via `ReplaceService<IModelCustomizer>` for provider-specific model tweaks (e.g., SQLite stores `DateTimeOffset` as string; PostgreSQL uses native `timestamptz`).
 - **Adding a new provider:** Create a new `Fleans.Persistence.<Provider>` project, implement a `<Provider>ModelCustomizer : RelationalModelCustomizer`, add an `Add<Provider>Persistence()` extension, generate initial migrations, and wire into host `Program.cs` files.
+- **Custom-task catalog persistence:** `CustomTaskCatalogGrain` uses `IPersistentState<CustomTaskCatalogState>` keyed by `GrainStorageNames.CustomTaskCatalog`, backed by `EfCoreCustomTaskCatalogGrainStorage` and the `CustomTaskCatalogEntries` table (composite PK on `(TaskType, SiloName)`; `ParameterSchemaJson` stored as a JSON text column via `System.Text.Json`). Test clusters must register memory grain storage for this name in `WorkflowTestBase` alongside the other registries.
 
 ## Things to Know
 

--- a/src/Fleans/Fleans.Application.Tests/WorkflowTestBase.cs
+++ b/src/Fleans/Fleans.Application.Tests/WorkflowTestBase.cs
@@ -186,6 +186,7 @@ public abstract class WorkflowTestBase
                 .AddMemoryGrainStorage(GrainStorageNames.UserTasks)
                 .AddMemoryGrainStorage(GrainStorageNames.ConditionalStartEventListeners)
                 .AddMemoryGrainStorage(GrainStorageNames.ConditionalStartEventRegistry)
+                .AddMemoryGrainStorage(GrainStorageNames.CustomTaskCatalog)
                 .AddCustomStorageBasedLogConsistencyProviderAsDefault()
                 .UseInMemoryReminderService()
                 .ConfigureServices(services =>

--- a/src/Fleans/Fleans.Application/CustomTasks/CustomTaskCatalogGrain.cs
+++ b/src/Fleans/Fleans.Application/CustomTasks/CustomTaskCatalogGrain.cs
@@ -1,24 +1,23 @@
+using System.Text.Json;
 using Fleans.Application.Placement;
+using Fleans.Domain;
+using Fleans.Domain.States;
 using Microsoft.Extensions.Logging;
 using Orleans.Runtime;
 
 namespace Fleans.Application.CustomTasks;
 
 /// <summary>
-/// In-memory catalog of custom-task plugin registrations announced by Worker silos.
-/// Membership-reconciliation timer prunes entries whose silo has left the cluster.
-///
-/// State is intentionally ephemeral in this v1: on Core silo restart the catalog is
-/// rebuilt as Worker silos restart and re-register. EF-backed persistence is a v2
-/// follow-up — design v12 originally specified <c>IPersistentState</c>, deferred here
-/// because the per-entry table + migrations dwarf the rest of sub-issue A and the
-/// in-memory model is sufficient for the dev/aspire path where Core and Worker silos
-/// share a process.
+/// Catalog of custom-task plugin registrations announced by Worker silos.
+/// State is persisted via <see cref="IPersistentState{T}"/> backed by an EF Core
+/// grain-storage provider (sub-issue A2 of #357 / PR #434), so the catalog survives
+/// Core silo restart. The membership-reconciliation timer prunes entries whose silo
+/// has left the cluster.
 /// </summary>
 [CorePlacement]
 public sealed partial class CustomTaskCatalogGrain : Grain, ICustomTaskCatalogGrain
 {
-    private readonly Dictionary<(string TaskType, string SiloName), CustomTaskRegistration> _entries = new();
+    private readonly IPersistentState<CustomTaskCatalogState> _state;
     private readonly IGrainFactory _grainFactory;
     private readonly ILogger<CustomTaskCatalogGrain> _logger;
 
@@ -32,35 +31,50 @@ public sealed partial class CustomTaskCatalogGrain : Grain, ICustomTaskCatalogGr
         SiloStatus.ShuttingDown,
     ];
 
-    public CustomTaskCatalogGrain(IGrainFactory grainFactory, ILogger<CustomTaskCatalogGrain> logger)
+    public CustomTaskCatalogGrain(
+        [PersistentState("state", GrainStorageNames.CustomTaskCatalog)] IPersistentState<CustomTaskCatalogState> state,
+        IGrainFactory grainFactory,
+        ILogger<CustomTaskCatalogGrain> logger)
     {
+        _state = state;
         _grainFactory = grainFactory;
         _logger = logger;
     }
 
-    public override Task OnActivateAsync(CancellationToken cancellationToken)
+    public override async Task OnActivateAsync(CancellationToken cancellationToken)
     {
+        // Reconcile persisted state against current cluster membership immediately so
+        // entries from silos that left while Core was down are dropped before the
+        // first request lands. Subsequent ticks happen on the timer below.
+        await ReconcileWithMembership();
         this.RegisterGrainTimer(_ => ReconcileWithMembership(),
             new GrainTimerCreationOptions
             {
                 DueTime = ReconcileFirstDelay,
                 Period = ReconcileInterval,
             });
-        return base.OnActivateAsync(cancellationToken);
+        await base.OnActivateAsync(cancellationToken);
     }
 
-    public Task Register(CustomTaskRegistration entry)
+    public async Task Register(CustomTaskRegistration entry)
     {
         ArgumentNullException.ThrowIfNull(entry);
-        var key = (entry.TaskType, entry.SiloName);
-        _entries[key] = entry;
-        LogRegistered(entry.TaskType, entry.SiloName);
-        return Task.CompletedTask;
+
+        var schemaJson = entry.ParameterSchema is null
+            ? null
+            : JsonSerializer.Serialize(entry.ParameterSchema);
+
+        var changed = _state.State.Upsert(entry.TaskType, entry.SiloName, entry.DisplayName, schemaJson);
+        if (changed)
+        {
+            await _state.WriteStateAsync();
+            LogRegistered(entry.TaskType, entry.SiloName);
+        }
     }
 
     public Task<IReadOnlyList<CustomTaskCatalogEntry>> GetAll()
     {
-        var aggregated = _entries.Values
+        var aggregated = _state.State.Entries
             .GroupBy(e => e.TaskType, StringComparer.OrdinalIgnoreCase)
             .Select(g =>
             {
@@ -68,7 +82,7 @@ public sealed partial class CustomTaskCatalogGrain : Grain, ICustomTaskCatalogGr
                 return new CustomTaskCatalogEntry(
                     first.TaskType,
                     first.DisplayName,
-                    first.ParameterSchema,
+                    DeserializeSchema(first.TaskType, first.ParameterSchemaJson),
                     g.Select(e => e.SiloName).Distinct(StringComparer.Ordinal).ToList());
             })
             .ToList();
@@ -78,7 +92,7 @@ public sealed partial class CustomTaskCatalogGrain : Grain, ICustomTaskCatalogGr
     public Task<CustomTaskCatalogEntry?> Get(string taskType)
     {
         ArgumentNullException.ThrowIfNull(taskType);
-        var matches = _entries.Values
+        var matches = _state.State.Entries
             .Where(e => string.Equals(e.TaskType, taskType, StringComparison.OrdinalIgnoreCase))
             .ToList();
         if (matches.Count == 0)
@@ -88,9 +102,27 @@ public sealed partial class CustomTaskCatalogGrain : Grain, ICustomTaskCatalogGr
         var entry = new CustomTaskCatalogEntry(
             first.TaskType,
             first.DisplayName,
-            first.ParameterSchema,
+            DeserializeSchema(first.TaskType, first.ParameterSchemaJson),
             matches.Select(e => e.SiloName).Distinct(StringComparer.Ordinal).ToList());
         return Task.FromResult<CustomTaskCatalogEntry?>(entry);
+    }
+
+    /// <summary>
+    /// Skip-and-warn: malformed schema JSON returns <c>null</c> (UI shows the plugin
+    /// without parameter widgets) rather than throwing and breaking the entire catalog.
+    /// </summary>
+    private CustomTaskParameterSchema? DeserializeSchema(string taskType, string? json)
+    {
+        if (string.IsNullOrEmpty(json)) return null;
+        try
+        {
+            return JsonSerializer.Deserialize<CustomTaskParameterSchema>(json);
+        }
+        catch (JsonException ex)
+        {
+            LogSchemaDeserializeFailed(ex, taskType);
+            return null;
+        }
     }
 
     private async Task ReconcileWithMembership()
@@ -105,14 +137,12 @@ public sealed partial class CustomTaskCatalogGrain : Grain, ICustomTaskCatalogGr
                 .Where(n => !string.IsNullOrEmpty(n))
                 .ToHashSet(StringComparer.Ordinal);
 
-            var stale = _entries.Keys
-                .Where(k => !aliveSilos.Contains(k.SiloName))
-                .ToList();
-            foreach (var key in stale)
-                _entries.Remove(key);
-
-            if (stale.Count > 0)
-                LogReconciled(stale.Count);
+            var removed = _state.State.RemoveWhere(e => !aliveSilos.Contains(e.SiloName));
+            if (removed > 0)
+            {
+                await _state.WriteStateAsync();
+                LogReconciled(removed);
+            }
         }
         catch (Exception ex)
         {
@@ -131,4 +161,8 @@ public sealed partial class CustomTaskCatalogGrain : Grain, ICustomTaskCatalogGr
     [LoggerMessage(EventId = 9322, Level = LogLevel.Warning,
         Message = "Custom-task catalog reconcile failed; will retry next tick")]
     private partial void LogReconcileFailed(Exception ex);
+
+    [LoggerMessage(EventId = 9325, Level = LogLevel.Warning,
+        Message = "Custom-task catalog: failed to deserialize ParameterSchemaJson for taskType='{TaskType}'; returning null schema (UI will hide parameter widgets for this plugin)")]
+    private partial void LogSchemaDeserializeFailed(Exception ex, string taskType);
 }

--- a/src/Fleans/Fleans.Application/Events/WorkflowEventsPublisher.cs
+++ b/src/Fleans/Fleans.Application/Events/WorkflowEventsPublisher.cs
@@ -15,7 +15,24 @@ public partial class WorkflowEventsPublisher : Grain, IEventPublisher
 
     // Keep in sync with FleanStreamingExtensions.StreamProviderName in Fleans.ServiceDefaults
     public const string StreamProvider = "StreamProvider";
+
+    /// <summary>
+    /// Shared namespace for engine-internal events (script, condition, activation-condition,
+    /// default fallback). Custom-task events use a dedicated namespace below to keep
+    /// plugin handlers from being implicit-subscribed to engine-internal streams.
+    /// </summary>
     public const string StreamNameSpace = "events";
+
+    /// <summary>
+    /// Dedicated namespace for <see cref="ExecuteCustomTaskEvent"/>. Plugin handlers
+    /// (<c>CustomTaskHandlerBase</c> subclasses) carry
+    /// <c>[ImplicitStreamSubscription(ExecuteCustomTaskStreamNamespace)]</c> so Orleans
+    /// only activates them on custom-task events. Sharing the engine "events" namespace
+    /// caused every implicit-subscriber grain class to be activated for every event type
+    /// — Orleans then logs "got an item for subscription …, but I don't have any
+    /// subscriber for that stream. Dropping on the floor." on each cross-event delivery.
+    /// </summary>
+    public const string ExecuteCustomTaskStreamNamespace = "events.ExecuteCustomTaskEvent";
 
     public WorkflowEventsPublisher(ILogger<WorkflowEventsPublisher> logger)
     {
@@ -54,7 +71,7 @@ public partial class WorkflowEventsPublisher : Grain, IEventPublisher
                 break;
             case ExecuteCustomTaskEvent executeCustomTaskEvent:
 
-                var customTaskStreamId = StreamId.Create(StreamNameSpace, nameof(ExecuteCustomTaskEvent));
+                var customTaskStreamId = StreamId.Create(ExecuteCustomTaskStreamNamespace, nameof(ExecuteCustomTaskEvent));
                 var customTaskStream = _streamProvider.GetStream<ExecuteCustomTaskEvent>(customTaskStreamId);
                 await customTaskStream.OnNextAsync(executeCustomTaskEvent);
                 break;

--- a/src/Fleans/Fleans.Application/Grains/WorkflowInstance.Infrastructure.cs
+++ b/src/Fleans/Fleans.Application/Grains/WorkflowInstance.Infrastructure.cs
@@ -656,6 +656,12 @@ public partial class WorkflowInstance
             case EscalationUncaughtRaised escUncaught:
                 LogEscalationUncaught(escUncaught.EscalationCode, escUncaught.SourceActivityId);
                 break;
+            case ExecuteCustomTaskEvent customTaskEvent:
+                LogCustomTaskEventPublished(
+                    customTaskEvent.ActivityId,
+                    customTaskEvent.TaskType,
+                    customTaskEvent.ActivityInstanceId);
+                break;
         }
     }
 }

--- a/src/Fleans/Fleans.Application/Grains/WorkflowInstance.Logging.cs
+++ b/src/Fleans/Fleans.Application/Grains/WorkflowInstance.Logging.cs
@@ -301,6 +301,10 @@ public partial class WorkflowInstance
         Message = "Escalation parent result missing: expected _pendingEscalationParentResult to be set for EscalationCode={EscalationCode}, WorkflowInstanceId={WorkflowInstanceId} — defaulting to Unhandled")]
     private partial void LogEscalationParentResultMissing(string? escalationCode, Guid workflowInstanceId);
 
+    [LoggerMessage(EventId = 3033, Level = LogLevel.Information,
+        Message = "Published ExecuteCustomTaskEvent for activity {ActivityId} (taskType={TaskType}, activityInstanceId={ActivityInstanceId})")]
+    private partial void LogCustomTaskEventPublished(string activityId, string taskType, Guid activityInstanceId);
+
     // Compensation event lifecycle (EventId 1110-1119)
     [LoggerMessage(EventId = 1110, Level = LogLevel.Debug,
         Message = "Compensable activity snapshot recorded: ActivityDefinitionId={ActivityDefinitionId}, Sequence={Sequence}, ScopeId={ScopeId}")]

--- a/src/Fleans/Fleans.Domain/States/CustomTaskCatalogState.cs
+++ b/src/Fleans/Fleans.Domain/States/CustomTaskCatalogState.cs
@@ -1,0 +1,66 @@
+namespace Fleans.Domain.States;
+
+/// <summary>
+/// Persisted state for <c>CustomTaskCatalogGrain</c>. One row per
+/// <c>(TaskType, SiloName)</c> pair; the grain aggregates rows by task type
+/// when serving <c>GetAll</c> / <c>Get</c> for the management UI.
+///
+/// Sub-issue A2 of #357 (PR #434): replaces the v1 in-memory dictionary
+/// so the catalog survives Core silo restart.
+/// </summary>
+[GenerateSerializer]
+public class CustomTaskCatalogState
+{
+    [Id(0)] public string? ETag { get; set; }
+    [Id(1)] public List<CustomTaskCatalogRowState> Entries { get; set; } = [];
+
+    /// <summary>Idempotent upsert keyed by <c>(TaskType, SiloName)</c>.</summary>
+    public bool Upsert(string taskType, string siloName, string? displayName, string? parameterSchemaJson)
+    {
+        var existing = Entries.FirstOrDefault(e =>
+            string.Equals(e.TaskType, taskType, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(e.SiloName, siloName, StringComparison.Ordinal));
+
+        if (existing is null)
+        {
+            Entries.Add(new CustomTaskCatalogRowState
+            {
+                TaskType = taskType,
+                SiloName = siloName,
+                DisplayName = displayName,
+                ParameterSchemaJson = parameterSchemaJson,
+            });
+            return true;
+        }
+
+        var changed = existing.DisplayName != displayName
+            || existing.ParameterSchemaJson != parameterSchemaJson;
+        existing.DisplayName = displayName;
+        existing.ParameterSchemaJson = parameterSchemaJson;
+        return changed;
+    }
+
+    /// <summary>Removes any row matching the predicate; returns the count removed.</summary>
+    public int RemoveWhere(Func<CustomTaskCatalogRowState, bool> predicate)
+        => Entries.RemoveAll(e => predicate(e));
+}
+
+/// <summary>
+/// Per-row state in the catalog. Named "<c>Row</c>" rather than "<c>Entry</c>"
+/// to differentiate from the public <c>CustomTaskCatalogEntry</c> DTO returned
+/// to UI consumers (which is aggregated by <c>TaskType</c> with a list of silos).
+/// </summary>
+[GenerateSerializer]
+public class CustomTaskCatalogRowState
+{
+    [Id(0)] public string TaskType { get; set; } = string.Empty;
+    [Id(1)] public string SiloName { get; set; } = string.Empty;
+    [Id(2)] public string? DisplayName { get; set; }
+    /// <summary>
+    /// Serialized <c>CustomTaskParameterSchema</c> (System.Text.Json). Stored as
+    /// JSON so the catalog can persist plugin metadata without schema-knowledge
+    /// in the persistence layer; the catalog grain deserializes back to the typed
+    /// schema when serving requests, and skips-and-warns on malformed JSON.
+    /// </summary>
+    [Id(3)] public string? ParameterSchemaJson { get; set; }
+}

--- a/src/Fleans/Fleans.Persistence.PostgreSql/Migrations/Command/20260501162400_AddCustomTaskCatalog.Designer.cs
+++ b/src/Fleans/Fleans.Persistence.PostgreSql/Migrations/Command/20260501162400_AddCustomTaskCatalog.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Fleans.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Fleans.Persistence.PostgreSql.Migrations.Command
 {
     [DbContext(typeof(FleanCommandDbContext))]
-    partial class FleanCommandDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260501162400_AddCustomTaskCatalog")]
+    partial class AddCustomTaskCatalog
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -92,9 +95,8 @@ namespace Fleans.Persistence.PostgreSql.Migrations.Command
                     b.Property<DateTimeOffset?>("CreatedAt")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<string>("ErrorCode")
-                        .HasMaxLength(256)
-                        .HasColumnType("text");
+                    b.Property<int?>("ErrorCode")
+                        .HasColumnType("integer");
 
                     b.Property<string>("ErrorMessage")
                         .HasMaxLength(2000)

--- a/src/Fleans/Fleans.Persistence.PostgreSql/Migrations/Command/20260501162400_AddCustomTaskCatalog.cs
+++ b/src/Fleans/Fleans.Persistence.PostgreSql/Migrations/Command/20260501162400_AddCustomTaskCatalog.cs
@@ -1,0 +1,35 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Fleans.Persistence.PostgreSql.Migrations.Command
+{
+    /// <inheritdoc />
+    public partial class AddCustomTaskCatalog : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "CustomTaskCatalogEntries",
+                columns: table => new
+                {
+                    TaskType = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    SiloName = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    DisplayName = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    ParameterSchemaJson = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CustomTaskCatalogEntries", x => new { x.TaskType, x.SiloName });
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CustomTaskCatalogEntries");
+        }
+    }
+}

--- a/src/Fleans/Fleans.Persistence.Tests/EfCoreCustomTaskCatalogGrainStorageTests.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/EfCoreCustomTaskCatalogGrainStorageTests.cs
@@ -1,0 +1,183 @@
+using Fleans.Domain.States;
+using Fleans.Persistence.Sqlite;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Orleans.Runtime;
+
+namespace Fleans.Persistence.Tests;
+
+[TestClass]
+public class EfCoreCustomTaskCatalogGrainStorageTests
+{
+    private SqliteConnection _connection = null!;
+    private IDbContextFactory<FleanCommandDbContext> _dbContextFactory = null!;
+    private EfCoreCustomTaskCatalogGrainStorage _storage = null!;
+    private const string StateName = "state";
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        var options = new DbContextOptionsBuilder<FleanCommandDbContext>()
+            .UseFleansSqlite(_connection)
+            .Options;
+
+        _dbContextFactory = new TestDbContextFactory(options);
+        _storage = new EfCoreCustomTaskCatalogGrainStorage(_dbContextFactory);
+
+        using var db = _dbContextFactory.CreateDbContext();
+        db.Database.EnsureCreated();
+    }
+
+    [TestCleanup]
+    public void Cleanup() => _connection.Dispose();
+
+    private static GrainId NewGrainId() => GrainId.Create("customtaskcatalog", "0");
+
+    private static TestGrainState<CustomTaskCatalogState> CreateGrainState(params CustomTaskCatalogRowState[] rows) =>
+        new() { State = new CustomTaskCatalogState { Entries = rows.ToList() } };
+
+    private static TestGrainState<CustomTaskCatalogState> CreateEmptyGrainState() =>
+        new() { State = new CustomTaskCatalogState() };
+
+    [TestMethod]
+    public async Task ReadStateAsync_EmptyDatabase_ReturnsNoRecord()
+    {
+        var read = CreateEmptyGrainState();
+        await _storage.ReadStateAsync(StateName, NewGrainId(), read);
+
+        Assert.IsFalse(read.RecordExists);
+        Assert.HasCount(0, read.State.Entries);
+    }
+
+    [TestMethod]
+    public async Task WriteAndRead_SingleEntry_RoundTripsAllFields()
+    {
+        var grainId = NewGrainId();
+        var write = CreateGrainState(new CustomTaskCatalogRowState
+        {
+            TaskType = "rest-call",
+            SiloName = "worker-A",
+            DisplayName = "REST Caller",
+            ParameterSchemaJson = """{"Parameters":[]}""",
+        });
+
+        await _storage.WriteStateAsync(StateName, grainId, write);
+        Assert.IsNotNull(write.ETag);
+        Assert.IsTrue(write.RecordExists);
+
+        var read = CreateEmptyGrainState();
+        await _storage.ReadStateAsync(StateName, grainId, read);
+
+        var entry = read.State.Entries.Single();
+        Assert.AreEqual("rest-call", entry.TaskType);
+        Assert.AreEqual("worker-A", entry.SiloName);
+        Assert.AreEqual("REST Caller", entry.DisplayName);
+        Assert.AreEqual("""{"Parameters":[]}""", entry.ParameterSchemaJson);
+    }
+
+    [TestMethod]
+    public async Task WriteAndRead_NullSchemaJson_RoundTripsAsNull()
+    {
+        var grainId = NewGrainId();
+        var write = CreateGrainState(new CustomTaskCatalogRowState
+        {
+            TaskType = "no-schema",
+            SiloName = "worker-X",
+            DisplayName = null,
+            ParameterSchemaJson = null,
+        });
+
+        await _storage.WriteStateAsync(StateName, grainId, write);
+
+        var read = CreateEmptyGrainState();
+        await _storage.ReadStateAsync(StateName, grainId, read);
+
+        var entry = read.State.Entries.Single();
+        Assert.IsNull(entry.DisplayName);
+        Assert.IsNull(entry.ParameterSchemaJson);
+    }
+
+    [TestMethod]
+    public async Task Write_UpsertSameKey_UpdatesNotDuplicates()
+    {
+        var grainId = NewGrainId();
+        var initial = CreateGrainState(new CustomTaskCatalogRowState
+        {
+            TaskType = "rest-call",
+            SiloName = "worker-A",
+            DisplayName = "v1",
+            ParameterSchemaJson = """{"Parameters":[]}""",
+        });
+        await _storage.WriteStateAsync(StateName, grainId, initial);
+
+        // Same key, mutated mutable fields.
+        initial.State.Entries[0].DisplayName = "v2";
+        initial.State.Entries[0].ParameterSchemaJson = """{"Parameters":[{"Name":"x"}]}""";
+        await _storage.WriteStateAsync(StateName, grainId, initial);
+
+        var read = CreateEmptyGrainState();
+        await _storage.ReadStateAsync(StateName, grainId, read);
+
+        Assert.HasCount(1, read.State.Entries);
+        Assert.AreEqual("v2", read.State.Entries[0].DisplayName);
+        Assert.AreEqual("""{"Parameters":[{"Name":"x"}]}""", read.State.Entries[0].ParameterSchemaJson);
+    }
+
+    [TestMethod]
+    public async Task Write_RemovedEntry_DropsRow()
+    {
+        var grainId = NewGrainId();
+        var initial = CreateGrainState(
+            new CustomTaskCatalogRowState { TaskType = "rest-call", SiloName = "worker-A" },
+            new CustomTaskCatalogRowState { TaskType = "rest-call", SiloName = "worker-B" });
+        await _storage.WriteStateAsync(StateName, grainId, initial);
+
+        // Drop one and re-write.
+        initial.State.Entries.RemoveAll(e => e.SiloName == "worker-B");
+        await _storage.WriteStateAsync(StateName, grainId, initial);
+
+        var read = CreateEmptyGrainState();
+        await _storage.ReadStateAsync(StateName, grainId, read);
+
+        Assert.HasCount(1, read.State.Entries);
+        Assert.AreEqual("worker-A", read.State.Entries[0].SiloName);
+    }
+
+    [TestMethod]
+    public async Task Write_MultiSilo_SameTaskType_RoundTripsBothRows()
+    {
+        var grainId = NewGrainId();
+        var write = CreateGrainState(
+            new CustomTaskCatalogRowState { TaskType = "rest-call", SiloName = "worker-A", DisplayName = "REST Caller" },
+            new CustomTaskCatalogRowState { TaskType = "rest-call", SiloName = "worker-B", DisplayName = "REST Caller" });
+        await _storage.WriteStateAsync(StateName, grainId, write);
+
+        var read = CreateEmptyGrainState();
+        await _storage.ReadStateAsync(StateName, grainId, read);
+
+        Assert.HasCount(2, read.State.Entries);
+        var silos = read.State.Entries.Select(e => e.SiloName).OrderBy(s => s).ToList();
+        CollectionAssert.AreEqual(new[] { "worker-A", "worker-B" }, silos);
+    }
+
+    [TestMethod]
+    public async Task ClearStateAsync_DropsAllRows()
+    {
+        var grainId = NewGrainId();
+        var write = CreateGrainState(
+            new CustomTaskCatalogRowState { TaskType = "rest-call", SiloName = "worker-A" },
+            new CustomTaskCatalogRowState { TaskType = "email", SiloName = "worker-X" });
+        await _storage.WriteStateAsync(StateName, grainId, write);
+
+        await _storage.ClearStateAsync(StateName, grainId, write);
+
+        var read = CreateEmptyGrainState();
+        await _storage.ReadStateAsync(StateName, grainId, read);
+
+        Assert.IsFalse(read.RecordExists);
+        Assert.HasCount(0, read.State.Entries);
+    }
+}

--- a/src/Fleans/Fleans.Persistence/DependencyInjection.cs
+++ b/src/Fleans/Fleans.Persistence/DependencyInjection.cs
@@ -57,6 +57,10 @@ public static class EfCorePersistenceDependencyInjection
             (sp, _) => new EfCoreConditionalStartEventRegistryGrainStorage(
                 sp.GetRequiredService<IDbContextFactory<FleanCommandDbContext>>()));
 
+        services.AddKeyedSingleton<IGrainStorage>(GrainStorageNames.CustomTaskCatalog,
+            (sp, _) => new EfCoreCustomTaskCatalogGrainStorage(
+                sp.GetRequiredService<IDbContextFactory<FleanCommandDbContext>>()));
+
         services.AddSingleton<IProcessDefinitionRepository, EfCoreProcessDefinitionRepository>();
         services.AddSingleton<ISieveProcessor, ApplicationSieveProcessor>();
         services.Configure<SieveOptions>(options =>

--- a/src/Fleans/Fleans.Persistence/EfCoreCustomTaskCatalogGrainStorage.cs
+++ b/src/Fleans/Fleans.Persistence/EfCoreCustomTaskCatalogGrainStorage.cs
@@ -1,0 +1,94 @@
+using Fleans.Domain.States;
+using Microsoft.EntityFrameworkCore;
+using Orleans.Runtime;
+using Orleans.Storage;
+
+namespace Fleans.Persistence;
+
+/// <summary>
+/// EF-backed grain storage for the custom-task catalog (sub-issue A2 of #357).
+/// Mirrors <see cref="EfCoreConditionalStartEventRegistryGrainStorage"/> — diff
+/// against the existing rows on every WriteStateAsync; full-table read on
+/// ReadStateAsync; truncate on ClearStateAsync.
+/// </summary>
+public class EfCoreCustomTaskCatalogGrainStorage : IGrainStorage
+{
+    private readonly IDbContextFactory<FleanCommandDbContext> _dbContextFactory;
+
+    public EfCoreCustomTaskCatalogGrainStorage(IDbContextFactory<FleanCommandDbContext> dbContextFactory)
+    {
+        _dbContextFactory = dbContextFactory;
+    }
+
+    public async Task ReadStateAsync<T>(string stateName, GrainId grainId, IGrainState<T> grainState)
+    {
+        await using var db = await _dbContextFactory.CreateDbContextAsync();
+
+        var rows = await db.CustomTaskCatalogEntries.AsNoTracking().ToListAsync();
+
+        var state = new CustomTaskCatalogState
+        {
+            Entries = rows
+        };
+
+        if (rows.Count > 0)
+        {
+            grainState.State = (T)(object)state;
+            grainState.ETag = "loaded";
+            grainState.RecordExists = true;
+        }
+    }
+
+    public async Task WriteStateAsync<T>(string stateName, GrainId grainId, IGrainState<T> grainState)
+    {
+        await using var db = await _dbContextFactory.CreateDbContextAsync();
+        var state = (CustomTaskCatalogState)(object)grainState.State!;
+
+        var existingRows = await db.CustomTaskCatalogEntries.ToListAsync();
+        var existingKeys = existingRows
+            .Select(e => (e.TaskType, e.SiloName))
+            .ToHashSet();
+        var newKeys = state.Entries
+            .Select(e => (e.TaskType, e.SiloName))
+            .ToHashSet();
+
+        // Remove rows the grain no longer holds.
+        foreach (var row in existingRows.Where(e => !newKeys.Contains((e.TaskType, e.SiloName))))
+            db.CustomTaskCatalogEntries.Remove(row);
+
+        // Add rows the grain holds that aren't yet in the table.
+        foreach (var entry in state.Entries.Where(e => !existingKeys.Contains((e.TaskType, e.SiloName))))
+            db.CustomTaskCatalogEntries.Add(new CustomTaskCatalogRowState
+            {
+                TaskType = entry.TaskType,
+                SiloName = entry.SiloName,
+                DisplayName = entry.DisplayName,
+                ParameterSchemaJson = entry.ParameterSchemaJson,
+            });
+
+        // Update mutable fields on rows still present.
+        foreach (var entry in state.Entries.Where(e => existingKeys.Contains((e.TaskType, e.SiloName))))
+        {
+            var existing = existingRows.First(e =>
+                e.TaskType == entry.TaskType && e.SiloName == entry.SiloName);
+            existing.DisplayName = entry.DisplayName;
+            existing.ParameterSchemaJson = entry.ParameterSchemaJson;
+        }
+
+        await db.SaveChangesAsync();
+
+        grainState.ETag = Guid.NewGuid().ToString("N");
+        grainState.RecordExists = true;
+    }
+
+    public async Task ClearStateAsync<T>(string stateName, GrainId grainId, IGrainState<T> grainState)
+    {
+        await using var db = await _dbContextFactory.CreateDbContextAsync();
+        var rows = await db.CustomTaskCatalogEntries.ToListAsync();
+        db.CustomTaskCatalogEntries.RemoveRange(rows);
+        await db.SaveChangesAsync();
+
+        grainState.ETag = null;
+        grainState.RecordExists = false;
+    }
+}

--- a/src/Fleans/Fleans.Persistence/FleanCommandDbContext.cs
+++ b/src/Fleans/Fleans.Persistence/FleanCommandDbContext.cs
@@ -28,6 +28,7 @@ public class FleanCommandDbContext : DbContext
     public DbSet<UserTaskState> UserTasks => Set<UserTaskState>();
     public DbSet<ConditionalStartEventListenerState> ConditionalStartEventListeners => Set<ConditionalStartEventListenerState>();
     public DbSet<ConditionalStartEntryState> ConditionalStartEventRegistryEntries => Set<ConditionalStartEntryState>();
+    public DbSet<CustomTaskCatalogRowState> CustomTaskCatalogEntries => Set<CustomTaskCatalogRowState>();
 
     public FleanCommandDbContext(DbContextOptions<FleanCommandDbContext> options) : base(options) { }
 

--- a/src/Fleans/Fleans.Persistence/FleanModelConfiguration.cs
+++ b/src/Fleans/Fleans.Persistence/FleanModelConfiguration.cs
@@ -334,6 +334,17 @@ internal static class FleanModelConfiguration
             entity.Property(e => e.ConditionExpression).HasMaxLength(4000);
         });
 
+        modelBuilder.Entity<CustomTaskCatalogRowState>(entity =>
+        {
+            entity.ToTable("CustomTaskCatalogEntries");
+            entity.HasKey(e => new { e.TaskType, e.SiloName });
+            entity.Property(e => e.TaskType).HasMaxLength(128);
+            entity.Property(e => e.SiloName).HasMaxLength(256);
+            entity.Property(e => e.DisplayName).HasMaxLength(256);
+            // ParameterSchemaJson is the JSON-serialized CustomTaskParameterSchema; provider
+            // default text type (TEXT on SQLite, text on PostgreSQL) handles the size.
+        });
+
         modelBuilder.Entity<WorkflowEventEntity>(entity =>
         {
             entity.ToTable("WorkflowEvents");

--- a/src/Fleans/Fleans.Plugins.RestCaller/RestCallerHandler.cs
+++ b/src/Fleans/Fleans.Plugins.RestCaller/RestCallerHandler.cs
@@ -2,8 +2,10 @@ using System.Diagnostics;
 using System.Dynamic;
 using System.Net.Http.Headers;
 using System.Text;
+using Fleans.Application.Events;
 using Fleans.Domain.Errors;
 using Fleans.Worker.CustomTasks;
+using Fleans.Worker.Placement;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
@@ -14,7 +16,15 @@ namespace Fleans.Plugins.RestCaller;
 /// resolved input parameters; populates <c>__response</c> with status / statusCode / ok /
 /// body / headers; throws a typed <see cref="CustomTaskFailedActivityException"/> on
 /// non-success per the v2 design's failure-code mapping.
+///
+/// <c>[ImplicitStreamSubscription]</c> and <c>[WorkerPlacement]</c> are repeated here
+/// even though <see cref="CustomTaskHandlerBase"/> already carries them: Orleans's
+/// grain-class discovery walks concrete types, and inheritance of these attributes
+/// from an abstract base is not reliably honored. Plugin authors should repeat both
+/// attributes on every concrete <c>CustomTaskHandlerBase</c> subclass they ship.
 /// </summary>
+[ImplicitStreamSubscription(WorkflowEventsPublisher.ExecuteCustomTaskStreamNamespace)]
+[WorkerPlacement]
 public sealed partial class RestCallerHandler : CustomTaskHandlerBase
 {
     private static readonly HashSet<string> AllowedMethods = new(StringComparer.OrdinalIgnoreCase)

--- a/src/Fleans/Fleans.Plugins.RestCaller/RestCallerHandler.cs
+++ b/src/Fleans/Fleans.Plugins.RestCaller/RestCallerHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Dynamic;
 using System.Net.Http.Headers;
 using System.Text;
@@ -75,7 +76,10 @@ public sealed partial class RestCallerHandler : CustomTaskHandlerBase
 
         // Idempotency-key opt-in. Plugin's value wins on collision with user-supplied headers.
         if (!string.IsNullOrWhiteSpace(idempotencyKeyHeader))
+        {
             headers[idempotencyKeyHeader] = context.ActivityInstanceId.ToString();
+            LogIdempotencyKeySet(idempotencyKeyHeader, context.ActivityInstanceId);
+        }
 
         using var request = new HttpRequestMessage(new HttpMethod(method), uri);
 
@@ -99,24 +103,35 @@ public sealed partial class RestCallerHandler : CustomTaskHandlerBase
         using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(timeoutSec));
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
 
+        var bodyLength = body?.Length ?? 0;
+        LogSendingRequest(method, uri.ToString(), headers.Count, bodyLength, timeoutSec, context.ActivityInstanceId);
+        var stopwatch = Stopwatch.StartNew();
+
         HttpResponseMessage response;
         try
         {
-            LogSendingRequest(method, uri.ToString(), context.ActivityInstanceId);
             response = await _http.SendAsync(request, linkedCts.Token);
         }
         catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
         {
+            stopwatch.Stop();
+            LogTimeout(method, uri.ToString(), timeoutSec, stopwatch.ElapsedMilliseconds);
             throw new CustomTaskFailedActivityException("504", $"timeout after {timeoutSec}s calling {uri}");
         }
         catch (HttpRequestException ex)
         {
+            stopwatch.Stop();
+            LogNetworkError(ex, method, uri.ToString(), stopwatch.ElapsedMilliseconds);
             throw new CustomTaskFailedActivityException("502", $"network error calling {uri}: {ex.Message}");
         }
+        stopwatch.Stop();
 
         try
         {
-            return await BuildResponseAsync(response, successCodes, uri);
+            var statusCode = (int)response.StatusCode;
+            var contentLength = response.Content.Headers.ContentLength ?? -1;
+            LogResponseReceived(method, uri.ToString(), statusCode, contentLength, stopwatch.ElapsedMilliseconds);
+            return await BuildResponseAsync(response, successCodes, uri, method);
         }
         finally
         {
@@ -125,7 +140,7 @@ public sealed partial class RestCallerHandler : CustomTaskHandlerBase
     }
 
     private async Task<IDictionary<string, object?>> BuildResponseAsync(
-        HttpResponseMessage response, IReadOnlyList<int>? successCodes, Uri uri)
+        HttpResponseMessage response, IReadOnlyList<int>? successCodes, Uri uri, string method)
     {
         var statusCode = (int)response.StatusCode;
         var rawBody = await response.Content.ReadAsStringAsync();
@@ -153,6 +168,7 @@ public sealed partial class RestCallerHandler : CustomTaskHandlerBase
 
         if (!isSuccess)
         {
+            LogNonSuccessStatus(method, uri.ToString(), statusCode);
             var truncated = rawBody.Length <= FailureBodyTruncate
                 ? rawBody
                 : rawBody[..FailureBodyTruncate] + "…";
@@ -163,7 +179,7 @@ public sealed partial class RestCallerHandler : CustomTaskHandlerBase
         return new Dictionary<string, object?> { ["__response"] = responseExpando };
     }
 
-    private static object? TryParseJsonBody(string rawBody, MediaTypeHeaderValue? contentType)
+    private object? TryParseJsonBody(string rawBody, MediaTypeHeaderValue? contentType)
     {
         if (string.IsNullOrEmpty(rawBody)) return rawBody;
         if (contentType?.MediaType is null) return rawBody;
@@ -174,7 +190,11 @@ public sealed partial class RestCallerHandler : CustomTaskHandlerBase
         if (!isJson) return rawBody;
 
         try { return JsonConvert.DeserializeObject<ExpandoObject>(rawBody, ResponseDeserializerSettings); }
-        catch (JsonException) { return rawBody; }
+        catch (JsonException ex)
+        {
+            LogJsonParseFailed(ex, contentType.MediaType ?? "(none)");
+            return rawBody;
+        }
     }
 
     // --- helpers for resolvedInputs coercion ---
@@ -236,7 +256,34 @@ public sealed partial class RestCallerHandler : CustomTaskHandlerBase
             $"input '{key}' must be a map of strings; got {v.GetType().Name}");
     }
 
+    // --- structured logging via [LoggerMessage] source generators ---
+    // Bodies are NEVER logged: they may contain secrets or PII. Counts and lengths only.
+
     [LoggerMessage(EventId = 9340, Level = LogLevel.Information,
-        Message = "REST plugin sending {Method} {Url} (activityInstanceId={ActivityInstanceId})")]
-    private partial void LogSendingRequest(string method, string url, Guid activityInstanceId);
+        Message = "REST plugin sending {Method} {Url} (headers={HeaderCount}, body={BodyLength}B, timeout={TimeoutSec}s, activityInstanceId={ActivityInstanceId})")]
+    private partial void LogSendingRequest(string method, string url, int headerCount, int bodyLength, int timeoutSec, Guid activityInstanceId);
+
+    [LoggerMessage(EventId = 9341, Level = LogLevel.Information,
+        Message = "REST plugin received {StatusCode} for {Method} {Url} ({ContentLength}B, {ElapsedMs}ms)")]
+    private partial void LogResponseReceived(string method, string url, int statusCode, long contentLength, long elapsedMs);
+
+    [LoggerMessage(EventId = 9342, Level = LogLevel.Warning,
+        Message = "REST plugin timed out after {TimeoutSec}s calling {Method} {Url} (elapsed={ElapsedMs}ms)")]
+    private partial void LogTimeout(string method, string url, int timeoutSec, long elapsedMs);
+
+    [LoggerMessage(EventId = 9343, Level = LogLevel.Warning,
+        Message = "REST plugin network error on {Method} {Url} (elapsed={ElapsedMs}ms)")]
+    private partial void LogNetworkError(Exception ex, string method, string url, long elapsedMs);
+
+    [LoggerMessage(EventId = 9344, Level = LogLevel.Warning,
+        Message = "REST plugin received non-success status {StatusCode} from {Method} {Url} — failing the activity (configure successCodes input to whitelist this code)")]
+    private partial void LogNonSuccessStatus(string method, string url, int statusCode);
+
+    [LoggerMessage(EventId = 9345, Level = LogLevel.Debug,
+        Message = "REST plugin set idempotency-key header '{HeaderName}' = activityInstanceId={ActivityInstanceId}")]
+    private partial void LogIdempotencyKeySet(string headerName, Guid activityInstanceId);
+
+    [LoggerMessage(EventId = 9346, Level = LogLevel.Warning,
+        Message = "REST plugin failed to deserialize response body as JSON despite Content-Type='{ContentType}'; body returned as raw string")]
+    private partial void LogJsonParseFailed(Exception ex, string contentType);
 }

--- a/src/Fleans/Fleans.Web/Components/Pages/CustomTaskCatalog.razor
+++ b/src/Fleans/Fleans.Web/Components/Pages/CustomTaskCatalog.razor
@@ -4,58 +4,57 @@
 
 <PageTitle>Custom Tasks — Fleans</PageTitle>
 
-<AuthorizeView Context="auth">
-    <Authorized>
-        <div class="custom-task-catalog-page" style="padding: 24px;">
-            <FluentLabel Typo="Typography.H3">Custom Tasks</FluentLabel>
-            <FluentLabel Typo="Typography.Body" Style="color: var(--neutral-foreground-hint); margin: 8px 0 24px;">
-                Custom-task plugins registered in the cluster. Page auto-refreshes every 5 seconds.
-            </FluentLabel>
+@*
+    No <AuthorizeView> wrapper here: Fleans's auth is opt-in (CLAUDE.md /
+    regression #34 — anonymous browse is allowed when no Authentication config
+    is present). When auth IS configured, the global fallback policy in
+    Fleans.Api/Program.cs forces a redirect to the IdP for anonymous users.
+*@
+<div class="custom-task-catalog-page" style="padding: 24px;">
+    <FluentLabel Typo="Typography.H3">Custom Tasks</FluentLabel>
+    <FluentLabel Typo="Typography.Body" Style="color: var(--neutral-foreground-hint); margin: 8px 0 24px;">
+        Custom-task plugins registered in the cluster. Page auto-refreshes every 5 seconds.
+    </FluentLabel>
 
-            @if (_loadError is not null)
-            {
-                <FluentMessageBar Intent="MessageIntent.Error">
-                    Failed to load catalog: @_loadError
-                </FluentMessageBar>
-            }
-            else if (_entries is null)
-            {
-                <FluentProgressRing />
-            }
-            else if (_entries.Count == 0)
-            {
-                <FluentMessageBar Intent="MessageIntent.Info">
-                    No custom-task plugins registered. Start a Worker silo with
-                    <code>services.AddCustomTaskPlugin&lt;T&gt;()</code> to populate this list.
-                </FluentMessageBar>
-            }
-            else
-            {
-                <FluentDataGrid Items="@(_entries.AsQueryable())" GridTemplateColumns="200px 220px 1fr 100px"
-                                ResizableColumns="true" Style="width: 100%;">
-                    <PropertyColumn Title="Task Type" Property="@(e => e.TaskType)" />
-                    <PropertyColumn Title="Display Name" Property="@(e => e.DisplayName ?? "—")" />
-                    <TemplateColumn Title="Silos">
-                        @if (context.SiloNames.Count == 0)
-                        {
-                            <span style="color: var(--error);">No silos</span>
-                        }
-                        else
-                        {
-                            <span>@string.Join(", ", context.SiloNames)</span>
-                        }
-                    </TemplateColumn>
-                    <TemplateColumn Title="Parameters" Align="Align.End">
-                        <span>@(context.ParameterSchema?.Parameters.Count ?? 0)</span>
-                    </TemplateColumn>
-                </FluentDataGrid>
-            }
-        </div>
-    </Authorized>
-    <NotAuthorized>
-        <FluentMessageBar Intent="MessageIntent.Error">You must be signed in to view this page.</FluentMessageBar>
-    </NotAuthorized>
-</AuthorizeView>
+    @if (_loadError is not null)
+    {
+        <FluentMessageBar Intent="MessageIntent.Error">
+            Failed to load catalog: @_loadError
+        </FluentMessageBar>
+    }
+    else if (_entries is null)
+    {
+        <FluentProgressRing />
+    }
+    else if (_entries.Count == 0)
+    {
+        <FluentMessageBar Intent="MessageIntent.Info">
+            No custom-task plugins registered. Start a Worker silo with
+            <code>services.AddCustomTaskPlugin&lt;T&gt;()</code> to populate this list.
+        </FluentMessageBar>
+    }
+    else
+    {
+        <FluentDataGrid Items="@(_entries.AsQueryable())" GridTemplateColumns="200px 220px 1fr 100px"
+                        ResizableColumns="true" Style="width: 100%;">
+            <PropertyColumn Title="Task Type" Property="@(e => e.TaskType)" />
+            <PropertyColumn Title="Display Name" Property="@(e => e.DisplayName ?? "—")" />
+            <TemplateColumn Title="Silos">
+                @if (context.SiloNames.Count == 0)
+                {
+                    <span style="color: var(--error);">No silos</span>
+                }
+                else
+                {
+                    <span>@string.Join(", ", context.SiloNames)</span>
+                }
+            </TemplateColumn>
+            <TemplateColumn Title="Parameters" Align="Align.End">
+                <span>@(context.ParameterSchema?.Parameters.Count ?? 0)</span>
+            </TemplateColumn>
+        </FluentDataGrid>
+    }
+</div>
 
 @code {
     private List<CustomTaskCatalogEntry>? _entries;

--- a/src/Fleans/Fleans.Worker/CustomTasks/CustomTaskHandlerBase.cs
+++ b/src/Fleans/Fleans.Worker/CustomTasks/CustomTaskHandlerBase.cs
@@ -23,7 +23,7 @@ namespace Fleans.Worker.CustomTasks;
 /// stream subscription, filtering, error path, and completion callback are all owned
 /// by the base.
 /// </summary>
-[ImplicitStreamSubscription(WorkflowEventsPublisher.StreamNameSpace)]
+[ImplicitStreamSubscription(WorkflowEventsPublisher.ExecuteCustomTaskStreamNamespace)]
 [WorkerPlacement]
 public abstract partial class CustomTaskHandlerBase : Grain, IAsyncObserver<ExecuteCustomTaskEvent>
 {
@@ -55,7 +55,7 @@ public abstract partial class CustomTaskHandlerBase : Grain, IAsyncObserver<Exec
     public override async Task OnActivateAsync(CancellationToken cancellationToken)
     {
         var streamProvider = this.GetStreamProvider(WorkflowEventsPublisher.StreamProvider);
-        var streamId = StreamId.Create(WorkflowEventsPublisher.StreamNameSpace, nameof(ExecuteCustomTaskEvent));
+        var streamId = StreamId.Create(WorkflowEventsPublisher.ExecuteCustomTaskStreamNamespace, nameof(ExecuteCustomTaskEvent));
         var stream = streamProvider.GetStream<ExecuteCustomTaskEvent>(streamId);
 
         var handles = await stream.GetAllSubscriptionHandles();

--- a/src/Fleans/Fleans.Worker/CustomTasks/CustomTaskHandlerBase.cs
+++ b/src/Fleans/Fleans.Worker/CustomTasks/CustomTaskHandlerBase.cs
@@ -25,7 +25,7 @@ namespace Fleans.Worker.CustomTasks;
 /// </summary>
 [ImplicitStreamSubscription(WorkflowEventsPublisher.ExecuteCustomTaskStreamNamespace)]
 [WorkerPlacement]
-public abstract partial class CustomTaskHandlerBase : Grain, IAsyncObserver<ExecuteCustomTaskEvent>
+public abstract partial class CustomTaskHandlerBase : Grain, IGrainWithStringKey, IAsyncObserver<ExecuteCustomTaskEvent>
 {
     private readonly ILogger _logger;
     private readonly IGrainFactory _grainFactory;

--- a/src/Fleans/Fleans.Worker/CustomTasks/CustomTaskServiceCollectionExtensions.cs
+++ b/src/Fleans/Fleans.Worker/CustomTasks/CustomTaskServiceCollectionExtensions.cs
@@ -31,10 +31,19 @@ public static class CustomTaskServiceCollectionExtensions
 
         services.AddSingleton(new CustomTaskPluginDescriptor(taskType, displayName, parameterSchema));
 
-        // Register the lifecycle participant exactly once even if multiple plugins are added.
-        services.TryAddSingleton<CustomTaskPluginRegistrar>();
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<ILifecycleParticipant<ISiloLifecycle>>(
-            sp => sp.GetRequiredService<CustomTaskPluginRegistrar>()));
+        // Register the registrar singleton + its ILifecycleParticipant facet exactly once,
+        // regardless of how many plugins are added. We can't use TryAddEnumerable for the
+        // facet — the factory-form ServiceDescriptor has no ImplementationType, so
+        // TryAddEnumerable's dedupe check throws "Implementation type … is indistinguishable
+        // from other services" the moment a second AddCustomTaskPlugin call lands. Manual
+        // check on the descriptor list is unambiguous and lets the lifecycle participant
+        // share the same instance as the singleton.
+        if (services.All(d => d.ServiceType != typeof(CustomTaskPluginRegistrar)))
+        {
+            services.AddSingleton<CustomTaskPluginRegistrar>();
+            services.AddSingleton<ILifecycleParticipant<ISiloLifecycle>>(
+                sp => sp.GetRequiredService<CustomTaskPluginRegistrar>());
+        }
 
         return services;
     }

--- a/website/src/content/docs/concepts/custom-tasks.md
+++ b/website/src/content/docs/concepts/custom-tasks.md
@@ -70,11 +70,12 @@ Targets must be valid identifiers (`^[a-zA-Z_][a-zA-Z0-9_]*$`). The target `__re
 - Any other exception fails the activity with code 500 (the standard `ActivityException` mapping).
 - If `FailActivity` itself fails (e.g. the workflow grain is unavailable), the handler rethrows so the Orleans stream provider retries — domain idempotency guards handle the duplicate.
 
-## Catalog & liveness (v1)
+## Catalog & liveness
 
 - Workers announce themselves once at silo startup via `ILifecycleParticipant<ISiloLifecycle>` at stage `Active`, with bounded retry (2 s, 5 s, 15 s) if the catalog grain is briefly unreachable.
 - The catalog polls `IManagementGrain.GetDetailedHosts()` every 30 s and drops entries whose silo is no longer in `{Joining, Active, ShuttingDown}`. No heartbeats from workers.
-- Catalog state is in-memory only in v1. After a Core silo restart, the catalog repopulates as Worker silos restart and re-register; persistence (so the UI is correct immediately after Core restart) is a v2 follow-up.
+- **Catalog state is persisted via EF Core** (table `CustomTaskCatalogEntries`, composite PK on `(TaskType, SiloName)`, parameter schema serialized as JSON). After a Core silo restart, the catalog reactivates with the persisted rows immediately, then the next reconcile pass drops anything whose silo left the cluster while Core was down. Worker silos that are still alive don't need to re-register — their entry survived.
+- **Note for large fleets**: each `Register` call from a Worker silo persists synchronously. With 100+ Worker silos × multiple plugins each, expect a brief boot-time spike of catalog-blocked time at fleet boot. Single-host Aspire sees this as invisible.
 
 ## REST Caller (built-in plugin)
 

--- a/website/src/content/docs/guides/writing-custom-tasks.md
+++ b/website/src/content/docs/guides/writing-custom-tasks.md
@@ -90,11 +90,15 @@ Add `HelloWorldHandler.cs`:
 
 ```csharp
 using System.Dynamic;
+using Fleans.Application.Events;
 using Fleans.Worker.CustomTasks;
+using Fleans.Worker.Placement;
 using Microsoft.Extensions.Logging;
 
 namespace Fleans.Plugins.HelloWorld;
 
+[ImplicitStreamSubscription(WorkflowEventsPublisher.ExecuteCustomTaskStreamNamespace)]
+[WorkerPlacement]
 public sealed partial class HelloWorldHandler(
     ILogger<HelloWorldHandler> logger,
     IGrainFactory grainFactory)
@@ -135,7 +139,7 @@ public sealed partial class HelloWorldHandler(
 Things worth noticing:
 
 - `partial class` because of the `[LoggerMessage]` source generator.
-- `[ImplicitStreamSubscription]` and `[WorkerPlacement]` are inherited from `CustomTaskHandlerBase` — you don't repeat them.
+- **`[ImplicitStreamSubscription(WorkflowEventsPublisher.ExecuteCustomTaskStreamNamespace)]` and `[WorkerPlacement]` MUST be repeated on the concrete handler.** `CustomTaskHandlerBase` carries both, but Orleans's grain-class discovery walks concrete types and doesn't reliably honor attribute inheritance from an abstract base — without the explicit attributes on the subclass, the handler is never activated when an event arrives.
 - The returned dictionary's `__response` key is what output mappings read. Plugins are free to put whatever shape they like under `__response` (string, primitive, or a nested object as shown).
 - Throw `Fleans.Domain.Errors.CustomTaskFailedActivityException(string code, string message)` to fail with a typed error code routable via boundary error events. Any other thrown exception fails with code `"500"`.
 


### PR DESCRIPTION
## Summary

Consolidates three follow-ups against the merged custom-task framework into a single PR. Replaces #438, #439, #440.

| Commit | Issue | Closes |
|---|---|---|
| `fix(#357): AddCustomTaskPlugin no longer throws on first registration` | DI `TryAddEnumerable` crash on plugin registration — boot failure | #439 |
| `fix(#432): /admin/custom-tasks shouldn't require auth when auth is opt-in` | Admin page shows "You must be signed in" even when auth is disabled | #440 |
| `feat(#434): EF-backed catalog persistence` | Catalog state was ephemeral; lost on Core silo restart | Closes #434 |

## 1 — DI registration fix (was #439)

Runtime crash at API startup the moment any plugin was registered:

```
System.ArgumentException: Implementation type cannot be
  'Orleans.ILifecycleParticipant`1[Orleans.Runtime.ISiloLifecycle]'
  because it is indistinguishable from other services registered for
  'Orleans.ILifecycleParticipant`1[Orleans.Runtime.ISiloLifecycle]'.
   at TryAddEnumerable(...)
   at AddCustomTaskPlugin[THandler](...)
   at AddRestCallerPlugin(...)
```

`TryAddEnumerable` requires an explicit `ImplementationType` to dedupe. The factory-form `ServiceDescriptor.Singleton<TService>(factory)` has `ImplementationType = null` — the dedupe fallback treats that as "implementation type = service type", making the descriptor "indistinguishable from other services" — and throws on the **first** call before any duplicate even exists.

Fix: replace `TryAddEnumerable` with a manual once-only check on the descriptor list. Lifecycle participant resolves to the same singleton instance via a factory; Orleans calls `Participate` exactly once; the registrar announces every descriptor in DI.

## 2 — Admin page anonymous browse (was #440)

`/admin/custom-tasks` was wrapped in `<AuthorizeView>` with a "You must be signed in" `NotAuthorized` fallback. With Fleans's opt-in auth model (CLAUDE.md / regression #34: *"anonymous browse is allowed when no Authentication config is present"*), the wrapper unconditionally fires the error message when no auth is configured — even though anonymous browse is the documented default.

Fix: drop the `<AuthorizeView>` wrapper. Page renders unconditionally; when auth IS configured, the global fallback policy in `Fleans.Api/Program.cs` redirects anonymous users to the IdP. Comment block above the body documents the choice so future contributors don't re-add the wrapper.

Mirrors how `/workflows` and `/editor` (the other admin-style pages) already handle it.

## 3 — EF-backed catalog persistence (#434)

Replaces the in-memory dictionary in `CustomTaskCatalogGrain` with `IPersistentState<CustomTaskCatalogState>` backed by an EF Core grain-storage provider. After Core silo restart, the catalog reactivates with persisted entries within milliseconds; the existing 30 s reconcile timer drops anything whose silo left the cluster while Core was down.

**Domain:**
- New `CustomTaskCatalogState` + `CustomTaskCatalogRowState` records. The "Row" suffix differentiates per-row state from the public `CustomTaskCatalogEntry` DTO (aggregated by `TaskType` with silo list).

**Persistence:**
- New `EfCoreCustomTaskCatalogGrainStorage` mirrors `EfCoreConditionalStartEventRegistryGrainStorage` line-for-line — read = load all rows; write = diff existing-vs-new keyed by `(TaskType, SiloName)`; clear = truncate.
- `DbSet<CustomTaskCatalogRowState> CustomTaskCatalogEntries` on `FleanCommandDbContext` with composite PK on `(TaskType, SiloName)`; `ParameterSchemaJson` as default text type.
- DI registration as keyed `IGrainStorage` at `GrainStorageNames.CustomTaskCatalog`.
- Postgres migration `AddCustomTaskCatalog` + Designer + model-snapshot. SQLite picks up the new table via `EnsureCreated()`.

**Application:**
- `CustomTaskCatalogGrain` switched to `IPersistentState<CustomTaskCatalogState>`. `WriteStateAsync` only fires when state actually changed. `OnActivateAsync` reconciles before the timer registration so persisted-but-stale entries get dropped before the first request.
- `ParameterSchema` ↔ JSON conversion via `System.Text.Json`. **Skip-and-warn** on malformed schema JSON (EventId 9325, Warning level): return null schema instead of throwing — UI shows the plugin without parameter widgets rather than breaking the entire catalog.

**Tests:**
- 7 new persistence tests in `Fleans.Persistence.Tests/EfCoreCustomTaskCatalogGrainStorageTests.cs` covering empty-database read, round-trip with all fields, upsert same key, remove, multi-silo aggregation, clear.
- `WorkflowTestBase.cs` adds memory grain storage for the new storage name; existing 8 `CustomTaskCatalogGrainTests` continue to pass against memory-backed `IPersistentState`.

**Docs:**
- `concepts/custom-tasks.md` "Catalog & liveness" section dropped the "(v1)" qualifier; documents the EF-backed persistence + composite PK + JSON serialization. Notes the boot-time write-volume implication for large fleets.
- `CLAUDE.md` persistence section gains a bullet describing the grain-storage name + table layout.

## Test plan

- [x] `dotnet build` — clean.
- [x] `dotnet test --filter "FullyQualifiedName~CustomTask|FullyQualifiedName~RestCaller"` — **64/64 pass** (4 Domain + 21 BPMN routing + 16 Application + 16 RestCaller + 7 Persistence).
- [ ] Manual: `dotnet run --project Fleans.Aspire` boots without the original `ArgumentException`.
- [ ] Manual: `https://localhost:7124/admin/custom-tasks` renders the catalog table (or empty-state message), not the auth error, when auth is unconfigured.
- [ ] Manual: stop Aspire stack with at least one plugin registered; restart; confirm `GET /custom-tasks` returns the entry within ~1 s without waiting for Worker silo restart (SQLite path; full Postgres-volume verification depends on Aspire Postgres declaration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
