### PR TITLE
test(#278): parametrise EF persistence tests across SQLite + PostgreSQL (Phase 4)

### DIFF
--- a/.github/workflows/pg-tests.yml
+++ b/.github/workflows/pg-tests.yml
@@ -1,0 +1,45 @@
+# Runs Fleans.Persistence.Tests against a real PostgreSQL container via
+# Testcontainers. Default `dotnet test` (in dotnet.yml) skips the PG rows
+# because FLEANS_PG_TESTS is not set there; this job exercises them.
+#
+# `[TestCategory("Postgres")]` is on the parametrised test classes, so the
+# filter below picks up every parametrised class (both SQLite and PG rows
+# of those classes — running them twice is cheap and proves the pattern).
+name: PostgreSQL tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+defaults:
+  run:
+    working-directory: src/Fleans
+
+jobs:
+  pg-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore
+
+      - name: Test (PostgreSQL category)
+        env:
+          FLEANS_PG_TESTS: "1"
+        run: >-
+          dotnet test Fleans.Persistence.Tests/Fleans.Persistence.Tests.csproj
+          --no-build
+          --verbosity normal
+          --filter "TestCategory=Postgres"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,6 +229,12 @@ Two providers: **SQLite** (default, local dev) and **PostgreSQL** (production/lo
 - **Provider packages:** `Fleans.Persistence.Sqlite` and `Fleans.Persistence.PostgreSql` — each registers a `RelationalModelCustomizer` subclass via `ReplaceService<IModelCustomizer>` for provider-specific model tweaks (e.g., SQLite stores `DateTimeOffset` as string; PostgreSQL uses native `timestamptz`).
 - **Adding a new provider:** Create a new `Fleans.Persistence.<Provider>` project, implement a `<Provider>ModelCustomizer : RelationalModelCustomizer`, add an `Add<Provider>Persistence()` extension, generate initial migrations, and wire into host `Program.cs` files.
 - **Custom-task catalog persistence:** `CustomTaskCatalogGrain` uses `IPersistentState<CustomTaskCatalogState>` keyed by `GrainStorageNames.CustomTaskCatalog`, backed by `EfCoreCustomTaskCatalogGrainStorage` and the `CustomTaskCatalogEntries` table (composite PK on `(TaskType, SiloName)`; `ParameterSchemaJson` stored as a JSON text column via `System.Text.Json`). Test clusters must register memory grain storage for this name in `WorkflowTestBase` alongside the other registries.
+- **Test parity (Sqlite ↔ PostgreSQL):** every EF/grain-storage class in `Fleans.Persistence.Tests` is parametrised via `[DataTestMethod] [DataRow(PersistenceProvider.Sqlite)] [DataRow(PersistenceProvider.Postgres)]` against the `Infrastructure/PersistenceTestBase` fixture. Default `dotnet test` runs only the SQLite rows (no Docker). To exercise the PG rows locally:
+  ```bash
+  cd src/Fleans
+  FLEANS_PG_TESTS=1 dotnet test --filter "TestCategory=Postgres"
+  ```
+  Requires Docker (Testcontainers boots `postgres:16-alpine`). Without `FLEANS_PG_TESTS=1` the PG rows surface as `Inconclusive` (non-failing) — never `Failed`. CI runs the dedicated `PostgreSQL tests` job (`.github/workflows/pg-tests.yml`) on every PR. **Bump `PostgresImage` in `Infrastructure/PostgresContainerFixture.cs` whenever the production deploy target moves** — today it tracks Aspire's `Aspire.Hosting.PostgreSQL` default (PG 16).
 
 ## Things to Know
 

--- a/src/Fleans/Fleans.Persistence.PostgreSql/Migrations/Command/20260501215503_AlignErrorCodeColumnType.Designer.cs
+++ b/src/Fleans/Fleans.Persistence.PostgreSql/Migrations/Command/20260501215503_AlignErrorCodeColumnType.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Fleans.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Fleans.Persistence.PostgreSql.Migrations.Command
 {
     [DbContext(typeof(FleanCommandDbContext))]
-    partial class FleanCommandDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260501215503_AlignErrorCodeColumnType")]
+    partial class AlignErrorCodeColumnType
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Fleans/Fleans.Persistence.PostgreSql/Migrations/Command/20260501215503_AlignErrorCodeColumnType.cs
+++ b/src/Fleans/Fleans.Persistence.PostgreSql/Migrations/Command/20260501215503_AlignErrorCodeColumnType.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Fleans.Persistence.PostgreSql.Migrations.Command
+{
+    /// <inheritdoc />
+    public partial class AlignErrorCodeColumnType : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ErrorCode",
+                table: "WorkflowActivityInstanceEntries",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldMaxLength: 256,
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ErrorCode",
+                table: "WorkflowActivityInstanceEntries",
+                type: "text",
+                maxLength: 256,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(256)",
+                oldMaxLength: 256,
+                oldNullable: true);
+        }
+    }
+}

--- a/src/Fleans/Fleans.Persistence.Tests/EfCoreCustomTaskCatalogGrainStorageTests.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/EfCoreCustomTaskCatalogGrainStorageTests.cs
@@ -1,38 +1,14 @@
 using Fleans.Domain.States;
-using Fleans.Persistence.Sqlite;
-using Microsoft.Data.Sqlite;
-using Microsoft.EntityFrameworkCore;
+using Fleans.Persistence.Tests.Infrastructure;
 using Orleans.Runtime;
 
 namespace Fleans.Persistence.Tests;
 
 [TestClass]
-public class EfCoreCustomTaskCatalogGrainStorageTests
+[TestCategory("Postgres")]
+public class EfCoreCustomTaskCatalogGrainStorageTests : PersistenceTestBase
 {
-    private SqliteConnection _connection = null!;
-    private IDbContextFactory<FleanCommandDbContext> _dbContextFactory = null!;
-    private EfCoreCustomTaskCatalogGrainStorage _storage = null!;
     private const string StateName = "state";
-
-    [TestInitialize]
-    public void Setup()
-    {
-        _connection = new SqliteConnection("DataSource=:memory:");
-        _connection.Open();
-
-        var options = new DbContextOptionsBuilder<FleanCommandDbContext>()
-            .UseFleansSqlite(_connection)
-            .Options;
-
-        _dbContextFactory = new TestDbContextFactory(options);
-        _storage = new EfCoreCustomTaskCatalogGrainStorage(_dbContextFactory);
-
-        using var db = _dbContextFactory.CreateDbContext();
-        db.Database.EnsureCreated();
-    }
-
-    [TestCleanup]
-    public void Cleanup() => _connection.Dispose();
 
     private static GrainId NewGrainId() => GrainId.Create("customtaskcatalog", "0");
 
@@ -42,19 +18,29 @@ public class EfCoreCustomTaskCatalogGrainStorageTests
     private static TestGrainState<CustomTaskCatalogState> CreateEmptyGrainState() =>
         new() { State = new CustomTaskCatalogState() };
 
-    [TestMethod]
-    public async Task ReadStateAsync_EmptyDatabase_ReturnsNoRecord()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task ReadStateAsync_EmptyDatabase_ReturnsNoRecord(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreCustomTaskCatalogGrainStorage(fixture.CommandFactory);
+
         var read = CreateEmptyGrainState();
-        await _storage.ReadStateAsync(StateName, NewGrainId(), read);
+        await storage.ReadStateAsync(StateName, NewGrainId(), read);
 
         Assert.IsFalse(read.RecordExists);
         Assert.HasCount(0, read.State.Entries);
     }
 
-    [TestMethod]
-    public async Task WriteAndRead_SingleEntry_RoundTripsAllFields()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task WriteAndRead_SingleEntry_RoundTripsAllFields(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreCustomTaskCatalogGrainStorage(fixture.CommandFactory);
+
         var grainId = NewGrainId();
         var write = CreateGrainState(new CustomTaskCatalogRowState
         {
@@ -64,12 +50,12 @@ public class EfCoreCustomTaskCatalogGrainStorageTests
             ParameterSchemaJson = """{"Parameters":[]}""",
         });
 
-        await _storage.WriteStateAsync(StateName, grainId, write);
+        await storage.WriteStateAsync(StateName, grainId, write);
         Assert.IsNotNull(write.ETag);
         Assert.IsTrue(write.RecordExists);
 
         var read = CreateEmptyGrainState();
-        await _storage.ReadStateAsync(StateName, grainId, read);
+        await storage.ReadStateAsync(StateName, grainId, read);
 
         var entry = read.State.Entries.Single();
         Assert.AreEqual("rest-call", entry.TaskType);
@@ -78,9 +64,14 @@ public class EfCoreCustomTaskCatalogGrainStorageTests
         Assert.AreEqual("""{"Parameters":[]}""", entry.ParameterSchemaJson);
     }
 
-    [TestMethod]
-    public async Task WriteAndRead_NullSchemaJson_RoundTripsAsNull()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task WriteAndRead_NullSchemaJson_RoundTripsAsNull(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreCustomTaskCatalogGrainStorage(fixture.CommandFactory);
+
         var grainId = NewGrainId();
         var write = CreateGrainState(new CustomTaskCatalogRowState
         {
@@ -90,19 +81,24 @@ public class EfCoreCustomTaskCatalogGrainStorageTests
             ParameterSchemaJson = null,
         });
 
-        await _storage.WriteStateAsync(StateName, grainId, write);
+        await storage.WriteStateAsync(StateName, grainId, write);
 
         var read = CreateEmptyGrainState();
-        await _storage.ReadStateAsync(StateName, grainId, read);
+        await storage.ReadStateAsync(StateName, grainId, read);
 
         var entry = read.State.Entries.Single();
         Assert.IsNull(entry.DisplayName);
         Assert.IsNull(entry.ParameterSchemaJson);
     }
 
-    [TestMethod]
-    public async Task Write_UpsertSameKey_UpdatesNotDuplicates()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task Write_UpsertSameKey_UpdatesNotDuplicates(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreCustomTaskCatalogGrainStorage(fixture.CommandFactory);
+
         var grainId = NewGrainId();
         var initial = CreateGrainState(new CustomTaskCatalogRowState
         {
@@ -111,71 +107,84 @@ public class EfCoreCustomTaskCatalogGrainStorageTests
             DisplayName = "v1",
             ParameterSchemaJson = """{"Parameters":[]}""",
         });
-        await _storage.WriteStateAsync(StateName, grainId, initial);
+        await storage.WriteStateAsync(StateName, grainId, initial);
 
-        // Same key, mutated mutable fields.
         initial.State.Entries[0].DisplayName = "v2";
         initial.State.Entries[0].ParameterSchemaJson = """{"Parameters":[{"Name":"x"}]}""";
-        await _storage.WriteStateAsync(StateName, grainId, initial);
+        await storage.WriteStateAsync(StateName, grainId, initial);
 
         var read = CreateEmptyGrainState();
-        await _storage.ReadStateAsync(StateName, grainId, read);
+        await storage.ReadStateAsync(StateName, grainId, read);
 
         Assert.HasCount(1, read.State.Entries);
         Assert.AreEqual("v2", read.State.Entries[0].DisplayName);
         Assert.AreEqual("""{"Parameters":[{"Name":"x"}]}""", read.State.Entries[0].ParameterSchemaJson);
     }
 
-    [TestMethod]
-    public async Task Write_RemovedEntry_DropsRow()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task Write_RemovedEntry_DropsRow(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreCustomTaskCatalogGrainStorage(fixture.CommandFactory);
+
         var grainId = NewGrainId();
         var initial = CreateGrainState(
             new CustomTaskCatalogRowState { TaskType = "rest-call", SiloName = "worker-A" },
             new CustomTaskCatalogRowState { TaskType = "rest-call", SiloName = "worker-B" });
-        await _storage.WriteStateAsync(StateName, grainId, initial);
+        await storage.WriteStateAsync(StateName, grainId, initial);
 
-        // Drop one and re-write.
         initial.State.Entries.RemoveAll(e => e.SiloName == "worker-B");
-        await _storage.WriteStateAsync(StateName, grainId, initial);
+        await storage.WriteStateAsync(StateName, grainId, initial);
 
         var read = CreateEmptyGrainState();
-        await _storage.ReadStateAsync(StateName, grainId, read);
+        await storage.ReadStateAsync(StateName, grainId, read);
 
         Assert.HasCount(1, read.State.Entries);
         Assert.AreEqual("worker-A", read.State.Entries[0].SiloName);
     }
 
-    [TestMethod]
-    public async Task Write_MultiSilo_SameTaskType_RoundTripsBothRows()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task Write_MultiSilo_SameTaskType_RoundTripsBothRows(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreCustomTaskCatalogGrainStorage(fixture.CommandFactory);
+
         var grainId = NewGrainId();
         var write = CreateGrainState(
             new CustomTaskCatalogRowState { TaskType = "rest-call", SiloName = "worker-A", DisplayName = "REST Caller" },
             new CustomTaskCatalogRowState { TaskType = "rest-call", SiloName = "worker-B", DisplayName = "REST Caller" });
-        await _storage.WriteStateAsync(StateName, grainId, write);
+        await storage.WriteStateAsync(StateName, grainId, write);
 
         var read = CreateEmptyGrainState();
-        await _storage.ReadStateAsync(StateName, grainId, read);
+        await storage.ReadStateAsync(StateName, grainId, read);
 
         Assert.HasCount(2, read.State.Entries);
         var silos = read.State.Entries.Select(e => e.SiloName).OrderBy(s => s).ToList();
         CollectionAssert.AreEqual(new[] { "worker-A", "worker-B" }, silos);
     }
 
-    [TestMethod]
-    public async Task ClearStateAsync_DropsAllRows()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task ClearStateAsync_DropsAllRows(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreCustomTaskCatalogGrainStorage(fixture.CommandFactory);
+
         var grainId = NewGrainId();
         var write = CreateGrainState(
             new CustomTaskCatalogRowState { TaskType = "rest-call", SiloName = "worker-A" },
             new CustomTaskCatalogRowState { TaskType = "email", SiloName = "worker-X" });
-        await _storage.WriteStateAsync(StateName, grainId, write);
+        await storage.WriteStateAsync(StateName, grainId, write);
 
-        await _storage.ClearStateAsync(StateName, grainId, write);
+        await storage.ClearStateAsync(StateName, grainId, write);
 
         var read = CreateEmptyGrainState();
-        await _storage.ReadStateAsync(StateName, grainId, read);
+        await storage.ReadStateAsync(StateName, grainId, read);
 
         Assert.IsFalse(read.RecordExists);
         Assert.HasCount(0, read.State.Entries);

--- a/src/Fleans/Fleans.Persistence.Tests/EfCoreEventStoreTests.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/EfCoreEventStoreTests.cs
@@ -2,48 +2,29 @@ using System.Dynamic;
 using Fleans.Domain.Events;
 using Fleans.Domain.States;
 using Fleans.Persistence.Events;
-using Microsoft.Data.Sqlite;
-using Fleans.Persistence.Sqlite;
+using Fleans.Persistence.Tests.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 
 namespace Fleans.Persistence.Tests;
 
 [TestClass]
-public class EfCoreEventStoreTests
+[TestCategory("Postgres")]
+public class EfCoreEventStoreTests : PersistenceTestBase
 {
-    private SqliteConnection _connection = null!;
-    private TestDbContextFactory _dbContextFactory = null!;
-    private EfCoreEventStore _store = null!;
-
-    [TestInitialize]
-    public void Setup()
+    private static EfCoreEventStore CreateStore(IPersistenceTestFixture fixture)
     {
-        _connection = new SqliteConnection("DataSource=:memory:");
-        _connection.Open();
-
-        var options = new DbContextOptionsBuilder<FleanCommandDbContext>()
-            .UseFleansSqlite(_connection)
-            .Options;
-
-        _dbContextFactory = new TestDbContextFactory(options);
-        var projection = new EfCoreWorkflowStateProjection(_dbContextFactory);
-        _store = new EfCoreEventStore(_dbContextFactory, projection);
-
-        using var db = _dbContextFactory.CreateDbContext();
-        db.Database.EnsureCreated();
+        var projection = new EfCoreWorkflowStateProjection(fixture.CommandFactory);
+        return new EfCoreEventStore(fixture.CommandFactory, projection);
     }
 
-    [TestCleanup]
-    public void Cleanup()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task AppendAndReadEvents_RoundTrip(PersistenceProvider provider)
     {
-        _connection.Dispose();
-    }
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var store = CreateStore(fixture);
 
-    // --- Event Append + Read ---
-
-    [TestMethod]
-    public async Task AppendAndReadEvents_RoundTrip()
-    {
         var grainId = "grain/test-1";
         var events = new List<IDomainEvent>
         {
@@ -52,19 +33,24 @@ public class EfCoreEventStoreTests
             new ActivitySpawned(Guid.NewGuid(), "start", "StartEvent", Guid.NewGuid(), null, null, null)
         };
 
-        var result = await _store.AppendEventsAsync(grainId, events, startVersion: 1);
+        var result = await store.AppendEventsAsync(grainId, events, startVersion: 1);
         Assert.IsTrue(result);
 
-        var loaded = await _store.ReadEventsAsync(grainId, afterVersion: 0);
+        var loaded = await store.ReadEventsAsync(grainId, afterVersion: 0);
         Assert.AreEqual(3, loaded.Count);
         Assert.IsInstanceOfType<WorkflowStarted>(loaded[0]);
         Assert.IsInstanceOfType<ExecutionStarted>(loaded[1]);
         Assert.IsInstanceOfType<ActivitySpawned>(loaded[2]);
     }
 
-    [TestMethod]
-    public async Task ReadEvents_AfterVersion_ReturnsOnlyLater()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task ReadEvents_AfterVersion_ReturnsOnlyLater(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var store = CreateStore(fixture);
+
         var grainId = "grain/test-2";
         var events = new List<IDomainEvent>
         {
@@ -73,45 +59,64 @@ public class EfCoreEventStoreTests
             new WorkflowCompleted()
         };
 
-        await _store.AppendEventsAsync(grainId, events, startVersion: 1);
+        await store.AppendEventsAsync(grainId, events, startVersion: 1);
 
-        var loaded = await _store.ReadEventsAsync(grainId, afterVersion: 2);
+        var loaded = await store.ReadEventsAsync(grainId, afterVersion: 2);
         Assert.AreEqual(1, loaded.Count);
         Assert.IsInstanceOfType<WorkflowCompleted>(loaded[0]);
     }
 
-    [TestMethod]
-    public async Task ReadEvents_EmptyGrain_ReturnsEmptyList()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task ReadEvents_EmptyGrain_ReturnsEmptyList(PersistenceProvider provider)
     {
-        var loaded = await _store.ReadEventsAsync("grain/nonexistent", afterVersion: 0);
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var store = CreateStore(fixture);
+
+        var loaded = await store.ReadEventsAsync("grain/nonexistent", afterVersion: 0);
         Assert.AreEqual(0, loaded.Count);
     }
 
-    [TestMethod]
-    public async Task AppendEvents_EmptyList_ReturnsTrue()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task AppendEvents_EmptyList_ReturnsTrue(PersistenceProvider provider)
     {
-        var result = await _store.AppendEventsAsync("grain/x", [], startVersion: 1);
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var store = CreateStore(fixture);
+
+        var result = await store.AppendEventsAsync("grain/x", [], startVersion: 1);
         Assert.IsTrue(result);
     }
 
-    [TestMethod]
-    public async Task AppendEvents_VersionConflict_ReturnsFalse()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task AppendEvents_VersionConflict_ReturnsFalse(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var store = CreateStore(fixture);
+
         var grainId = "grain/conflict";
         var events1 = new List<IDomainEvent> { new WorkflowStarted(Guid.NewGuid(), "p1", Guid.NewGuid()) };
         var events2 = new List<IDomainEvent> { new ExecutionStarted() };
 
-        var result1 = await _store.AppendEventsAsync(grainId, events1, startVersion: 1);
+        var result1 = await store.AppendEventsAsync(grainId, events1, startVersion: 1);
         Assert.IsTrue(result1);
 
-        // Same version — should conflict
-        var result2 = await _store.AppendEventsAsync(grainId, events2, startVersion: 1);
+        var result2 = await store.AppendEventsAsync(grainId, events2, startVersion: 1);
         Assert.IsFalse(result2);
     }
 
-    [TestMethod]
-    public async Task AppendEvents_PreservesOrdering()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task AppendEvents_PreservesOrdering(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var store = CreateStore(fixture);
+
         var grainId = "grain/ordering";
         var ids = Enumerable.Range(0, 10)
             .Select(_ => Guid.NewGuid())
@@ -120,9 +125,9 @@ public class EfCoreEventStoreTests
         var events = ids.Select(id =>
             (IDomainEvent)new ActivityExecutionStarted(id)).ToList();
 
-        await _store.AppendEventsAsync(grainId, events, startVersion: 1);
+        await store.AppendEventsAsync(grainId, events, startVersion: 1);
 
-        var loaded = await _store.ReadEventsAsync(grainId, afterVersion: 0);
+        var loaded = await store.ReadEventsAsync(grainId, afterVersion: 0);
         Assert.AreEqual(10, loaded.Count);
 
         for (int i = 0; i < 10; i++)
@@ -132,11 +137,14 @@ public class EfCoreEventStoreTests
         }
     }
 
-    // --- ExpandoObject Round-trip ---
-
-    [TestMethod]
-    public async Task AppendAndRead_ActivityCompleted_PreservesExpandoObject()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task AppendAndRead_ActivityCompleted_PreservesExpandoObject(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var store = CreateStore(fixture);
+
         var grainId = "grain/expando";
         var variables = new ExpandoObject();
         var dict = (IDictionary<string, object?>)variables;
@@ -149,8 +157,8 @@ public class EfCoreEventStoreTests
             new ActivityCompleted(Guid.NewGuid(), Guid.NewGuid(), variables)
         };
 
-        await _store.AppendEventsAsync(grainId, events, startVersion: 1);
-        var loaded = await _store.ReadEventsAsync(grainId, afterVersion: 0);
+        await store.AppendEventsAsync(grainId, events, startVersion: 1);
+        var loaded = await store.ReadEventsAsync(grainId, afterVersion: 0);
 
         var completed = (ActivityCompleted)loaded[0];
         var loadedDict = (IDictionary<string, object?>)completed.Variables;
@@ -160,77 +168,90 @@ public class EfCoreEventStoreTests
         Assert.AreEqual(true, loadedDict["active"]);
     }
 
-    // --- Snapshot ---
-
-    [TestMethod]
-    public async Task ReadSnapshot_EmptyGrain_ReturnsNullAndZero()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task ReadSnapshot_EmptyGrain_ReturnsNullAndZero(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var store = CreateStore(fixture);
+
         var grainId = Guid.NewGuid().ToString();
-        var (state, version) = await _store.ReadSnapshotAsync(grainId);
+        var (state, version) = await store.ReadSnapshotAsync(grainId);
         Assert.IsNull(state);
         Assert.AreEqual(0, version);
     }
 
-    [TestMethod]
-    public async Task WriteAndReadSnapshot_RoundTrip()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task WriteAndReadSnapshot_RoundTrip(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var store = CreateStore(fixture);
+
         var id = Guid.NewGuid();
         var grainId = id.ToString();
         var state = CreateTestState(id);
 
-        await _store.WriteSnapshotAsync(grainId, version: 5, state);
+        await store.WriteSnapshotAsync(grainId, version: 5, state);
 
-        var (loaded, version) = await _store.ReadSnapshotAsync(grainId);
+        var (loaded, version) = await store.ReadSnapshotAsync(grainId);
         Assert.IsNotNull(loaded);
         Assert.AreEqual(5, version);
         Assert.AreEqual(state.Id, loaded.Id);
         Assert.AreEqual(state.IsStarted, loaded.IsStarted);
         Assert.AreEqual(state.ProcessDefinitionId, loaded.ProcessDefinitionId);
 
-        // Verify state is stored in normalized WorkflowInstances table, not as JSON blob
-        await using var db = await _dbContextFactory.CreateDbContextAsync();
+        await using var db = await fixture.CommandFactory.CreateDbContextAsync();
         var row = await db.WorkflowInstances.AsNoTracking().FirstOrDefaultAsync(s => s.Id == id);
         Assert.IsNotNull(row, "Snapshot state should exist in WorkflowInstances table");
 
-        // Verify no JSON payload in snapshot metadata table
         var snapshotMeta = await db.WorkflowSnapshots.AsNoTracking().FirstOrDefaultAsync(s => s.GrainId == grainId);
         Assert.IsNotNull(snapshotMeta);
         Assert.AreEqual(5, snapshotMeta.Version);
     }
 
-    [TestMethod]
-    public async Task WriteSnapshot_UpdateExisting()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task WriteSnapshot_UpdateExisting(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var store = CreateStore(fixture);
+
         var id = Guid.NewGuid();
         var grainId = id.ToString();
         var state1 = CreateTestState(id);
 
-        await _store.WriteSnapshotAsync(grainId, version: 5, state1);
+        await store.WriteSnapshotAsync(grainId, version: 5, state1);
 
-        // Update the same grain's snapshot with new version
         var state2 = CreateTestState(id);
 
-        await _store.WriteSnapshotAsync(grainId, version: 10, state2);
+        await store.WriteSnapshotAsync(grainId, version: 10, state2);
 
-        var (loaded, version) = await _store.ReadSnapshotAsync(grainId);
+        var (loaded, version) = await store.ReadSnapshotAsync(grainId);
         Assert.IsNotNull(loaded);
         Assert.AreEqual(10, version);
         Assert.AreEqual(id, loaded.Id);
     }
 
-    // --- Isolation ---
-
-    [TestMethod]
-    public async Task DifferentGrainIds_AreIsolated()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task DifferentGrainIds_AreIsolated(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var store = CreateStore(fixture);
+
         var events1 = new List<IDomainEvent> { new WorkflowStarted(Guid.NewGuid(), "p1", Guid.NewGuid()) };
         var events2 = new List<IDomainEvent> { new ExecutionStarted() };
 
-        await _store.AppendEventsAsync("grain/a", events1, startVersion: 1);
-        await _store.AppendEventsAsync("grain/b", events2, startVersion: 1);
+        await store.AppendEventsAsync("grain/a", events1, startVersion: 1);
+        await store.AppendEventsAsync("grain/b", events2, startVersion: 1);
 
-        var loadedA = await _store.ReadEventsAsync("grain/a", afterVersion: 0);
-        var loadedB = await _store.ReadEventsAsync("grain/b", afterVersion: 0);
+        var loadedA = await store.ReadEventsAsync("grain/a", afterVersion: 0);
+        var loadedB = await store.ReadEventsAsync("grain/b", afterVersion: 0);
 
         Assert.AreEqual(1, loadedA.Count);
         Assert.AreEqual(1, loadedB.Count);
@@ -238,20 +259,23 @@ public class EfCoreEventStoreTests
         Assert.IsInstanceOfType<ExecutionStarted>(loadedB[0]);
     }
 
-    // --- Multi-batch Append ---
-
-    [TestMethod]
-    public async Task AppendEvents_MultipleBatches_VersionsContinue()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task AppendEvents_MultipleBatches_VersionsContinue(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var store = CreateStore(fixture);
+
         var grainId = "grain/multi-batch";
 
         var batch1 = new List<IDomainEvent> { new WorkflowStarted(Guid.NewGuid(), "p1", Guid.NewGuid()) };
         var batch2 = new List<IDomainEvent> { new ExecutionStarted(), new WorkflowCompleted() };
 
-        await _store.AppendEventsAsync(grainId, batch1, startVersion: 1);
-        await _store.AppendEventsAsync(grainId, batch2, startVersion: 2);
+        await store.AppendEventsAsync(grainId, batch1, startVersion: 1);
+        await store.AppendEventsAsync(grainId, batch2, startVersion: 2);
 
-        var all = await _store.ReadEventsAsync(grainId, afterVersion: 0);
+        var all = await store.ReadEventsAsync(grainId, afterVersion: 0);
         Assert.AreEqual(3, all.Count);
         Assert.IsInstanceOfType<WorkflowStarted>(all[0]);
         Assert.IsInstanceOfType<ExecutionStarted>(all[1]);
@@ -261,7 +285,6 @@ public class EfCoreEventStoreTests
     private static WorkflowInstanceState CreateTestState(Guid? id = null)
     {
         var state = new WorkflowInstanceState();
-        // Use null ProcessDefinitionId to avoid FK constraint against ProcessDefinitions table
         state.Initialize(id ?? Guid.NewGuid(), null, Guid.NewGuid());
         state.Start();
         return state;

--- a/src/Fleans/Fleans.Persistence.Tests/EfCoreMessageCorrelationGrainStorageTests.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/EfCoreMessageCorrelationGrainStorageTests.cs
@@ -1,56 +1,34 @@
 using Fleans.Domain.States;
-using Microsoft.Data.Sqlite;
-using Fleans.Persistence.Sqlite;
-using Microsoft.EntityFrameworkCore;
+using Fleans.Persistence.Tests.Infrastructure;
 using Orleans.Runtime;
 using Orleans.Storage;
 
 namespace Fleans.Persistence.Tests;
 
 [TestClass]
-public class EfCoreMessageCorrelationGrainStorageTests
+[TestCategory("Postgres")]
+public class EfCoreMessageCorrelationGrainStorageTests : PersistenceTestBase
 {
-    private SqliteConnection _connection = null!;
-    private IDbContextFactory<FleanCommandDbContext> _dbContextFactory = null!;
-    private EfCoreMessageCorrelationGrainStorage _storage = null!;
     private const string StateName = "state";
 
-    [TestInitialize]
-    public void Setup()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task WriteAndRead_RoundTrip_ReturnsStoredState(PersistenceProvider provider)
     {
-        _connection = new SqliteConnection("DataSource=:memory:");
-        _connection.Open();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreMessageCorrelationGrainStorage(fixture.CommandFactory);
 
-        var options = new DbContextOptionsBuilder<FleanCommandDbContext>()
-            .UseFleansSqlite(_connection)
-            .Options;
-
-        _dbContextFactory = new TestDbContextFactory(options);
-        _storage = new EfCoreMessageCorrelationGrainStorage(_dbContextFactory);
-
-        using var db = _dbContextFactory.CreateDbContext();
-        db.Database.EnsureCreated();
-    }
-
-    [TestCleanup]
-    public void Cleanup()
-    {
-        _connection.Dispose();
-    }
-
-    [TestMethod]
-    public async Task WriteAndRead_RoundTrip_ReturnsStoredState()
-    {
         var grainId = NewGrainId("paymentReceived/order-123");
         var state = CreateGrainState(
             new MessageSubscription(Guid.NewGuid(), "waitPayment", Guid.NewGuid(), "order-123"));
 
-        await _storage.WriteStateAsync(StateName, grainId, state);
+        await storage.WriteStateAsync(StateName, grainId, state);
         Assert.IsNotNull(state.ETag);
         Assert.IsTrue(state.RecordExists);
 
         var readState = CreateEmptyGrainState();
-        await _storage.ReadStateAsync(StateName, grainId, readState);
+        await storage.ReadStateAsync(StateName, grainId, readState);
 
         Assert.IsNotNull(readState.State.Subscription);
         Assert.AreEqual("order-123", readState.State.Subscription.CorrelationKey);
@@ -59,19 +37,24 @@ public class EfCoreMessageCorrelationGrainStorageTests
         Assert.IsTrue(readState.RecordExists);
     }
 
-    [TestMethod]
-    public async Task WriteAndRead_RoundTrip_PreservesSubscriptionDetails()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task WriteAndRead_RoundTrip_PreservesSubscriptionDetails(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreMessageCorrelationGrainStorage(fixture.CommandFactory);
+
         var instanceId = Guid.NewGuid();
         var hostActivityInstanceId = Guid.NewGuid();
         var grainId = NewGrainId("orderCancelled/corr-key-1");
         var state = CreateGrainState(
             new MessageSubscription(instanceId, "activity-1", hostActivityInstanceId, "corr-key-1"));
 
-        await _storage.WriteStateAsync(StateName, grainId, state);
+        await storage.WriteStateAsync(StateName, grainId, state);
 
         var readState = CreateEmptyGrainState();
-        await _storage.ReadStateAsync(StateName, grainId, readState);
+        await storage.ReadStateAsync(StateName, grainId, readState);
 
         var sub = readState.State.Subscription!;
         Assert.AreEqual(instanceId, sub.WorkflowInstanceId);
@@ -80,122 +63,161 @@ public class EfCoreMessageCorrelationGrainStorageTests
         Assert.AreEqual("orderCancelled/corr-key-1", sub.MessageName);
     }
 
-    [TestMethod]
-    public async Task Write_WithCorrectETag_Succeeds()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task Write_WithCorrectETag_Succeeds(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreMessageCorrelationGrainStorage(fixture.CommandFactory);
+
         var grainId = NewGrainId("msg1/key1");
         var state = CreateGrainState(
             new MessageSubscription(Guid.NewGuid(), "act1", Guid.NewGuid(), "key1"));
-        await _storage.WriteStateAsync(StateName, grainId, state);
+        await storage.WriteStateAsync(StateName, grainId, state);
         var firstETag = state.ETag;
 
-        // Update the subscription
         state.State.Subscription = new MessageSubscription(Guid.NewGuid(), "act2", Guid.NewGuid(), "key1");
-        await _storage.WriteStateAsync(StateName, grainId, state);
+        await storage.WriteStateAsync(StateName, grainId, state);
 
         Assert.AreNotEqual(firstETag, state.ETag);
 
         var readState = CreateEmptyGrainState();
-        await _storage.ReadStateAsync(StateName, grainId, readState);
+        await storage.ReadStateAsync(StateName, grainId, readState);
         Assert.AreEqual("act2", readState.State.Subscription!.ActivityId);
     }
 
-    [TestMethod]
-    public async Task Write_WithStaleETag_ThrowsInconsistentStateException()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task Write_WithStaleETag_ThrowsInconsistentStateException(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreMessageCorrelationGrainStorage(fixture.CommandFactory);
+
         var grainId = NewGrainId("staleMsg/key1");
         var state = CreateGrainState(
             new MessageSubscription(Guid.NewGuid(), "act1", Guid.NewGuid(), "key1"));
-        await _storage.WriteStateAsync(StateName, grainId, state);
+        await storage.WriteStateAsync(StateName, grainId, state);
 
         var concurrentState = CreateEmptyGrainState();
-        await _storage.ReadStateAsync(StateName, grainId, concurrentState);
+        await storage.ReadStateAsync(StateName, grainId, concurrentState);
         concurrentState.State.Subscription = new MessageSubscription(Guid.NewGuid(), "act2", Guid.NewGuid(), "key1");
-        await _storage.WriteStateAsync(StateName, grainId, concurrentState);
+        await storage.WriteStateAsync(StateName, grainId, concurrentState);
 
         state.State.Subscription = new MessageSubscription(Guid.NewGuid(), "act3", Guid.NewGuid(), "key1");
         await Assert.ThrowsExactlyAsync<InconsistentStateException>(
-            () => _storage.WriteStateAsync(StateName, grainId, state));
+            () => storage.WriteStateAsync(StateName, grainId, state));
     }
 
-    [TestMethod]
-    public async Task Write_RemoveSubscription_Succeeds()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task Write_RemoveSubscription_Succeeds(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreMessageCorrelationGrainStorage(fixture.CommandFactory);
+
         var grainId = NewGrainId("diffRemove/key1");
         var state = CreateGrainState(
             new MessageSubscription(Guid.NewGuid(), "act1", Guid.NewGuid(), "key1"));
-        await _storage.WriteStateAsync(StateName, grainId, state);
+        await storage.WriteStateAsync(StateName, grainId, state);
 
         state.State.Subscription = null;
-        await _storage.WriteStateAsync(StateName, grainId, state);
+        await storage.WriteStateAsync(StateName, grainId, state);
 
         var readState = CreateEmptyGrainState();
-        await _storage.ReadStateAsync(StateName, grainId, readState);
+        await storage.ReadStateAsync(StateName, grainId, readState);
         Assert.IsNull(readState.State.Subscription);
     }
 
-    [TestMethod]
-    public async Task Clear_RemovesState_SubsequentReadReturnsDefault()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task Clear_RemovesState_SubsequentReadReturnsDefault(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreMessageCorrelationGrainStorage(fixture.CommandFactory);
+
         var grainId = NewGrainId("clearMsg/key1");
         var state = CreateGrainState(
             new MessageSubscription(Guid.NewGuid(), "act1", Guid.NewGuid(), "key1"));
-        await _storage.WriteStateAsync(StateName, grainId, state);
+        await storage.WriteStateAsync(StateName, grainId, state);
 
-        await _storage.ClearStateAsync(StateName, grainId, state);
+        await storage.ClearStateAsync(StateName, grainId, state);
         Assert.IsNull(state.ETag);
         Assert.IsFalse(state.RecordExists);
 
         var readState = CreateEmptyGrainState();
-        await _storage.ReadStateAsync(StateName, grainId, readState);
+        await storage.ReadStateAsync(StateName, grainId, readState);
         Assert.IsNull(readState.ETag);
         Assert.IsFalse(readState.RecordExists);
     }
 
-    [TestMethod]
-    public async Task Clear_WithStaleETag_ThrowsInconsistentStateException()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task Clear_WithStaleETag_ThrowsInconsistentStateException(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreMessageCorrelationGrainStorage(fixture.CommandFactory);
+
         var grainId = NewGrainId("clearStale/key1");
         var state = CreateGrainState(
             new MessageSubscription(Guid.NewGuid(), "act1", Guid.NewGuid(), "key1"));
-        await _storage.WriteStateAsync(StateName, grainId, state);
+        await storage.WriteStateAsync(StateName, grainId, state);
 
         var concurrentState = CreateEmptyGrainState();
-        await _storage.ReadStateAsync(StateName, grainId, concurrentState);
+        await storage.ReadStateAsync(StateName, grainId, concurrentState);
         concurrentState.State.Subscription = new MessageSubscription(Guid.NewGuid(), "act2", Guid.NewGuid(), "key1");
-        await _storage.WriteStateAsync(StateName, grainId, concurrentState);
+        await storage.WriteStateAsync(StateName, grainId, concurrentState);
 
         await Assert.ThrowsExactlyAsync<InconsistentStateException>(
-            () => _storage.ClearStateAsync(StateName, grainId, state));
+            () => storage.ClearStateAsync(StateName, grainId, state));
     }
 
-    [TestMethod]
-    public async Task Clear_NonExistentGrain_IsNoOp()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task Clear_NonExistentGrain_IsNoOp(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreMessageCorrelationGrainStorage(fixture.CommandFactory);
+
         var grainId = NewGrainId("noop/key1");
         var state = CreateEmptyGrainState();
 
-        await _storage.ClearStateAsync(StateName, grainId, state);
+        await storage.ClearStateAsync(StateName, grainId, state);
 
         Assert.IsNull(state.ETag);
         Assert.IsFalse(state.RecordExists);
     }
 
-    [TestMethod]
-    public async Task Read_NonExistentKey_LeavesStateUnchanged()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task Read_NonExistentKey_LeavesStateUnchanged(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreMessageCorrelationGrainStorage(fixture.CommandFactory);
+
         var grainId = NewGrainId("missing/key1");
         var state = CreateEmptyGrainState();
 
-        await _storage.ReadStateAsync(StateName, grainId, state);
+        await storage.ReadStateAsync(StateName, grainId, state);
 
         Assert.IsNull(state.ETag);
         Assert.IsFalse(state.RecordExists);
     }
 
-    [TestMethod]
-    public async Task DifferentGrainIds_AreIsolated()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task DifferentGrainIds_AreIsolated(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreMessageCorrelationGrainStorage(fixture.CommandFactory);
+
         var grainId1 = NewGrainId("msgA/keyA");
         var grainId2 = NewGrainId("msgB/keyB");
 
@@ -207,13 +229,13 @@ public class EfCoreMessageCorrelationGrainStorageTests
         var state2 = CreateGrainState(
             new MessageSubscription(id2, "actB", Guid.NewGuid(), "keyB"));
 
-        await _storage.WriteStateAsync(StateName, grainId1, state1);
-        await _storage.WriteStateAsync(StateName, grainId2, state2);
+        await storage.WriteStateAsync(StateName, grainId1, state1);
+        await storage.WriteStateAsync(StateName, grainId2, state2);
 
         var read1 = CreateEmptyGrainState();
         var read2 = CreateEmptyGrainState();
-        await _storage.ReadStateAsync(StateName, grainId1, read1);
-        await _storage.ReadStateAsync(StateName, grainId2, read2);
+        await storage.ReadStateAsync(StateName, grainId1, read1);
+        await storage.ReadStateAsync(StateName, grainId2, read2);
 
         Assert.IsNotNull(read1.State.Subscription);
         Assert.AreEqual(id1, read1.State.Subscription.WorkflowInstanceId);
@@ -221,22 +243,27 @@ public class EfCoreMessageCorrelationGrainStorageTests
         Assert.AreEqual(id2, read2.State.Subscription.WorkflowInstanceId);
     }
 
-    [TestMethod]
-    public async Task WriteClearWrite_ReCreatesSameGrainId()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task WriteClearWrite_ReCreatesSameGrainId(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreMessageCorrelationGrainStorage(fixture.CommandFactory);
+
         var grainId = NewGrainId("recreate/key1");
         var state = CreateGrainState(
             new MessageSubscription(Guid.NewGuid(), "act1", Guid.NewGuid(), "key1"));
-        await _storage.WriteStateAsync(StateName, grainId, state);
+        await storage.WriteStateAsync(StateName, grainId, state);
 
-        await _storage.ClearStateAsync(StateName, grainId, state);
+        await storage.ClearStateAsync(StateName, grainId, state);
 
         var newState = CreateGrainState(
             new MessageSubscription(Guid.NewGuid(), "act2", Guid.NewGuid(), "key2"));
-        await _storage.WriteStateAsync(StateName, grainId, newState);
+        await storage.WriteStateAsync(StateName, grainId, newState);
 
         var readState = CreateEmptyGrainState();
-        await _storage.ReadStateAsync(StateName, grainId, readState);
+        await storage.ReadStateAsync(StateName, grainId, readState);
 
         Assert.IsNotNull(readState.State.Subscription);
         Assert.AreEqual("key2", readState.State.Subscription.CorrelationKey);

--- a/src/Fleans/Fleans.Persistence.Tests/EfCoreProcessDefinitionGrainStorageTests.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/EfCoreProcessDefinitionGrainStorageTests.cs
@@ -1,59 +1,37 @@
 using Fleans.Domain;
 using Fleans.Domain.Activities;
 using Fleans.Domain.Sequences;
-using Microsoft.Data.Sqlite;
-using Fleans.Persistence.Sqlite;
-using Microsoft.EntityFrameworkCore;
+using Fleans.Persistence.Tests.Infrastructure;
 using Orleans.Runtime;
 using Orleans.Storage;
 
 namespace Fleans.Persistence.Tests;
 
 [TestClass]
-public class EfCoreProcessDefinitionGrainStorageTests
+[TestCategory("Postgres")]
+public class EfCoreProcessDefinitionGrainStorageTests : PersistenceTestBase
 {
-    private SqliteConnection _connection = null!;
-    private IDbContextFactory<FleanCommandDbContext> _dbContextFactory = null!;
-    private EfCoreProcessDefinitionGrainStorage _storage = null!;
     private const string StateName = "state";
 
-    [TestInitialize]
-    public void Setup()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task WriteAndRead_RoundTrip_ReturnsStoredState(PersistenceProvider provider)
     {
-        _connection = new SqliteConnection("DataSource=:memory:");
-        _connection.Open();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreProcessDefinitionGrainStorage(fixture.CommandFactory);
 
-        var options = new DbContextOptionsBuilder<FleanCommandDbContext>()
-            .UseFleansSqlite(_connection)
-            .Options;
-
-        _dbContextFactory = new TestDbContextFactory(options);
-        _storage = new EfCoreProcessDefinitionGrainStorage(_dbContextFactory);
-
-        using var db = _dbContextFactory.CreateDbContext();
-        db.Database.EnsureCreated();
-    }
-
-    [TestCleanup]
-    public void Cleanup()
-    {
-        _connection.Dispose();
-    }
-
-    [TestMethod]
-    public async Task WriteAndRead_RoundTrip_ReturnsStoredState()
-    {
         var id = "myProcess:1:ts";
         var grainId = NewGrainId(id);
         var state = CreateGrainState(id, "myProcess", 1);
         var deployedAt = state.State.DeployedAt;
 
-        await _storage.WriteStateAsync(StateName, grainId, state);
+        await storage.WriteStateAsync(StateName, grainId, state);
         Assert.IsNotNull(state.ETag);
         Assert.IsTrue(state.RecordExists);
 
         var readState = CreateEmptyGrainState();
-        await _storage.ReadStateAsync(StateName, grainId, readState);
+        await storage.ReadStateAsync(StateName, grainId, readState);
 
         Assert.AreEqual(id, readState.State.ProcessDefinitionId);
         Assert.AreEqual("myProcess", readState.State.ProcessDefinitionKey);
@@ -64,17 +42,22 @@ public class EfCoreProcessDefinitionGrainStorageTests
         Assert.IsTrue(readState.RecordExists);
     }
 
-    [TestMethod]
-    public async Task WriteAndRead_RoundTrip_WorkflowJsonPreserved()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task WriteAndRead_RoundTrip_WorkflowJsonPreserved(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreProcessDefinitionGrainStorage(fixture.CommandFactory);
+
         var id = "poly:1:ts";
         var grainId = NewGrainId(id);
         var state = CreateGrainStateWithMixedActivities(id);
 
-        await _storage.WriteStateAsync(StateName, grainId, state);
+        await storage.WriteStateAsync(StateName, grainId, state);
 
         var readState = CreateEmptyGrainState();
-        await _storage.ReadStateAsync(StateName, grainId, readState);
+        await storage.ReadStateAsync(StateName, grainId, readState);
 
         var workflow = readState.State.Workflow;
         Assert.AreEqual(4, workflow.Activities.Count);
@@ -88,130 +71,175 @@ public class EfCoreProcessDefinitionGrainStorageTests
         Assert.IsInstanceOfType<DefaultSequenceFlow>(workflow.SequenceFlows[3]);
     }
 
-    [TestMethod]
-    public async Task Write_WithCorrectETag_Succeeds()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task Write_WithCorrectETag_Succeeds(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreProcessDefinitionGrainStorage(fixture.CommandFactory);
+
         var id = "upd:1:ts";
         var grainId = NewGrainId(id);
         var state = CreateGrainState(id, "upd", 1);
-        await _storage.WriteStateAsync(StateName, grainId, state);
+        await storage.WriteStateAsync(StateName, grainId, state);
         var firstETag = state.ETag;
 
         state.State = WithBpmnXml(state.State, "<bpmn updated/>");
-        await _storage.WriteStateAsync(StateName, grainId, state);
+        await storage.WriteStateAsync(StateName, grainId, state);
 
         Assert.AreNotEqual(firstETag, state.ETag);
 
         var readState = CreateEmptyGrainState();
-        await _storage.ReadStateAsync(StateName, grainId, readState);
+        await storage.ReadStateAsync(StateName, grainId, readState);
         Assert.AreEqual("<bpmn updated/>", readState.State.BpmnXml);
     }
 
-    [TestMethod]
-    public async Task Write_WithStaleETag_ThrowsInconsistentStateException()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task Write_WithStaleETag_ThrowsInconsistentStateException(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreProcessDefinitionGrainStorage(fixture.CommandFactory);
+
         var id = "stale:1:ts";
         var grainId = NewGrainId(id);
         var state = CreateGrainState(id, "stale", 1);
-        await _storage.WriteStateAsync(StateName, grainId, state);
+        await storage.WriteStateAsync(StateName, grainId, state);
 
         var concurrentState = CreateEmptyGrainState();
-        await _storage.ReadStateAsync(StateName, grainId, concurrentState);
+        await storage.ReadStateAsync(StateName, grainId, concurrentState);
         concurrentState.State = WithBpmnXml(concurrentState.State, "<concurrent/>");
-        await _storage.WriteStateAsync(StateName, grainId, concurrentState);
+        await storage.WriteStateAsync(StateName, grainId, concurrentState);
 
         state.State = WithBpmnXml(state.State, "<stale/>");
         await Assert.ThrowsExactlyAsync<InconsistentStateException>(
-            () => _storage.WriteStateAsync(StateName, grainId, state));
+            () => storage.WriteStateAsync(StateName, grainId, state));
     }
 
-    [TestMethod]
-    public async Task FirstWrite_WithoutETag_Succeeds()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task FirstWrite_WithoutETag_Succeeds(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreProcessDefinitionGrainStorage(fixture.CommandFactory);
+
         var id = "first:1:ts";
         var grainId = NewGrainId(id);
         var state = CreateGrainState(id, "first", 1);
         Assert.IsNull(state.ETag);
 
-        await _storage.WriteStateAsync(StateName, grainId, state);
+        await storage.WriteStateAsync(StateName, grainId, state);
 
         Assert.IsNotNull(state.ETag);
         Assert.IsTrue(state.RecordExists);
     }
 
-    [TestMethod]
-    public async Task Write_WithStaleETagToNonExistentKey_ThrowsInconsistentStateException()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task Write_WithStaleETagToNonExistentKey_ThrowsInconsistentStateException(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreProcessDefinitionGrainStorage(fixture.CommandFactory);
+
         var grainId = NewGrainId("nope:1:ts");
         var state = CreateGrainState("nope:1:ts", "nope", 1);
         state.ETag = "stale-etag";
 
         await Assert.ThrowsExactlyAsync<InconsistentStateException>(
-            () => _storage.WriteStateAsync(StateName, grainId, state));
+            () => storage.WriteStateAsync(StateName, grainId, state));
     }
 
-    [TestMethod]
-    public async Task Clear_RemovesState_SubsequentReadReturnsDefault()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task Clear_RemovesState_SubsequentReadReturnsDefault(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreProcessDefinitionGrainStorage(fixture.CommandFactory);
+
         var id = "clr:1:ts";
         var grainId = NewGrainId(id);
         var state = CreateGrainState(id, "clr", 1);
-        await _storage.WriteStateAsync(StateName, grainId, state);
+        await storage.WriteStateAsync(StateName, grainId, state);
 
-        await _storage.ClearStateAsync(StateName, grainId, state);
+        await storage.ClearStateAsync(StateName, grainId, state);
         Assert.IsNull(state.ETag);
         Assert.IsFalse(state.RecordExists);
 
         var readState = CreateEmptyGrainState();
-        await _storage.ReadStateAsync(StateName, grainId, readState);
+        await storage.ReadStateAsync(StateName, grainId, readState);
         Assert.IsNull(readState.ETag);
         Assert.IsFalse(readState.RecordExists);
     }
 
-    [TestMethod]
-    public async Task Clear_WithStaleETag_ThrowsInconsistentStateException()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task Clear_WithStaleETag_ThrowsInconsistentStateException(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreProcessDefinitionGrainStorage(fixture.CommandFactory);
+
         var id = "clrstale:1:ts";
         var grainId = NewGrainId(id);
         var state = CreateGrainState(id, "clrstale", 1);
-        await _storage.WriteStateAsync(StateName, grainId, state);
+        await storage.WriteStateAsync(StateName, grainId, state);
 
         var concurrentState = CreateEmptyGrainState();
-        await _storage.ReadStateAsync(StateName, grainId, concurrentState);
+        await storage.ReadStateAsync(StateName, grainId, concurrentState);
         concurrentState.State = WithBpmnXml(concurrentState.State, "<concurrent/>");
-        await _storage.WriteStateAsync(StateName, grainId, concurrentState);
+        await storage.WriteStateAsync(StateName, grainId, concurrentState);
 
         await Assert.ThrowsExactlyAsync<InconsistentStateException>(
-            () => _storage.ClearStateAsync(StateName, grainId, state));
+            () => storage.ClearStateAsync(StateName, grainId, state));
     }
 
-    [TestMethod]
-    public async Task Clear_NonExistentGrain_IsNoOp()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task Clear_NonExistentGrain_IsNoOp(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreProcessDefinitionGrainStorage(fixture.CommandFactory);
+
         var grainId = NewGrainId("noop:1:ts");
         var state = CreateEmptyGrainState();
 
-        await _storage.ClearStateAsync(StateName, grainId, state);
+        await storage.ClearStateAsync(StateName, grainId, state);
 
         Assert.IsNull(state.ETag);
         Assert.IsFalse(state.RecordExists);
     }
 
-    [TestMethod]
-    public async Task Read_NonExistentKey_LeavesStateUnchanged()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task Read_NonExistentKey_LeavesStateUnchanged(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreProcessDefinitionGrainStorage(fixture.CommandFactory);
+
         var grainId = NewGrainId("missing:1:ts");
         var state = CreateEmptyGrainState();
 
-        await _storage.ReadStateAsync(StateName, grainId, state);
+        await storage.ReadStateAsync(StateName, grainId, state);
 
         Assert.IsNull(state.ETag);
         Assert.IsFalse(state.RecordExists);
     }
 
-    [TestMethod]
-    public async Task DifferentGrainIds_AreIsolated()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task DifferentGrainIds_AreIsolated(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreProcessDefinitionGrainStorage(fixture.CommandFactory);
+
         var id1 = "iso1:1:ts";
         var id2 = "iso2:1:ts";
         var grainId1 = NewGrainId(id1);
@@ -220,13 +248,13 @@ public class EfCoreProcessDefinitionGrainStorageTests
         var state1 = CreateGrainState(id1, "iso1", 1);
         var state2 = CreateGrainState(id2, "iso2", 2);
 
-        await _storage.WriteStateAsync(StateName, grainId1, state1);
-        await _storage.WriteStateAsync(StateName, grainId2, state2);
+        await storage.WriteStateAsync(StateName, grainId1, state1);
+        await storage.WriteStateAsync(StateName, grainId2, state2);
 
         var read1 = CreateEmptyGrainState();
         var read2 = CreateEmptyGrainState();
-        await _storage.ReadStateAsync(StateName, grainId1, read1);
-        await _storage.ReadStateAsync(StateName, grainId2, read2);
+        await storage.ReadStateAsync(StateName, grainId1, read1);
+        await storage.ReadStateAsync(StateName, grainId2, read2);
 
         Assert.AreEqual("iso1", read1.State.ProcessDefinitionKey);
         Assert.AreEqual(1, read1.State.Version);
@@ -234,17 +262,22 @@ public class EfCoreProcessDefinitionGrainStorageTests
         Assert.AreEqual(2, read2.State.Version);
     }
 
-    [TestMethod]
-    public async Task WriteAndRead_UserTaskWithListProperties_RoundTripsCorrectly()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task WriteAndRead_UserTaskWithListProperties_RoundTripsCorrectly(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreProcessDefinitionGrainStorage(fixture.CommandFactory);
+
         var id = "usertask:1:ts";
         var grainId = NewGrainId(id);
         var state = CreateGrainStateWithUserTask(id);
 
-        await _storage.WriteStateAsync(StateName, grainId, state);
+        await storage.WriteStateAsync(StateName, grainId, state);
 
         var readState = CreateEmptyGrainState();
-        await _storage.ReadStateAsync(StateName, grainId, readState);
+        await storage.ReadStateAsync(StateName, grainId, readState);
 
         var workflow = readState.State.Workflow;
         Assert.AreEqual(3, workflow.Activities.Count);
@@ -262,21 +295,26 @@ public class EfCoreProcessDefinitionGrainStorageTests
             new[] { "approved", "comments" }, userTask.ExpectedOutputVariables!.ToList());
     }
 
-    [TestMethod]
-    public async Task WriteClearWrite_ReCreatesSameGrainId()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task WriteClearWrite_ReCreatesSameGrainId(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreProcessDefinitionGrainStorage(fixture.CommandFactory);
+
         var id = "recreate:1:ts";
         var grainId = NewGrainId(id);
         var state = CreateGrainState(id, "recreate", 1);
-        await _storage.WriteStateAsync(StateName, grainId, state);
+        await storage.WriteStateAsync(StateName, grainId, state);
 
-        await _storage.ClearStateAsync(StateName, grainId, state);
+        await storage.ClearStateAsync(StateName, grainId, state);
 
         var newState = CreateGrainState(id, "recreate", 2);
-        await _storage.WriteStateAsync(StateName, grainId, newState);
+        await storage.WriteStateAsync(StateName, grainId, newState);
 
         var readState = CreateEmptyGrainState();
-        await _storage.ReadStateAsync(StateName, grainId, readState);
+        await storage.ReadStateAsync(StateName, grainId, readState);
 
         Assert.AreEqual("recreate", readState.State.ProcessDefinitionKey);
         Assert.AreEqual(2, readState.State.Version);

--- a/src/Fleans/Fleans.Persistence.Tests/EfCoreProcessDefinitionGrainStorageTests.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/EfCoreProcessDefinitionGrainStorageTests.cs
@@ -36,7 +36,7 @@ public class EfCoreProcessDefinitionGrainStorageTests : PersistenceTestBase
         Assert.AreEqual(id, readState.State.ProcessDefinitionId);
         Assert.AreEqual("myProcess", readState.State.ProcessDefinitionKey);
         Assert.AreEqual(1, readState.State.Version);
-        Assert.AreEqual(deployedAt, readState.State.DeployedAt);
+        Assert.AreEqual(TruncateToMicroseconds(deployedAt), TruncateToMicroseconds(readState.State.DeployedAt));
         Assert.AreEqual("<bpmn/>", readState.State.BpmnXml);
         Assert.AreEqual(state.ETag, readState.ETag);
         Assert.IsTrue(readState.RecordExists);
@@ -333,6 +333,11 @@ public class EfCoreProcessDefinitionGrainStorageTests : PersistenceTestBase
 
     private static GrainId NewGrainId(string key)
         => GrainId.Create("processDefinition", key);
+
+    // PostgreSQL `timestamptz` stores microseconds; .NET DateTimeOffset has 100ns ticks.
+    // Round-trip equality must be checked at microsecond resolution.
+    private static DateTimeOffset TruncateToMicroseconds(DateTimeOffset value)
+        => new(value.Ticks - value.Ticks % 10, value.Offset);
 
     private static TestGrainState<ProcessDefinition> CreateGrainState(
         string id, string key, int version)

--- a/src/Fleans/Fleans.Persistence.Tests/EfCoreProcessDefinitionRepositoryTests.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/EfCoreProcessDefinitionRepositoryTests.cs
@@ -2,57 +2,28 @@ using Fleans.Domain;
 using Fleans.Domain.Activities;
 using Fleans.Domain.Persistence;
 using Fleans.Domain.Sequences;
-using Microsoft.Data.Sqlite;
-using Fleans.Persistence.Sqlite;
-using Microsoft.EntityFrameworkCore;
+using Fleans.Persistence.Tests.Infrastructure;
 
 namespace Fleans.Persistence.Tests;
 
 [TestClass]
-public class EfCoreProcessDefinitionRepositoryTests
+[TestCategory("Postgres")]
+public class EfCoreProcessDefinitionRepositoryTests : PersistenceTestBase
 {
-    private SqliteConnection _connection = null!;
-    private IDbContextFactory<FleanCommandDbContext> _dbContextFactory = null!;
-    private IDbContextFactory<FleanQueryDbContext> _queryDbContextFactory = null!;
-    private IProcessDefinitionRepository _repository = null!;
-
-    [TestInitialize]
-    public void Setup()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task SaveAndGetById_RoundTrip_ReturnsAllScalarFields(PersistenceProvider provider)
     {
-        _connection = new SqliteConnection("DataSource=:memory:");
-        _connection.Open();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryFactory);
 
-        var commandOptions = new DbContextOptionsBuilder<FleanCommandDbContext>()
-            .UseFleansSqlite(_connection)
-            .Options;
-
-        var queryOptions = new DbContextOptionsBuilder<FleanQueryDbContext>()
-            .UseFleansSqlite(_connection)
-            .Options;
-
-        _dbContextFactory = new TestDbContextFactory(commandOptions);
-        _queryDbContextFactory = new TestQueryDbContextFactory(queryOptions);
-        _repository = new EfCoreProcessDefinitionRepository(_dbContextFactory, _queryDbContextFactory);
-
-        using var db = _dbContextFactory.CreateDbContext();
-        db.Database.EnsureCreated();
-    }
-
-    [TestCleanup]
-    public void Cleanup()
-    {
-        _connection.Dispose();
-    }
-
-    [TestMethod]
-    public async Task SaveAndGetById_RoundTrip_ReturnsAllScalarFields()
-    {
         var deployedAt = DateTimeOffset.UtcNow;
         var definition = CreateDefinition("key1:1:ts", "key1", 1, deployedAt);
 
-        await _repository.SaveAsync(definition);
+        await repository.SaveAsync(definition);
 
-        var result = await _repository.GetByIdAsync("key1:1:ts");
+        var result = await repository.GetByIdAsync("key1:1:ts");
 
         Assert.IsNotNull(result);
         Assert.AreEqual("key1:1:ts", result.ProcessDefinitionId);
@@ -62,14 +33,19 @@ public class EfCoreProcessDefinitionRepositoryTests
         Assert.AreEqual("<bpmn/>", result.BpmnXml);
     }
 
-    [TestMethod]
-    public async Task SaveAndGetById_WorkflowJsonRoundTrip_PolymorphicActivityTypes()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task SaveAndGetById_WorkflowJsonRoundTrip_PolymorphicActivityTypes(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryFactory);
+
         var definition = CreateDefinitionWithMixedActivities();
 
-        await _repository.SaveAsync(definition);
+        await repository.SaveAsync(definition);
 
-        var result = await _repository.GetByIdAsync(definition.ProcessDefinitionId);
+        var result = await repository.GetByIdAsync(definition.ProcessDefinitionId);
 
         Assert.IsNotNull(result);
         var workflow = result.Workflow;
@@ -84,14 +60,19 @@ public class EfCoreProcessDefinitionRepositoryTests
         Assert.AreEqual("csharp", scriptTask.ScriptFormat);
     }
 
-    [TestMethod]
-    public async Task SaveAndGetById_WorkflowJsonRoundTrip_PolymorphicSequenceFlowTypes()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task SaveAndGetById_WorkflowJsonRoundTrip_PolymorphicSequenceFlowTypes(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryFactory);
+
         var definition = CreateDefinitionWithMixedActivities();
 
-        await _repository.SaveAsync(definition);
+        await repository.SaveAsync(definition);
 
-        var result = await _repository.GetByIdAsync(definition.ProcessDefinitionId);
+        var result = await repository.GetByIdAsync(definition.ProcessDefinitionId);
 
         Assert.IsNotNull(result);
         var workflow = result.Workflow;
@@ -106,39 +87,46 @@ public class EfCoreProcessDefinitionRepositoryTests
         Assert.AreEqual("x > 10", conditionalFlow.Condition);
     }
 
-    [TestMethod]
-    public async Task SaveAndGetById_WorkflowJsonRoundTrip_SharedActivityReferences()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task SaveAndGetById_WorkflowJsonRoundTrip_SharedActivityReferences(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryFactory);
+
         var definition = CreateDefinitionWithMixedActivities();
 
-        await _repository.SaveAsync(definition);
+        await repository.SaveAsync(definition);
 
-        var result = await _repository.GetByIdAsync(definition.ProcessDefinitionId);
+        var result = await repository.GetByIdAsync(definition.ProcessDefinitionId);
 
         Assert.IsNotNull(result);
         var workflow = result.Workflow;
 
-        // SequenceFlow[0].Source should be the same object as Activities[0] (StartEvent)
         Assert.IsTrue(ReferenceEquals(workflow.SequenceFlows[0].Source, workflow.Activities[0]),
             "SequenceFlow.Source should reference the same Activity instance from the Activities list");
 
-        // SequenceFlow[0].Target should be the same object as Activities[1] (ScriptTask)
         Assert.IsTrue(ReferenceEquals(workflow.SequenceFlows[0].Target, workflow.Activities[1]),
             "SequenceFlow.Target should reference the same Activity instance from the Activities list");
 
-        // ConditionalSequenceFlow[1].Source should be the same as Activities[2] (ExclusiveGateway)
         Assert.IsTrue(ReferenceEquals(workflow.SequenceFlows[1].Source, workflow.Activities[2]),
             "ConditionalSequenceFlow.Source should reference the same gateway Activity instance");
     }
 
-    [TestMethod]
-    public async Task GetByKey_ReturnsVersionsOrderedByVersion()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetByKey_ReturnsVersionsOrderedByVersion(PersistenceProvider provider)
     {
-        await _repository.SaveAsync(CreateDefinition("key1:3:ts", "key1", 3, DateTimeOffset.UtcNow));
-        await _repository.SaveAsync(CreateDefinition("key1:1:ts", "key1", 1, DateTimeOffset.UtcNow));
-        await _repository.SaveAsync(CreateDefinition("key1:2:ts", "key1", 2, DateTimeOffset.UtcNow));
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryFactory);
 
-        var results = await _repository.GetByKeyAsync("key1");
+        await repository.SaveAsync(CreateDefinition("key1:3:ts", "key1", 3, DateTimeOffset.UtcNow));
+        await repository.SaveAsync(CreateDefinition("key1:1:ts", "key1", 1, DateTimeOffset.UtcNow));
+        await repository.SaveAsync(CreateDefinition("key1:2:ts", "key1", 2, DateTimeOffset.UtcNow));
+
+        var results = await repository.GetByKeyAsync("key1");
 
         Assert.AreEqual(3, results.Count);
         Assert.AreEqual(1, results[0].Version);
@@ -146,15 +134,20 @@ public class EfCoreProcessDefinitionRepositoryTests
         Assert.AreEqual(3, results[2].Version);
     }
 
-    [TestMethod]
-    public async Task GetAll_ReturnsAllDefinitionsOrderedByKeyThenVersion()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetAll_ReturnsAllDefinitionsOrderedByKeyThenVersion(PersistenceProvider provider)
     {
-        await _repository.SaveAsync(CreateDefinition("beta:2:ts", "beta", 2, DateTimeOffset.UtcNow));
-        await _repository.SaveAsync(CreateDefinition("alpha:1:ts", "alpha", 1, DateTimeOffset.UtcNow));
-        await _repository.SaveAsync(CreateDefinition("beta:1:ts", "beta", 1, DateTimeOffset.UtcNow));
-        await _repository.SaveAsync(CreateDefinition("alpha:2:ts", "alpha", 2, DateTimeOffset.UtcNow));
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryFactory);
 
-        var results = await _repository.GetAllAsync();
+        await repository.SaveAsync(CreateDefinition("beta:2:ts", "beta", 2, DateTimeOffset.UtcNow));
+        await repository.SaveAsync(CreateDefinition("alpha:1:ts", "alpha", 1, DateTimeOffset.UtcNow));
+        await repository.SaveAsync(CreateDefinition("beta:1:ts", "beta", 1, DateTimeOffset.UtcNow));
+        await repository.SaveAsync(CreateDefinition("alpha:2:ts", "alpha", 2, DateTimeOffset.UtcNow));
+
+        var results = await repository.GetAllAsync();
 
         Assert.AreEqual(4, results.Count);
         Assert.AreEqual("alpha", results[0].ProcessDefinitionKey);
@@ -167,112 +160,151 @@ public class EfCoreProcessDefinitionRepositoryTests
         Assert.AreEqual(2, results[3].Version);
     }
 
-    [TestMethod]
-    public async Task GetById_NonExistent_ReturnsNull()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetById_NonExistent_ReturnsNull(PersistenceProvider provider)
     {
-        var result = await _repository.GetByIdAsync("does-not-exist");
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryFactory);
+
+        var result = await repository.GetByIdAsync("does-not-exist");
 
         Assert.IsNull(result);
     }
 
-    [TestMethod]
-    public async Task Delete_RemovesDefinition_SubsequentGetByIdReturnsNull()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task Delete_RemovesDefinition_SubsequentGetByIdReturnsNull(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryFactory);
+
         var definition = CreateDefinition("key1:1:ts", "key1", 1, DateTimeOffset.UtcNow);
-        await _repository.SaveAsync(definition);
+        await repository.SaveAsync(definition);
 
-        await _repository.DeleteAsync("key1:1:ts");
+        await repository.DeleteAsync("key1:1:ts");
 
-        var result = await _repository.GetByIdAsync("key1:1:ts");
+        var result = await repository.GetByIdAsync("key1:1:ts");
         Assert.IsNull(result);
     }
 
-    [TestMethod]
-    public async Task Delete_NonExistentId_IsNoOp()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task Delete_NonExistentId_IsNoOp(PersistenceProvider provider)
     {
-        await _repository.DeleteAsync("does-not-exist");
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryFactory);
 
-        // Should not throw — just a no-op
+        await repository.DeleteAsync("does-not-exist");
     }
 
-    [TestMethod]
-    public async Task Save_DuplicateProcessDefinitionId_ThrowsInvalidOperationException()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task Save_DuplicateProcessDefinitionId_ThrowsInvalidOperationException(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryFactory);
+
         var definition = CreateDefinition("key1:1:ts", "key1", 1, DateTimeOffset.UtcNow);
-        await _repository.SaveAsync(definition);
+        await repository.SaveAsync(definition);
 
         await Assert.ThrowsExactlyAsync<InvalidOperationException>(
-            () => _repository.SaveAsync(definition));
+            () => repository.SaveAsync(definition));
     }
 
-    [TestMethod]
-    public async Task SaveAndGetById_DisabledProcess_IsActiveFalseRoundTrip()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task SaveAndGetById_DisabledProcess_IsActiveFalseRoundTrip(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryFactory);
+
         var definition = CreateDefinition("disabled:1:ts", "disabled", 1, DateTimeOffset.UtcNow);
         definition.Disable();
 
-        await _repository.SaveAsync(definition);
+        await repository.SaveAsync(definition);
 
-        var result = await _repository.GetByIdAsync("disabled:1:ts");
+        var result = await repository.GetByIdAsync("disabled:1:ts");
 
         Assert.IsNotNull(result);
         Assert.IsFalse(result.IsActive, "IsActive should be false after round-trip");
     }
 
-    [TestMethod]
-    public async Task SaveAndGetById_EnabledProcess_IsActiveTrueByDefault()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task SaveAndGetById_EnabledProcess_IsActiveTrueByDefault(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryFactory);
+
         var definition = CreateDefinition("enabled:1:ts", "enabled", 1, DateTimeOffset.UtcNow);
 
-        await _repository.SaveAsync(definition);
+        await repository.SaveAsync(definition);
 
-        var result = await _repository.GetByIdAsync("enabled:1:ts");
+        var result = await repository.GetByIdAsync("enabled:1:ts");
 
         Assert.IsNotNull(result);
         Assert.IsTrue(result.IsActive, "IsActive should be true by default");
     }
 
-    [TestMethod]
-    public async Task UpdateAsync_DisableExistingProcess_PersistsIsActiveFalse()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task UpdateAsync_DisableExistingProcess_PersistsIsActiveFalse(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryFactory);
+
         var definition = CreateDefinition("upd:1:ts", "upd", 1, DateTimeOffset.UtcNow);
-        await _repository.SaveAsync(definition);
+        await repository.SaveAsync(definition);
 
         definition.Disable();
-        await _repository.UpdateAsync(definition);
+        await repository.UpdateAsync(definition);
 
-        var result = await _repository.GetByIdAsync("upd:1:ts");
+        var result = await repository.GetByIdAsync("upd:1:ts");
         Assert.IsNotNull(result);
         Assert.IsFalse(result.IsActive, "IsActive should be false after UpdateAsync with Disable()");
     }
 
-    [TestMethod]
-    public async Task UpdateAsync_EnableDisabledProcess_PersistsIsActiveTrue()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task UpdateAsync_EnableDisabledProcess_PersistsIsActiveTrue(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryFactory);
+
         var definition = CreateDefinition("upd2:1:ts", "upd2", 1, DateTimeOffset.UtcNow);
         definition.Disable();
-        await _repository.SaveAsync(definition);
+        await repository.SaveAsync(definition);
 
         definition.Enable();
-        await _repository.UpdateAsync(definition);
+        await repository.UpdateAsync(definition);
 
-        var result = await _repository.GetByIdAsync("upd2:1:ts");
+        var result = await repository.GetByIdAsync("upd2:1:ts");
         Assert.IsNotNull(result);
         Assert.IsTrue(result.IsActive, "IsActive should be true after UpdateAsync with Enable()");
     }
 
-    [TestMethod]
-    public async Task UpdateAsync_NonExistentDefinition_ThrowsInvalidOperationException()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task UpdateAsync_NonExistentDefinition_ThrowsInvalidOperationException(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryFactory);
+
         var definition = CreateDefinition("missing:1:ts", "missing", 1, DateTimeOffset.UtcNow);
 
         await Assert.ThrowsExactlyAsync<InvalidOperationException>(
-            () => _repository.UpdateAsync(definition));
+            () => repository.UpdateAsync(definition));
     }
-
-    // ───────────────────────────────────────────────
-    // Helpers
-    // ───────────────────────────────────────────────
 
     private static ProcessDefinition CreateDefinition(
         string id, string key, int version, DateTimeOffset deployedAt)
@@ -326,5 +358,4 @@ public class EfCoreProcessDefinitionRepositoryTests
             }
         };
     }
-
 }

--- a/src/Fleans/Fleans.Persistence.Tests/EfCoreProcessDefinitionRepositoryTests.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/EfCoreProcessDefinitionRepositoryTests.cs
@@ -29,7 +29,7 @@ public class EfCoreProcessDefinitionRepositoryTests : PersistenceTestBase
         Assert.AreEqual("key1:1:ts", result.ProcessDefinitionId);
         Assert.AreEqual("key1", result.ProcessDefinitionKey);
         Assert.AreEqual(1, result.Version);
-        Assert.AreEqual(deployedAt, result.DeployedAt);
+        Assert.AreEqual(TruncateToMicroseconds(deployedAt), TruncateToMicroseconds(result.DeployedAt));
         Assert.AreEqual("<bpmn/>", result.BpmnXml);
     }
 
@@ -305,6 +305,9 @@ public class EfCoreProcessDefinitionRepositoryTests : PersistenceTestBase
         await Assert.ThrowsExactlyAsync<InvalidOperationException>(
             () => repository.UpdateAsync(definition));
     }
+
+    private static DateTimeOffset TruncateToMicroseconds(DateTimeOffset value)
+        => new(value.Ticks - value.Ticks % 10, value.Offset);
 
     private static ProcessDefinition CreateDefinition(
         string id, string key, int version, DateTimeOffset deployedAt)

--- a/src/Fleans/Fleans.Persistence.Tests/EfCoreSignalCorrelationGrainStorageTests.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/EfCoreSignalCorrelationGrainStorageTests.cs
@@ -1,57 +1,35 @@
 using Fleans.Domain.States;
-using Microsoft.Data.Sqlite;
-using Fleans.Persistence.Sqlite;
-using Microsoft.EntityFrameworkCore;
+using Fleans.Persistence.Tests.Infrastructure;
 using Orleans.Runtime;
 using Orleans.Storage;
 
 namespace Fleans.Persistence.Tests;
 
 [TestClass]
-public class EfCoreSignalCorrelationGrainStorageTests
+[TestCategory("Postgres")]
+public class EfCoreSignalCorrelationGrainStorageTests : PersistenceTestBase
 {
-    private SqliteConnection _connection = null!;
-    private IDbContextFactory<FleanCommandDbContext> _dbContextFactory = null!;
-    private EfCoreSignalCorrelationGrainStorage _storage = null!;
     private const string StateName = "state";
 
-    [TestInitialize]
-    public void Setup()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task WriteAndRead_RoundTrip_ReturnsStoredState(PersistenceProvider provider)
     {
-        _connection = new SqliteConnection("DataSource=:memory:");
-        _connection.Open();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreSignalCorrelationGrainStorage(fixture.CommandFactory);
 
-        var options = new DbContextOptionsBuilder<FleanCommandDbContext>()
-            .UseFleansSqlite(_connection)
-            .Options;
-
-        _dbContextFactory = new TestDbContextFactory(options);
-        _storage = new EfCoreSignalCorrelationGrainStorage(_dbContextFactory);
-
-        using var db = _dbContextFactory.CreateDbContext();
-        db.Database.EnsureCreated();
-    }
-
-    [TestCleanup]
-    public void Cleanup()
-    {
-        _connection.Dispose();
-    }
-
-    [TestMethod]
-    public async Task WriteAndRead_RoundTrip_ReturnsStoredState()
-    {
         var grainId = NewGrainId("approvalSignal");
         var sub1 = new SignalSubscription(Guid.NewGuid(), "waitApproval", Guid.NewGuid());
         var sub2 = new SignalSubscription(Guid.NewGuid(), "waitConfirm", Guid.NewGuid());
         var state = CreateGrainState(sub1, sub2);
 
-        await _storage.WriteStateAsync(StateName, grainId, state);
+        await storage.WriteStateAsync(StateName, grainId, state);
         Assert.IsNotNull(state.ETag);
         Assert.IsTrue(state.RecordExists);
 
         var readState = CreateEmptyGrainState();
-        await _storage.ReadStateAsync(StateName, grainId, readState);
+        await storage.ReadStateAsync(StateName, grainId, readState);
 
         Assert.AreEqual(2, readState.State.Subscriptions.Count);
         Assert.IsTrue(readState.State.Subscriptions.Any(s => s.ActivityId == "waitApproval"));
@@ -60,19 +38,24 @@ public class EfCoreSignalCorrelationGrainStorageTests
         Assert.IsTrue(readState.RecordExists);
     }
 
-    [TestMethod]
-    public async Task WriteAndRead_RoundTrip_PreservesSubscriptionDetails()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task WriteAndRead_RoundTrip_PreservesSubscriptionDetails(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreSignalCorrelationGrainStorage(fixture.CommandFactory);
+
         var instanceId = Guid.NewGuid();
         var hostId = Guid.NewGuid();
         var grainId = NewGrainId("detailSignal");
         var state = CreateGrainState(
             new SignalSubscription(instanceId, "activity-1", hostId));
 
-        await _storage.WriteStateAsync(StateName, grainId, state);
+        await storage.WriteStateAsync(StateName, grainId, state);
 
         var readState = CreateEmptyGrainState();
-        await _storage.ReadStateAsync(StateName, grainId, readState);
+        await storage.ReadStateAsync(StateName, grainId, readState);
 
         var sub = readState.State.Subscriptions[0];
         Assert.AreEqual(instanceId, sub.WorkflowInstanceId);
@@ -81,123 +64,163 @@ public class EfCoreSignalCorrelationGrainStorageTests
         Assert.AreEqual("detailSignal", sub.SignalName);
     }
 
-    [TestMethod]
-    public async Task Write_WithCorrectETag_Succeeds()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task Write_WithCorrectETag_Succeeds(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreSignalCorrelationGrainStorage(fixture.CommandFactory);
+
         var grainId = NewGrainId("sig1");
         var state = CreateGrainState(
             new SignalSubscription(Guid.NewGuid(), "act1", Guid.NewGuid()));
-        await _storage.WriteStateAsync(StateName, grainId, state);
+        await storage.WriteStateAsync(StateName, grainId, state);
         var firstETag = state.ETag;
 
         state.State.Subscriptions.Add(new SignalSubscription(Guid.NewGuid(), "act2", Guid.NewGuid()));
-        await _storage.WriteStateAsync(StateName, grainId, state);
+        await storage.WriteStateAsync(StateName, grainId, state);
 
         Assert.AreNotEqual(firstETag, state.ETag);
 
         var readState = CreateEmptyGrainState();
-        await _storage.ReadStateAsync(StateName, grainId, readState);
+        await storage.ReadStateAsync(StateName, grainId, readState);
         Assert.AreEqual(2, readState.State.Subscriptions.Count);
     }
 
-    [TestMethod]
-    public async Task Write_WithStaleETag_ThrowsInconsistentStateException()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task Write_WithStaleETag_ThrowsInconsistentStateException(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreSignalCorrelationGrainStorage(fixture.CommandFactory);
+
         var grainId = NewGrainId("staleSig");
         var state = CreateGrainState(
             new SignalSubscription(Guid.NewGuid(), "act1", Guid.NewGuid()));
-        await _storage.WriteStateAsync(StateName, grainId, state);
+        await storage.WriteStateAsync(StateName, grainId, state);
 
         var concurrentState = CreateEmptyGrainState();
-        await _storage.ReadStateAsync(StateName, grainId, concurrentState);
+        await storage.ReadStateAsync(StateName, grainId, concurrentState);
         concurrentState.State.Subscriptions.Add(new SignalSubscription(Guid.NewGuid(), "act2", Guid.NewGuid()));
-        await _storage.WriteStateAsync(StateName, grainId, concurrentState);
+        await storage.WriteStateAsync(StateName, grainId, concurrentState);
 
         state.State.Subscriptions.Add(new SignalSubscription(Guid.NewGuid(), "act3", Guid.NewGuid()));
         await Assert.ThrowsExactlyAsync<InconsistentStateException>(
-            () => _storage.WriteStateAsync(StateName, grainId, state));
+            () => storage.WriteStateAsync(StateName, grainId, state));
     }
 
-    [TestMethod]
-    public async Task Write_DiffRemovesSubscription()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task Write_DiffRemovesSubscription(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreSignalCorrelationGrainStorage(fixture.CommandFactory);
+
         var grainId = NewGrainId("diffRemove");
         var sub1 = new SignalSubscription(Guid.NewGuid(), "act1", Guid.NewGuid());
         var sub2 = new SignalSubscription(Guid.NewGuid(), "act2", Guid.NewGuid());
         var state = CreateGrainState(sub1, sub2);
-        await _storage.WriteStateAsync(StateName, grainId, state);
+        await storage.WriteStateAsync(StateName, grainId, state);
 
         state.State.Subscriptions.Remove(sub1);
-        await _storage.WriteStateAsync(StateName, grainId, state);
+        await storage.WriteStateAsync(StateName, grainId, state);
 
         var readState = CreateEmptyGrainState();
-        await _storage.ReadStateAsync(StateName, grainId, readState);
+        await storage.ReadStateAsync(StateName, grainId, readState);
         Assert.AreEqual(1, readState.State.Subscriptions.Count);
         Assert.AreEqual("act2", readState.State.Subscriptions[0].ActivityId);
     }
 
-    [TestMethod]
-    public async Task Clear_RemovesState_SubsequentReadReturnsDefault()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task Clear_RemovesState_SubsequentReadReturnsDefault(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreSignalCorrelationGrainStorage(fixture.CommandFactory);
+
         var grainId = NewGrainId("clearSig");
         var state = CreateGrainState(
             new SignalSubscription(Guid.NewGuid(), "act1", Guid.NewGuid()));
-        await _storage.WriteStateAsync(StateName, grainId, state);
+        await storage.WriteStateAsync(StateName, grainId, state);
 
-        await _storage.ClearStateAsync(StateName, grainId, state);
+        await storage.ClearStateAsync(StateName, grainId, state);
         Assert.IsNull(state.ETag);
         Assert.IsFalse(state.RecordExists);
 
         var readState = CreateEmptyGrainState();
-        await _storage.ReadStateAsync(StateName, grainId, readState);
+        await storage.ReadStateAsync(StateName, grainId, readState);
         Assert.IsNull(readState.ETag);
         Assert.IsFalse(readState.RecordExists);
     }
 
-    [TestMethod]
-    public async Task Clear_WithStaleETag_ThrowsInconsistentStateException()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task Clear_WithStaleETag_ThrowsInconsistentStateException(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreSignalCorrelationGrainStorage(fixture.CommandFactory);
+
         var grainId = NewGrainId("clearStale");
         var state = CreateGrainState(
             new SignalSubscription(Guid.NewGuid(), "act1", Guid.NewGuid()));
-        await _storage.WriteStateAsync(StateName, grainId, state);
+        await storage.WriteStateAsync(StateName, grainId, state);
 
         var concurrentState = CreateEmptyGrainState();
-        await _storage.ReadStateAsync(StateName, grainId, concurrentState);
+        await storage.ReadStateAsync(StateName, grainId, concurrentState);
         concurrentState.State.Subscriptions.Add(new SignalSubscription(Guid.NewGuid(), "act2", Guid.NewGuid()));
-        await _storage.WriteStateAsync(StateName, grainId, concurrentState);
+        await storage.WriteStateAsync(StateName, grainId, concurrentState);
 
         await Assert.ThrowsExactlyAsync<InconsistentStateException>(
-            () => _storage.ClearStateAsync(StateName, grainId, state));
+            () => storage.ClearStateAsync(StateName, grainId, state));
     }
 
-    [TestMethod]
-    public async Task Clear_NonExistentGrain_IsNoOp()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task Clear_NonExistentGrain_IsNoOp(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreSignalCorrelationGrainStorage(fixture.CommandFactory);
+
         var grainId = NewGrainId("noop");
         var state = CreateEmptyGrainState();
 
-        await _storage.ClearStateAsync(StateName, grainId, state);
+        await storage.ClearStateAsync(StateName, grainId, state);
 
         Assert.IsNull(state.ETag);
         Assert.IsFalse(state.RecordExists);
     }
 
-    [TestMethod]
-    public async Task Read_NonExistentKey_LeavesStateUnchanged()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task Read_NonExistentKey_LeavesStateUnchanged(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreSignalCorrelationGrainStorage(fixture.CommandFactory);
+
         var grainId = NewGrainId("missing");
         var state = CreateEmptyGrainState();
 
-        await _storage.ReadStateAsync(StateName, grainId, state);
+        await storage.ReadStateAsync(StateName, grainId, state);
 
         Assert.IsNull(state.ETag);
         Assert.IsFalse(state.RecordExists);
     }
 
-    [TestMethod]
-    public async Task DifferentGrainIds_AreIsolated()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task DifferentGrainIds_AreIsolated(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreSignalCorrelationGrainStorage(fixture.CommandFactory);
+
         var grainId1 = NewGrainId("sigA");
         var grainId2 = NewGrainId("sigB");
 
@@ -209,13 +232,13 @@ public class EfCoreSignalCorrelationGrainStorageTests
         var state2 = CreateGrainState(
             new SignalSubscription(id2, "actB", Guid.NewGuid()));
 
-        await _storage.WriteStateAsync(StateName, grainId1, state1);
-        await _storage.WriteStateAsync(StateName, grainId2, state2);
+        await storage.WriteStateAsync(StateName, grainId1, state1);
+        await storage.WriteStateAsync(StateName, grainId2, state2);
 
         var read1 = CreateEmptyGrainState();
         var read2 = CreateEmptyGrainState();
-        await _storage.ReadStateAsync(StateName, grainId1, read1);
-        await _storage.ReadStateAsync(StateName, grainId2, read2);
+        await storage.ReadStateAsync(StateName, grainId1, read1);
+        await storage.ReadStateAsync(StateName, grainId2, read2);
 
         Assert.AreEqual(1, read1.State.Subscriptions.Count);
         Assert.AreEqual(id1, read1.State.Subscriptions[0].WorkflowInstanceId);
@@ -223,22 +246,27 @@ public class EfCoreSignalCorrelationGrainStorageTests
         Assert.AreEqual(id2, read2.State.Subscriptions[0].WorkflowInstanceId);
     }
 
-    [TestMethod]
-    public async Task WriteClearWrite_ReCreatesSameGrainId()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task WriteClearWrite_ReCreatesSameGrainId(PersistenceProvider provider)
     {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var storage = new EfCoreSignalCorrelationGrainStorage(fixture.CommandFactory);
+
         var grainId = NewGrainId("recreate");
         var state = CreateGrainState(
             new SignalSubscription(Guid.NewGuid(), "act1", Guid.NewGuid()));
-        await _storage.WriteStateAsync(StateName, grainId, state);
+        await storage.WriteStateAsync(StateName, grainId, state);
 
-        await _storage.ClearStateAsync(StateName, grainId, state);
+        await storage.ClearStateAsync(StateName, grainId, state);
 
         var newState = CreateGrainState(
             new SignalSubscription(Guid.NewGuid(), "act2", Guid.NewGuid()));
-        await _storage.WriteStateAsync(StateName, grainId, newState);
+        await storage.WriteStateAsync(StateName, grainId, newState);
 
         var readState = CreateEmptyGrainState();
-        await _storage.ReadStateAsync(StateName, grainId, readState);
+        await storage.ReadStateAsync(StateName, grainId, readState);
 
         Assert.AreEqual(1, readState.State.Subscriptions.Count);
         Assert.AreEqual("act2", readState.State.Subscriptions[0].ActivityId);

--- a/src/Fleans/Fleans.Persistence.Tests/Fleans.Persistence.Tests.csproj
+++ b/src/Fleans/Fleans.Persistence.Tests/Fleans.Persistence.Tests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="MSTest" Version="4.0.1" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.11.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -20,6 +21,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Fleans.Persistence\Fleans.Persistence.csproj" />
     <ProjectReference Include="..\Fleans.Persistence.Sqlite\Fleans.Persistence.Sqlite.csproj" />
+    <ProjectReference Include="..\Fleans.Persistence.PostgreSql\Fleans.Persistence.PostgreSql.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Fleans/Fleans.Persistence.Tests/Infrastructure/AssemblyInit.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/Infrastructure/AssemblyInit.cs
@@ -1,0 +1,12 @@
+namespace Fleans.Persistence.Tests.Infrastructure;
+
+/// <summary>
+/// Wires the assembly-level <c>[AssemblyCleanup]</c> hook for stopping the shared
+/// PostgreSQL container if any test in the assembly started it.
+/// </summary>
+[TestClass]
+public static class AssemblyInit
+{
+    [AssemblyCleanup]
+    public static async Task CleanupAsync() => await PostgresContainerFixture.DisposeAsync();
+}

--- a/src/Fleans/Fleans.Persistence.Tests/Infrastructure/IPersistenceTestFixture.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/Infrastructure/IPersistenceTestFixture.cs
@@ -1,0 +1,15 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Fleans.Persistence.Tests.Infrastructure;
+
+/// <summary>
+/// Per-row disposable handle returned by <see cref="TestFixtureFactory"/>. Exposes the
+/// command and query <see cref="IDbContextFactory{TContext}"/> the test class needs to
+/// construct EF-backed grain storage and repository components.
+/// </summary>
+public interface IPersistenceTestFixture : IAsyncDisposable
+{
+    PersistenceProvider Provider { get; }
+    IDbContextFactory<FleanCommandDbContext> CommandFactory { get; }
+    IDbContextFactory<FleanQueryDbContext> QueryFactory { get; }
+}

--- a/src/Fleans/Fleans.Persistence.Tests/Infrastructure/PersistenceProvider.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/Infrastructure/PersistenceProvider.cs
@@ -1,0 +1,10 @@
+namespace Fleans.Persistence.Tests.Infrastructure;
+
+/// <summary>
+/// Persistence backends exercised by parametrised tests.
+/// </summary>
+public enum PersistenceProvider
+{
+    Sqlite,
+    Postgres,
+}

--- a/src/Fleans/Fleans.Persistence.Tests/Infrastructure/PersistenceTestBase.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/Infrastructure/PersistenceTestBase.cs
@@ -1,0 +1,124 @@
+using Fleans.Persistence.PostgreSql;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+
+namespace Fleans.Persistence.Tests.Infrastructure;
+
+/// <summary>
+/// Base class for parametrised <see cref="PersistenceProvider"/> tests. Owns the
+/// per-class PostgreSQL database lifecycle: <c>[ClassInitialize]</c> creates a fresh
+/// <c>fleans_test_&lt;guid&gt;</c> database and runs <see cref="DatabaseFacade.MigrateAsync"/>;
+/// <c>[TestInitialize]</c> truncates the model tables for per-test isolation;
+/// <c>[ClassCleanup]</c> drops the database with <c>WITH (FORCE)</c>.
+///
+/// PG state is populated only when <c>FLEANS_PG_TESTS=1</c>; the SQLite path is unaffected.
+///
+/// MSTest execution is single-threaded by default. If
+/// <c>[Parallelize(Scope = ExecutionScope.ClassLevel)]</c> is ever enabled, the static
+/// fields below need to be promoted to a <c>ConcurrentDictionary&lt;Type,…&gt;</c> keyed
+/// on the concrete derived class type to prevent races between sibling classes.
+/// </summary>
+public abstract class PersistenceTestBase
+{
+    protected internal static string PgDbName = string.Empty;
+    protected internal static string PgConnectionString = string.Empty;
+    protected internal static NpgsqlDataSource? PgCommandDataSource;
+    protected internal static IReadOnlyList<string> CommandModelTables = Array.Empty<string>();
+    protected internal static IReadOnlyList<string> QueryModelTables = Array.Empty<string>();
+
+    protected static bool PgEnabled => PostgresContainerFixture.IsEnabled;
+
+    [ClassInitialize(InheritanceBehavior.BeforeEachDerivedClass)]
+    public static async Task InitClassAsync(TestContext _)
+    {
+        if (!PgEnabled) return;
+
+        PgDbName = $"fleans_test_{Guid.NewGuid():N}";
+        await using (var admin = new NpgsqlConnection(PostgresContainerFixture.ContainerConnectionString))
+        {
+            await admin.OpenAsync();
+            await using var cmd = new NpgsqlCommand($"CREATE DATABASE \"{PgDbName}\"", admin);
+            await cmd.ExecuteNonQueryAsync();
+        }
+        PgConnectionString = PostgresContainerFixture.BuildConnectionString(PgDbName);
+        PgCommandDataSource = NpgsqlDataSource.Create(PgConnectionString);
+
+        await using (var commandCtx = new FleanCommandDbContext(BuildCommandOptions(PgCommandDataSource)))
+        {
+            await commandCtx.Database.MigrateAsync();
+            CommandModelTables = commandCtx.Model.GetEntityTypes()
+                .Select(t => t.GetTableName())
+                .Where(n => !string.IsNullOrEmpty(n))
+                .Distinct()
+                .ToList()!;
+        }
+
+        await using (var queryCtx = new FleanQueryDbContext(BuildQueryOptions(PgCommandDataSource)))
+        {
+            QueryModelTables = queryCtx.Model.GetEntityTypes()
+                .Select(t => t.GetTableName())
+                .Where(n => !string.IsNullOrEmpty(n))
+                .Distinct()
+                .ToList()!;
+        }
+    }
+
+    [ClassCleanup(InheritanceBehavior.BeforeEachDerivedClass)]
+    public static async Task CleanupClassAsync()
+    {
+        if (!PgEnabled || string.IsNullOrEmpty(PgDbName)) return;
+
+        if (PgCommandDataSource is { } ds)
+        {
+            await ds.DisposeAsync();
+            PgCommandDataSource = null;
+        }
+
+        await using var admin = new NpgsqlConnection(PostgresContainerFixture.ContainerConnectionString);
+        await admin.OpenAsync();
+        await using var cmd = new NpgsqlCommand(
+            $"DROP DATABASE IF EXISTS \"{PgDbName}\" WITH (FORCE)", admin);
+        await cmd.ExecuteNonQueryAsync();
+
+        PgDbName = string.Empty;
+        PgConnectionString = string.Empty;
+        CommandModelTables = Array.Empty<string>();
+        QueryModelTables = Array.Empty<string>();
+    }
+
+    /// <summary>
+    /// Truncates every model-derived table in the per-class PG database to give each
+    /// <c>[TestMethod]</c> a clean slate. SQLite rows are unaffected — they create a
+    /// fresh in-memory database per fixture.
+    /// </summary>
+    [TestInitialize]
+    public virtual async Task TruncateAsync()
+    {
+        if (!PgEnabled || PgCommandDataSource is null) return;
+
+        var allTables = CommandModelTables
+            .Concat(QueryModelTables)
+            .Distinct()
+            .Select(n => $"\"{n}\"");
+        var tables = string.Join(", ", allTables);
+        if (string.IsNullOrEmpty(tables)) return;
+
+        await using var conn = PgCommandDataSource.CreateConnection();
+        await conn.OpenAsync();
+        await using var cmd = new NpgsqlCommand(
+            $"TRUNCATE TABLE {tables} RESTART IDENTITY CASCADE", conn);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    /// <summary>
+    /// Builds command-context options against the supplied data source using the
+    /// production <c>UseFleansPostgres</c> extension — guarantees the
+    /// <c>PostgresModelCustomizer</c> is applied and migrations resolve from
+    /// <c>Fleans.Persistence.PostgreSql</c>.
+    /// </summary>
+    protected internal static DbContextOptions<FleanCommandDbContext> BuildCommandOptions(NpgsqlDataSource ds) =>
+        new DbContextOptionsBuilder<FleanCommandDbContext>().UseFleansPostgres(ds).Options;
+
+    protected internal static DbContextOptions<FleanQueryDbContext> BuildQueryOptions(NpgsqlDataSource ds) =>
+        new DbContextOptionsBuilder<FleanQueryDbContext>().UseFleansPostgres(ds).Options;
+}

--- a/src/Fleans/Fleans.Persistence.Tests/Infrastructure/PostgresContainerFixture.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/Infrastructure/PostgresContainerFixture.cs
@@ -1,0 +1,112 @@
+using Testcontainers.PostgreSql;
+
+namespace Fleans.Persistence.Tests.Infrastructure;
+
+/// <summary>
+/// Owns a single <see cref="PostgreSqlContainer"/> for the assembly. The container starts
+/// lazily on first PG fixture request — Docker-less developers running only SQLite rows
+/// pay zero startup cost. Disposed via <see cref="AssemblyInit"/>'s
+/// <c>[AssemblyCleanup]</c>.
+/// </summary>
+internal static class PostgresContainerFixture
+{
+    /// <summary>
+    /// Image pinned for reproducible tests. Bump when the production deployment target
+    /// (Aspire <c>Aspire.Hosting.PostgreSQL</c> default) moves; see
+    /// <c>CLAUDE.md § Persistence Providers</c>.
+    /// </summary>
+    public const string PostgresImage = "postgres:16-alpine";
+
+    private const string BootstrapDatabaseName = "fleans_bootstrap";
+
+    private static readonly SemaphoreSlim s_lock = new(1, 1);
+    private static PostgreSqlContainer? s_container;
+
+    /// <summary>
+    /// True when <c>FLEANS_PG_TESTS=1</c> — gates container startup and PG row execution.
+    /// </summary>
+    public static bool IsEnabled =>
+        string.Equals(
+            Environment.GetEnvironmentVariable("FLEANS_PG_TESTS"),
+            "1",
+            StringComparison.Ordinal);
+
+    /// <summary>
+    /// Connection string pointed at the container's bootstrap database. Use this only for
+    /// administrative operations (CREATE/DROP DATABASE); per-test work uses
+    /// <see cref="BuildConnectionString"/>.
+    /// </summary>
+    public static string ContainerConnectionString => EnsureStarted().GetConnectionString();
+
+    /// <summary>
+    /// Builds a connection string targeting the named per-class database on the running
+    /// container.
+    /// </summary>
+    public static string BuildConnectionString(string databaseName)
+    {
+        var container = EnsureStarted();
+        var template = container.GetConnectionString();
+        var builder = new Npgsql.NpgsqlConnectionStringBuilder(template)
+        {
+            Database = databaseName,
+        };
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Stops the container if it was started. Called by <see cref="AssemblyInit"/>'s
+    /// <c>[AssemblyCleanup]</c>.
+    /// </summary>
+    public static async Task DisposeAsync()
+    {
+        PostgreSqlContainer? container;
+        await s_lock.WaitAsync();
+        try
+        {
+            container = s_container;
+            s_container = null;
+        }
+        finally
+        {
+            s_lock.Release();
+        }
+
+        if (container is not null)
+        {
+            await container.DisposeAsync();
+        }
+    }
+
+    private static PostgreSqlContainer EnsureStarted()
+    {
+        if (!IsEnabled)
+        {
+            throw new InvalidOperationException(
+                "PostgresContainerFixture accessed without FLEANS_PG_TESTS=1.");
+        }
+
+        if (s_container is { } existing)
+        {
+            return existing;
+        }
+
+        s_lock.Wait();
+        try
+        {
+            if (s_container is null)
+            {
+                var container = new PostgreSqlBuilder()
+                    .WithImage(PostgresImage)
+                    .WithDatabase(BootstrapDatabaseName)
+                    .Build();
+                container.StartAsync().GetAwaiter().GetResult();
+                s_container = container;
+            }
+            return s_container;
+        }
+        finally
+        {
+            s_lock.Release();
+        }
+    }
+}

--- a/src/Fleans/Fleans.Persistence.Tests/Infrastructure/PostgresRowFixture.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/Infrastructure/PostgresRowFixture.cs
@@ -1,0 +1,47 @@
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+
+namespace Fleans.Persistence.Tests.Infrastructure;
+
+/// <summary>
+/// Per-row fixture for <see cref="PersistenceProvider.Postgres"/>. Reads the per-class
+/// connection from <see cref="PersistenceTestBase"/> static state and wraps it in a
+/// disposable that exposes the EF factories. Connection pool resources owned by the
+/// underlying <see cref="NpgsqlDataSource"/> on <see cref="PersistenceTestBase"/> are
+/// released by <see cref="PersistenceTestBase.CleanupClassAsync"/>.
+/// </summary>
+internal sealed class PostgresRowFixture : IPersistenceTestFixture
+{
+    private PostgresRowFixture(
+        IDbContextFactory<FleanCommandDbContext> commandFactory,
+        IDbContextFactory<FleanQueryDbContext> queryFactory)
+    {
+        CommandFactory = commandFactory;
+        QueryFactory = queryFactory;
+    }
+
+    public PersistenceProvider Provider => PersistenceProvider.Postgres;
+
+    public IDbContextFactory<FleanCommandDbContext> CommandFactory { get; }
+
+    public IDbContextFactory<FleanQueryDbContext> QueryFactory { get; }
+
+    public static Task<IPersistenceTestFixture> CreateAsync()
+    {
+        if (PersistenceTestBase.PgCommandDataSource is null)
+        {
+            throw new InvalidOperationException(
+                "PostgresRowFixture requires PersistenceTestBase.InitClassAsync to have run; " +
+                "ensure the test class extends PersistenceTestBase.");
+        }
+
+        var commandOptions = PersistenceTestBase.BuildCommandOptions(PersistenceTestBase.PgCommandDataSource);
+        var queryOptions = PersistenceTestBase.BuildQueryOptions(PersistenceTestBase.PgCommandDataSource);
+        var commandFactory = new TestDbContextFactory(commandOptions);
+        var queryFactory = new TestQueryDbContextFactory(queryOptions);
+        IPersistenceTestFixture fixture = new PostgresRowFixture(commandFactory, queryFactory);
+        return Task.FromResult(fixture);
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+}

--- a/src/Fleans/Fleans.Persistence.Tests/Infrastructure/Skip.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/Infrastructure/Skip.cs
@@ -1,0 +1,18 @@
+namespace Fleans.Persistence.Tests.Infrastructure;
+
+/// <summary>
+/// Helper for skipping <see cref="PersistenceProvider.Postgres"/> rows when
+/// <c>FLEANS_PG_TESTS</c> is not set to <c>1</c>. Calls
+/// <see cref="Assert.Inconclusive(string)"/> — non-failing in MSTest, so the default
+/// developer loop stays Docker-free.
+/// </summary>
+public static class Skip
+{
+    public static void IfPostgresUnavailable(PersistenceProvider provider)
+    {
+        if (provider == PersistenceProvider.Postgres && !PostgresContainerFixture.IsEnabled)
+        {
+            Assert.Inconclusive("FLEANS_PG_TESTS != 1 — skipping Postgres row.");
+        }
+    }
+}

--- a/src/Fleans/Fleans.Persistence.Tests/Infrastructure/SqliteRowFixture.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/Infrastructure/SqliteRowFixture.cs
@@ -1,0 +1,60 @@
+using Fleans.Persistence.Sqlite;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace Fleans.Persistence.Tests.Infrastructure;
+
+/// <summary>
+/// Per-row fixture for <see cref="PersistenceProvider.Sqlite"/>. Owns an in-memory
+/// SQLite connection that is held open for the lifetime of the fixture so EF Core sees a
+/// stable schema across DbContexts.
+/// </summary>
+internal sealed class SqliteRowFixture : IPersistenceTestFixture
+{
+    private readonly SqliteConnection _connection;
+
+    private SqliteRowFixture(
+        SqliteConnection connection,
+        IDbContextFactory<FleanCommandDbContext> commandFactory,
+        IDbContextFactory<FleanQueryDbContext> queryFactory)
+    {
+        _connection = connection;
+        CommandFactory = commandFactory;
+        QueryFactory = queryFactory;
+    }
+
+    public PersistenceProvider Provider => PersistenceProvider.Sqlite;
+
+    public IDbContextFactory<FleanCommandDbContext> CommandFactory { get; }
+
+    public IDbContextFactory<FleanQueryDbContext> QueryFactory { get; }
+
+    public static async Task<IPersistenceTestFixture> CreateAsync()
+    {
+        var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync();
+
+        var commandOptions = new DbContextOptionsBuilder<FleanCommandDbContext>()
+            .UseFleansSqlite(connection)
+            .Options;
+        var queryOptions = new DbContextOptionsBuilder<FleanQueryDbContext>()
+            .UseFleansSqlite(connection)
+            .Options;
+
+        var commandFactory = new TestDbContextFactory(commandOptions);
+        var queryFactory = new TestQueryDbContextFactory(queryOptions);
+
+        await using (var ctx = await commandFactory.CreateDbContextAsync())
+        {
+            await ctx.Database.EnsureCreatedAsync();
+        }
+
+        return new SqliteRowFixture(connection, commandFactory, queryFactory);
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _connection.Dispose();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/Fleans/Fleans.Persistence.Tests/Infrastructure/TestFixtureFactory.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/Infrastructure/TestFixtureFactory.cs
@@ -1,0 +1,21 @@
+namespace Fleans.Persistence.Tests.Infrastructure;
+
+/// <summary>
+/// Builds a per-row <see cref="IPersistenceTestFixture"/> for the chosen provider.
+/// Calls <see cref="Skip.IfPostgresUnavailable(PersistenceProvider)"/> implicitly so
+/// that Postgres rows on a Docker-less developer loop surface as
+/// <c>Inconclusive</c> rather than <c>Failed</c>.
+/// </summary>
+public static class TestFixtureFactory
+{
+    public static Task<IPersistenceTestFixture> CreateAsync(PersistenceProvider provider)
+    {
+        Skip.IfPostgresUnavailable(provider);
+        return provider switch
+        {
+            PersistenceProvider.Sqlite => SqliteRowFixture.CreateAsync(),
+            PersistenceProvider.Postgres => PostgresRowFixture.CreateAsync(),
+            _ => throw new ArgumentOutOfRangeException(nameof(provider), provider, "Unknown provider"),
+        };
+    }
+}

--- a/src/Fleans/Fleans.Persistence.Tests/WorkflowQueryServiceTests.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/WorkflowQueryServiceTests.cs
@@ -6,8 +6,7 @@ using Fleans.Domain.Activities;
 using Fleans.Domain.Sequences;
 using Fleans.Domain.States;
 using Fleans.Persistence;
-using Microsoft.Data.Sqlite;
-using Fleans.Persistence.Sqlite;
+using Fleans.Persistence.Tests.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using Sieve.Models;
@@ -16,63 +15,48 @@ using Sieve.Services;
 namespace Fleans.Persistence.Tests;
 
 [TestClass]
-public class WorkflowQueryServiceTests
+[TestCategory("Postgres")]
+public class WorkflowQueryServiceTests : PersistenceTestBase
 {
-    private SqliteConnection _connection = null!;
-    private IDbContextFactory<FleanCommandDbContext> _commandDbContextFactory = null!;
-    private IDbContextFactory<FleanQueryDbContext> _queryDbContextFactory = null!;
-    private IWorkflowQueryService _service = null!;
-
-    [TestInitialize]
-    public void Setup()
+    private static (IWorkflowQueryService Service, IDbContextFactory<FleanCommandDbContext> CommandFactory)
+        BuildService(IPersistenceTestFixture fixture)
     {
-        _connection = new SqliteConnection("DataSource=:memory:");
-        _connection.Open();
-
-        var commandOptions = new DbContextOptionsBuilder<FleanCommandDbContext>()
-            .UseFleansSqlite(_connection)
-            .Options;
-
-        var queryOptions = new DbContextOptionsBuilder<FleanQueryDbContext>()
-            .UseFleansSqlite(_connection)
-            .Options;
-
-        _commandDbContextFactory = new TestCommandDbContextFactory(commandOptions);
-        _queryDbContextFactory = new TestQueryDbContextFactory(queryOptions);
         var sieveOptions = Options.Create(new SieveOptions
         {
             DefaultPageSize = 20,
             MaxPageSize = 100
         });
         ISieveProcessor sieveProcessor = new ApplicationSieveProcessor(sieveOptions);
-        _service = new WorkflowQueryService(_queryDbContextFactory, sieveProcessor);
-
-        using var db = _commandDbContextFactory.CreateDbContext();
-        db.Database.EnsureCreated();
-    }
-
-    [TestCleanup]
-    public void Cleanup()
-    {
-        _connection.Dispose();
+        var service = new WorkflowQueryService(fixture.QueryFactory, sieveProcessor);
+        return (service, fixture.CommandFactory);
     }
 
     // ─────────────────────────────────────────────────
     // GetStateSnapshot
     // ─────────────────────────────────────────────────
 
-    [TestMethod]
-    public async Task GetStateSnapshot_ReturnsNull_WhenInstanceDoesNotExist()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetStateSnapshot_ReturnsNull_WhenInstanceDoesNotExist(PersistenceProvider provider)
     {
-        var result = await _service.GetStateSnapshot(Guid.NewGuid());
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        var result = await service.GetStateSnapshot(Guid.NewGuid());
 
         Assert.IsNull(result);
     }
 
-    [TestMethod]
-    public async Task GetStateSnapshot_ReturnsSnapshot_WithActiveAndCompletedActivities()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetStateSnapshot_ReturnsSnapshot_WithActiveAndCompletedActivities(PersistenceProvider provider)
     {
-        using var db = _commandDbContextFactory.CreateDbContext();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        using var db = commandFactory.CreateDbContext();
 
         var instanceId = Guid.NewGuid();
         var processDefId = "proc:1:ts";
@@ -97,7 +81,7 @@ public class WorkflowQueryServiceTests
         db.WorkflowActivityInstanceEntries.Add(completedEntry);
         await db.SaveChangesAsync();
 
-        var result = await _service.GetStateSnapshot(instanceId);
+        var result = await service.GetStateSnapshot(instanceId);
 
         Assert.IsNotNull(result);
         Assert.AreEqual(1, result.ActiveActivityIds.Count);
@@ -112,10 +96,15 @@ public class WorkflowQueryServiceTests
         Assert.IsTrue(result.CompletedActivities[0].IsCompleted);
     }
 
-    [TestMethod]
-    public async Task GetStateSnapshot_ReturnsSnapshot_WithVariables()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetStateSnapshot_ReturnsSnapshot_WithVariables(PersistenceProvider provider)
     {
-        using var db = _commandDbContextFactory.CreateDbContext();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        using var db = commandFactory.CreateDbContext();
 
         var instanceId = Guid.NewGuid();
         await SeedWorkflowInstance(db, instanceId, isStarted: true);
@@ -132,7 +121,7 @@ public class WorkflowQueryServiceTests
         db.Entry(vars).Property(e => e.Variables).CurrentValue = (ExpandoObject)expando;
         await db.SaveChangesAsync();
 
-        var result = await _service.GetStateSnapshot(instanceId);
+        var result = await service.GetStateSnapshot(instanceId);
 
         Assert.IsNotNull(result);
         Assert.AreEqual(1, result.VariableStates.Count);
@@ -141,10 +130,15 @@ public class WorkflowQueryServiceTests
         Assert.AreEqual("42", result.VariableStates[0].Variables["key2"]);
     }
 
-    [TestMethod]
-    public async Task GetStateSnapshot_ReturnsSnapshot_WithConditionSequences()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetStateSnapshot_ReturnsSnapshot_WithConditionSequences(PersistenceProvider provider)
     {
-        using var db = _commandDbContextFactory.CreateDbContext();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        using var db = commandFactory.CreateDbContext();
 
         var instanceId = Guid.NewGuid();
         var processDefId = "proc:1:ts";
@@ -159,7 +153,7 @@ public class WorkflowQueryServiceTests
         db.Entry(cs).Property(e => e.IsEvaluated).CurrentValue = true;
         await db.SaveChangesAsync();
 
-        var result = await _service.GetStateSnapshot(instanceId);
+        var result = await service.GetStateSnapshot(instanceId);
 
         Assert.IsNotNull(result);
         Assert.AreEqual(1, result.ConditionSequences.Count);
@@ -169,26 +163,36 @@ public class WorkflowQueryServiceTests
         Assert.AreEqual("x > 10", result.ConditionSequences[0].Condition);
     }
 
-    [TestMethod]
-    public async Task GetStateSnapshot_ReturnsSnapshot_WithProcessDefinitionId()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetStateSnapshot_ReturnsSnapshot_WithProcessDefinitionId(PersistenceProvider provider)
     {
-        using var db = _commandDbContextFactory.CreateDbContext();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        using var db = commandFactory.CreateDbContext();
 
         var instanceId = Guid.NewGuid();
         var processDefId = "myproc:1:ts";
         await SeedProcessDefinition(db, processDefId, "myproc", 1);
         await SeedWorkflowInstance(db, instanceId, processDefinitionId: processDefId, isStarted: true);
 
-        var result = await _service.GetStateSnapshot(instanceId);
+        var result = await service.GetStateSnapshot(instanceId);
 
         Assert.IsNotNull(result);
         Assert.AreEqual("myproc:1:ts", result.ProcessDefinitionId);
     }
 
-    [TestMethod]
-    public async Task GetStateSnapshot_ReturnsSnapshot_WithTimestamps()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetStateSnapshot_ReturnsSnapshot_WithTimestamps(PersistenceProvider provider)
     {
-        using var db = _commandDbContextFactory.CreateDbContext();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        using var db = commandFactory.CreateDbContext();
 
         var instanceId = Guid.NewGuid();
         var createdAt = new DateTimeOffset(2026, 1, 1, 10, 0, 0, TimeSpan.Zero);
@@ -199,7 +203,7 @@ public class WorkflowQueryServiceTests
             isStarted: true, isCompleted: true,
             createdAt: createdAt, executionStartedAt: executionStartedAt, completedAt: completedAt);
 
-        var result = await _service.GetStateSnapshot(instanceId);
+        var result = await service.GetStateSnapshot(instanceId);
 
         Assert.IsNotNull(result);
         Assert.IsTrue(result.IsStarted);
@@ -209,10 +213,15 @@ public class WorkflowQueryServiceTests
         Assert.AreEqual(completedAt, result.CompletedAt);
     }
 
-    [TestMethod]
-    public async Task GetStateSnapshot_ReturnsErrorState_OnFailedActivity()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetStateSnapshot_ReturnsErrorState_OnFailedActivity(PersistenceProvider provider)
     {
-        using var db = _commandDbContextFactory.CreateDbContext();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        using var db = commandFactory.CreateDbContext();
 
         var instanceId = Guid.NewGuid();
         await SeedWorkflowInstance(db, instanceId, isStarted: true);
@@ -225,7 +234,7 @@ public class WorkflowQueryServiceTests
         db.WorkflowActivityInstanceEntries.Add(entry);
         await db.SaveChangesAsync();
 
-        var result = await _service.GetStateSnapshot(instanceId);
+        var result = await service.GetStateSnapshot(instanceId);
 
         Assert.IsNotNull(result);
         Assert.AreEqual(1, result.CompletedActivities.Count);
@@ -239,17 +248,22 @@ public class WorkflowQueryServiceTests
     // GetAllProcessDefinitions
     // ─────────────────────────────────────────────────
 
-    [TestMethod]
-    public async Task GetAllProcessDefinitions_ReturnsAll_OrderedByKeyThenVersion()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetAllProcessDefinitions_ReturnsAll_OrderedByKeyThenVersion(PersistenceProvider provider)
     {
-        using var db = _commandDbContextFactory.CreateDbContext();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        using var db = commandFactory.CreateDbContext();
 
         await SeedProcessDefinition(db, "beta:2:ts", "beta", 2);
         await SeedProcessDefinition(db, "alpha:1:ts", "alpha", 1);
         await SeedProcessDefinition(db, "beta:1:ts", "beta", 1);
         await SeedProcessDefinition(db, "alpha:2:ts", "alpha", 2);
 
-        var results = await _service.GetAllProcessDefinitions();
+        var results = await service.GetAllProcessDefinitions();
 
         Assert.AreEqual(4, results.Count);
         Assert.AreEqual("alpha", results[0].ProcessDefinitionKey);
@@ -262,10 +276,15 @@ public class WorkflowQueryServiceTests
         Assert.AreEqual(2, results[3].Version);
     }
 
-    [TestMethod]
-    public async Task GetAllProcessDefinitions_ReturnsEmpty_WhenNoneExist()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetAllProcessDefinitions_ReturnsEmpty_WhenNoneExist(PersistenceProvider provider)
     {
-        var results = await _service.GetAllProcessDefinitions();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        var results = await service.GetAllProcessDefinitions();
 
         Assert.AreEqual(0, results.Count);
     }
@@ -274,10 +293,15 @@ public class WorkflowQueryServiceTests
     // GetInstancesByKey
     // ─────────────────────────────────────────────────
 
-    [TestMethod]
-    public async Task GetInstancesByKey_ReturnsMatchingInstances()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetInstancesByKey_ReturnsMatchingInstances(PersistenceProvider provider)
     {
-        using var db = _commandDbContextFactory.CreateDbContext();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        using var db = commandFactory.CreateDbContext();
 
         await SeedProcessDefinition(db, "mykey:1:ts", "mykey", 1);
         await SeedProcessDefinition(db, "mykey:2:ts", "mykey", 2);
@@ -290,7 +314,7 @@ public class WorkflowQueryServiceTests
         await SeedWorkflowInstance(db, id2, processDefinitionId: "mykey:2:ts", isStarted: true, isCompleted: true);
         await SeedWorkflowInstance(db, id3, processDefinitionId: "other:1:ts", isStarted: true);
 
-        var results = await _service.GetInstancesByKey("mykey", new PageRequest(PageSize: 100));
+        var results = await service.GetInstancesByKey("mykey", new PageRequest(PageSize: 100));
 
         Assert.AreEqual(2, results.Items.Count);
         var instanceIds = results.Items.Select(r => r.InstanceId).ToList();
@@ -299,15 +323,20 @@ public class WorkflowQueryServiceTests
         CollectionAssert.DoesNotContain(instanceIds, id3);
     }
 
-    [TestMethod]
-    public async Task GetInstancesByKey_ReturnsEmpty_WhenNoMatch()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetInstancesByKey_ReturnsEmpty_WhenNoMatch(PersistenceProvider provider)
     {
-        using var db = _commandDbContextFactory.CreateDbContext();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        using var db = commandFactory.CreateDbContext();
 
         await SeedProcessDefinition(db, "existing:1:ts", "existing", 1);
         await SeedWorkflowInstance(db, Guid.NewGuid(), processDefinitionId: "existing:1:ts", isStarted: true);
 
-        var results = await _service.GetInstancesByKey("nonexistent", new PageRequest());
+        var results = await service.GetInstancesByKey("nonexistent", new PageRequest());
 
         Assert.AreEqual(0, results.Items.Count);
     }
@@ -316,10 +345,15 @@ public class WorkflowQueryServiceTests
     // GetInstancesByKeyAndVersion
     // ─────────────────────────────────────────────────
 
-    [TestMethod]
-    public async Task GetInstancesByKeyAndVersion_ReturnsMatchingInstances()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetInstancesByKeyAndVersion_ReturnsMatchingInstances(PersistenceProvider provider)
     {
-        using var db = _commandDbContextFactory.CreateDbContext();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        using var db = commandFactory.CreateDbContext();
 
         await SeedProcessDefinition(db, "key:1:ts", "key", 1);
         await SeedProcessDefinition(db, "key:2:ts", "key", 2);
@@ -329,22 +363,27 @@ public class WorkflowQueryServiceTests
         await SeedWorkflowInstance(db, v1Instance, processDefinitionId: "key:1:ts", isStarted: true);
         await SeedWorkflowInstance(db, v2Instance, processDefinitionId: "key:2:ts", isStarted: true);
 
-        var results = await _service.GetInstancesByKeyAndVersion("key", 1, new PageRequest());
+        var results = await service.GetInstancesByKeyAndVersion("key", 1, new PageRequest());
 
         Assert.AreEqual(1, results.Items.Count);
         Assert.AreEqual(v1Instance, results.Items[0].InstanceId);
         Assert.AreEqual("key:1:ts", results.Items[0].ProcessDefinitionId);
     }
 
-    [TestMethod]
-    public async Task GetInstancesByKeyAndVersion_ReturnsEmpty_WhenVersionNotFound()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetInstancesByKeyAndVersion_ReturnsEmpty_WhenVersionNotFound(PersistenceProvider provider)
     {
-        using var db = _commandDbContextFactory.CreateDbContext();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        using var db = commandFactory.CreateDbContext();
 
         await SeedProcessDefinition(db, "key:1:ts", "key", 1);
         await SeedWorkflowInstance(db, Guid.NewGuid(), processDefinitionId: "key:1:ts", isStarted: true);
 
-        var results = await _service.GetInstancesByKeyAndVersion("key", 99, new PageRequest());
+        var results = await service.GetInstancesByKeyAndVersion("key", 99, new PageRequest());
 
         Assert.AreEqual(0, results.Items.Count);
     }
@@ -353,16 +392,21 @@ public class WorkflowQueryServiceTests
     // GetInstancesByKey (paginated)
     // ─────────────────────────────────────────────────
 
-    [TestMethod]
-    public async Task GetInstancesByKey_Paginated_ReturnsPagedResult()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetInstancesByKey_Paginated_ReturnsPagedResult(PersistenceProvider provider)
     {
-        using var db = _commandDbContextFactory.CreateDbContext();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        using var db = commandFactory.CreateDbContext();
 
         await SeedProcessDefinition(db, "paged:1:ts", "paged", 1);
         for (int i = 0; i < 5; i++)
             await SeedWorkflowInstance(db, Guid.NewGuid(), processDefinitionId: "paged:1:ts", isStarted: true);
 
-        var page1 = await _service.GetInstancesByKey("paged", new PageRequest(Page: 1, PageSize: 2));
+        var page1 = await service.GetInstancesByKey("paged", new PageRequest(Page: 1, PageSize: 2));
 
         Assert.AreEqual(2, page1.Items.Count);
         Assert.AreEqual(5, page1.TotalCount);
@@ -370,50 +414,70 @@ public class WorkflowQueryServiceTests
         Assert.AreEqual(2, page1.PageSize);
     }
 
-    [TestMethod]
-    public async Task GetInstancesByKey_Paginated_ReturnsSecondPage()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetInstancesByKey_Paginated_ReturnsSecondPage(PersistenceProvider provider)
     {
-        using var db = _commandDbContextFactory.CreateDbContext();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        using var db = commandFactory.CreateDbContext();
 
         await SeedProcessDefinition(db, "paged2:1:ts", "paged2", 1);
         for (int i = 0; i < 5; i++)
             await SeedWorkflowInstance(db, Guid.NewGuid(), processDefinitionId: "paged2:1:ts", isStarted: true);
 
-        var page2 = await _service.GetInstancesByKey("paged2", new PageRequest(Page: 2, PageSize: 2));
+        var page2 = await service.GetInstancesByKey("paged2", new PageRequest(Page: 2, PageSize: 2));
 
         Assert.AreEqual(2, page2.Items.Count);
         Assert.AreEqual(5, page2.TotalCount);
         Assert.AreEqual(2, page2.Page);
     }
 
-    [TestMethod]
-    public async Task GetInstancesByKey_Paginated_ReturnsLastPartialPage()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetInstancesByKey_Paginated_ReturnsLastPartialPage(PersistenceProvider provider)
     {
-        using var db = _commandDbContextFactory.CreateDbContext();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        using var db = commandFactory.CreateDbContext();
 
         await SeedProcessDefinition(db, "paged3:1:ts", "paged3", 1);
         for (int i = 0; i < 5; i++)
             await SeedWorkflowInstance(db, Guid.NewGuid(), processDefinitionId: "paged3:1:ts", isStarted: true);
 
-        var page3 = await _service.GetInstancesByKey("paged3", new PageRequest(Page: 3, PageSize: 2));
+        var page3 = await service.GetInstancesByKey("paged3", new PageRequest(Page: 3, PageSize: 2));
 
         Assert.AreEqual(1, page3.Items.Count);
         Assert.AreEqual(5, page3.TotalCount);
     }
 
-    [TestMethod]
-    public async Task GetInstancesByKey_Paginated_ReturnsEmpty_WhenNoMatch()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetInstancesByKey_Paginated_ReturnsEmpty_WhenNoMatch(PersistenceProvider provider)
     {
-        var result = await _service.GetInstancesByKey("nonexistent", new PageRequest());
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        var result = await service.GetInstancesByKey("nonexistent", new PageRequest());
 
         Assert.AreEqual(0, result.Items.Count);
         Assert.AreEqual(0, result.TotalCount);
     }
 
-    [TestMethod]
-    public async Task GetInstancesByKey_Paginated_SortsByCreatedAtDescending()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetInstancesByKey_Paginated_SortsByCreatedAtDescending(PersistenceProvider provider)
     {
-        using var db = _commandDbContextFactory.CreateDbContext();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        using var db = commandFactory.CreateDbContext();
 
         await SeedProcessDefinition(db, "sorted:1:ts", "sorted", 1);
         var oldest = Guid.NewGuid();
@@ -423,7 +487,7 @@ public class WorkflowQueryServiceTests
         await SeedWorkflowInstance(db, newest, processDefinitionId: "sorted:1:ts", isStarted: true,
             createdAt: new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero));
 
-        var result = await _service.GetInstancesByKey("sorted",
+        var result = await service.GetInstancesByKey("sorted",
             new PageRequest(Sorts: "-CreatedAt"));
 
         Assert.AreEqual(2, result.Items.Count);
@@ -431,10 +495,15 @@ public class WorkflowQueryServiceTests
         Assert.AreEqual(oldest, result.Items[1].InstanceId);
     }
 
-    [TestMethod]
-    public async Task GetInstancesByKey_Paginated_FiltersCompleted()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetInstancesByKey_Paginated_FiltersCompleted(PersistenceProvider provider)
     {
-        using var db = _commandDbContextFactory.CreateDbContext();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        using var db = commandFactory.CreateDbContext();
 
         await SeedProcessDefinition(db, "filtered:1:ts", "filtered", 1);
         await SeedWorkflowInstance(db, Guid.NewGuid(), processDefinitionId: "filtered:1:ts",
@@ -444,7 +513,7 @@ public class WorkflowQueryServiceTests
         await SeedWorkflowInstance(db, Guid.NewGuid(), processDefinitionId: "filtered:1:ts",
             isStarted: true, isCompleted: false);
 
-        var result = await _service.GetInstancesByKey("filtered",
+        var result = await service.GetInstancesByKey("filtered",
             new PageRequest(Filters: "IsCompleted==true"));
 
         Assert.AreEqual(1, result.Items.Count);
@@ -452,15 +521,20 @@ public class WorkflowQueryServiceTests
         Assert.IsTrue(result.Items[0].IsCompleted);
     }
 
-    [TestMethod]
-    public async Task GetInstancesByKey_Paginated_NormalizesInvalidPage()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetInstancesByKey_Paginated_NormalizesInvalidPage(PersistenceProvider provider)
     {
-        using var db = _commandDbContextFactory.CreateDbContext();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        using var db = commandFactory.CreateDbContext();
 
         await SeedProcessDefinition(db, "norm:1:ts", "norm", 1);
         await SeedWorkflowInstance(db, Guid.NewGuid(), processDefinitionId: "norm:1:ts", isStarted: true);
 
-        var result = await _service.GetInstancesByKey("norm",
+        var result = await service.GetInstancesByKey("norm",
             new PageRequest(Page: -1, PageSize: 0));
 
         Assert.AreEqual(1, result.Page);
@@ -471,10 +545,15 @@ public class WorkflowQueryServiceTests
     // GetInstancesByKeyAndVersion (paginated)
     // ─────────────────────────────────────────────────
 
-    [TestMethod]
-    public async Task GetInstancesByKeyAndVersion_Paginated_ReturnsPagedResult()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetInstancesByKeyAndVersion_Paginated_ReturnsPagedResult(PersistenceProvider provider)
     {
-        using var db = _commandDbContextFactory.CreateDbContext();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        using var db = commandFactory.CreateDbContext();
 
         await SeedProcessDefinition(db, "pvkey:1:ts", "pvkey", 1);
         await SeedProcessDefinition(db, "pvkey:2:ts", "pvkey", 2);
@@ -483,22 +562,27 @@ public class WorkflowQueryServiceTests
             await SeedWorkflowInstance(db, Guid.NewGuid(), processDefinitionId: "pvkey:1:ts", isStarted: true);
         await SeedWorkflowInstance(db, Guid.NewGuid(), processDefinitionId: "pvkey:2:ts", isStarted: true);
 
-        var result = await _service.GetInstancesByKeyAndVersion("pvkey", 1,
+        var result = await service.GetInstancesByKeyAndVersion("pvkey", 1,
             new PageRequest(Page: 1, PageSize: 2));
 
         Assert.AreEqual(2, result.Items.Count);
         Assert.AreEqual(3, result.TotalCount);
     }
 
-    [TestMethod]
-    public async Task GetInstancesByKeyAndVersion_Paginated_ReturnsEmpty_WhenVersionNotFound()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetInstancesByKeyAndVersion_Paginated_ReturnsEmpty_WhenVersionNotFound(PersistenceProvider provider)
     {
-        using var db = _commandDbContextFactory.CreateDbContext();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        using var db = commandFactory.CreateDbContext();
 
         await SeedProcessDefinition(db, "pvkey2:1:ts", "pvkey2", 1);
         await SeedWorkflowInstance(db, Guid.NewGuid(), processDefinitionId: "pvkey2:1:ts", isStarted: true);
 
-        var result = await _service.GetInstancesByKeyAndVersion("pvkey2", 99, new PageRequest());
+        var result = await service.GetInstancesByKeyAndVersion("pvkey2", 99, new PageRequest());
 
         Assert.AreEqual(0, result.Items.Count);
         Assert.AreEqual(0, result.TotalCount);
@@ -508,10 +592,15 @@ public class WorkflowQueryServiceTests
     // GetBpmnXml
     // ─────────────────────────────────────────────────
 
-    [TestMethod]
-    public async Task GetBpmnXml_ReturnsBpmn_WhenInstanceExists()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetBpmnXml_ReturnsBpmn_WhenInstanceExists(PersistenceProvider provider)
     {
-        using var db = _commandDbContextFactory.CreateDbContext();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        using var db = commandFactory.CreateDbContext();
 
         var bpmn = "<bpmn:definitions>full xml here</bpmn:definitions>";
         await SeedProcessDefinition(db, "proc:1:ts", "proc", 1, bpmnXml: bpmn);
@@ -519,15 +608,20 @@ public class WorkflowQueryServiceTests
         var instanceId = Guid.NewGuid();
         await SeedWorkflowInstance(db, instanceId, processDefinitionId: "proc:1:ts", isStarted: true);
 
-        var result = await _service.GetBpmnXml(instanceId);
+        var result = await service.GetBpmnXml(instanceId);
 
         Assert.AreEqual(bpmn, result);
     }
 
-    [TestMethod]
-    public async Task GetBpmnXml_ReturnsNull_WhenInstanceNotFound()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetBpmnXml_ReturnsNull_WhenInstanceNotFound(PersistenceProvider provider)
     {
-        var result = await _service.GetBpmnXml(Guid.NewGuid());
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        var result = await service.GetBpmnXml(Guid.NewGuid());
 
         Assert.IsNull(result);
     }
@@ -536,16 +630,21 @@ public class WorkflowQueryServiceTests
     // GetBpmnXmlByKey
     // ─────────────────────────────────────────────────
 
-    [TestMethod]
-    public async Task GetBpmnXmlByKey_ReturnsLatestVersion()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetBpmnXmlByKey_ReturnsLatestVersion(PersistenceProvider provider)
     {
-        using var db = _commandDbContextFactory.CreateDbContext();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        using var db = commandFactory.CreateDbContext();
 
         await SeedProcessDefinition(db, "proc:1:ts", "proc", 1, bpmnXml: "<bpmn>v1</bpmn>");
         await SeedProcessDefinition(db, "proc:2:ts", "proc", 2, bpmnXml: "<bpmn>v2</bpmn>");
         await SeedProcessDefinition(db, "proc:3:ts", "proc", 3, bpmnXml: "<bpmn>v3</bpmn>");
 
-        var result = await _service.GetBpmnXmlByKey("proc");
+        var result = await service.GetBpmnXmlByKey("proc");
 
         Assert.AreEqual("<bpmn>v3</bpmn>", result);
     }
@@ -554,15 +653,20 @@ public class WorkflowQueryServiceTests
     // GetBpmnXmlByKeyAndVersion
     // ─────────────────────────────────────────────────
 
-    [TestMethod]
-    public async Task GetBpmnXmlByKeyAndVersion_ReturnsExactVersion()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetBpmnXmlByKeyAndVersion_ReturnsExactVersion(PersistenceProvider provider)
     {
-        using var db = _commandDbContextFactory.CreateDbContext();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        using var db = commandFactory.CreateDbContext();
 
         await SeedProcessDefinition(db, "proc:1:ts", "proc", 1, bpmnXml: "<bpmn>v1</bpmn>");
         await SeedProcessDefinition(db, "proc:2:ts", "proc", 2, bpmnXml: "<bpmn>v2</bpmn>");
 
-        var result = await _service.GetBpmnXmlByKeyAndVersion("proc", 1);
+        var result = await service.GetBpmnXmlByKeyAndVersion("proc", 1);
 
         Assert.AreEqual("<bpmn>v1</bpmn>", result);
     }
@@ -571,15 +675,20 @@ public class WorkflowQueryServiceTests
     // GetAllProcessDefinitions (paginated)
     // ─────────────────────────────────────────────────
 
-    [TestMethod]
-    public async Task GetAllProcessDefinitions_Paginated_ReturnsPagedResult()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetAllProcessDefinitions_Paginated_ReturnsPagedResult(PersistenceProvider provider)
     {
-        using var db = _commandDbContextFactory.CreateDbContext();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        using var db = commandFactory.CreateDbContext();
 
         for (int i = 1; i <= 5; i++)
             await SeedProcessDefinition(db, $"pagdef:key{i}:1:ts", $"key{i}", 1);
 
-        var result = await _service.GetAllProcessDefinitions(new PageRequest(Page: 1, PageSize: 2));
+        var result = await service.GetAllProcessDefinitions(new PageRequest(Page: 1, PageSize: 2));
 
         Assert.AreEqual(2, result.Items.Count);
         Assert.AreEqual(5, result.TotalCount);
@@ -587,25 +696,35 @@ public class WorkflowQueryServiceTests
         Assert.AreEqual(2, result.PageSize);
     }
 
-    [TestMethod]
-    public async Task GetAllProcessDefinitions_Paginated_ReturnsSecondPage()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetAllProcessDefinitions_Paginated_ReturnsSecondPage(PersistenceProvider provider)
     {
-        using var db = _commandDbContextFactory.CreateDbContext();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        using var db = commandFactory.CreateDbContext();
 
         for (int i = 1; i <= 5; i++)
             await SeedProcessDefinition(db, $"pagdef2:key{i}:1:ts", $"pagdef2key{i}", 1);
 
-        var result = await _service.GetAllProcessDefinitions(new PageRequest(Page: 2, PageSize: 2));
+        var result = await service.GetAllProcessDefinitions(new PageRequest(Page: 2, PageSize: 2));
 
         Assert.AreEqual(2, result.Items.Count);
         Assert.AreEqual(5, result.TotalCount);
         Assert.AreEqual(2, result.Page);
     }
 
-    [TestMethod]
-    public async Task GetAllProcessDefinitions_Paginated_FiltersByIsActive()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetAllProcessDefinitions_Paginated_FiltersByIsActive(PersistenceProvider provider)
     {
-        using var db = _commandDbContextFactory.CreateDbContext();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        using var db = commandFactory.CreateDbContext();
 
         await SeedProcessDefinition(db, "active:1:ts", "activeproc", 1);
         await SeedProcessDefinition(db, "inactive:1:ts", "inactiveproc", 1);
@@ -614,7 +733,7 @@ public class WorkflowQueryServiceTests
         def!.Disable();
         await db.SaveChangesAsync();
 
-        var result = await _service.GetAllProcessDefinitions(
+        var result = await service.GetAllProcessDefinitions(
             new PageRequest(Filters: "IsActive==true"));
 
         Assert.AreEqual(1, result.Items.Count);
@@ -625,10 +744,15 @@ public class WorkflowQueryServiceTests
     // GetProcessDefinitionGroups
     // ─────────────────────────────────────────────────
 
-    [TestMethod]
-    public async Task GetProcessDefinitionGroups_ReturnsCorrectPage()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetProcessDefinitionGroups_ReturnsCorrectPage(PersistenceProvider provider)
     {
-        using var db = _commandDbContextFactory.CreateDbContext();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        using var db = commandFactory.CreateDbContext();
 
         for (int i = 1; i <= 5; i++)
         {
@@ -636,7 +760,7 @@ public class WorkflowQueryServiceTests
             await SeedProcessDefinition(db, $"grp:key{i}:2:ts", $"grpkey{i}", 2);
         }
 
-        var result = await _service.GetProcessDefinitionGroups(
+        var result = await service.GetProcessDefinitionGroups(
             new PageRequest(Page: 1, PageSize: 2));
 
         Assert.AreEqual(2, result.Items.Count);
@@ -645,41 +769,56 @@ public class WorkflowQueryServiceTests
         Assert.AreEqual(2, result.PageSize);
     }
 
-    [TestMethod]
-    public async Task GetProcessDefinitionGroups_LastPage_ReturnsRemainder()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetProcessDefinitionGroups_LastPage_ReturnsRemainder(PersistenceProvider provider)
     {
-        using var db = _commandDbContextFactory.CreateDbContext();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        using var db = commandFactory.CreateDbContext();
 
         for (int i = 1; i <= 5; i++)
             await SeedProcessDefinition(db, $"grplast:key{i}:1:ts", $"grplastkey{i}", 1);
 
-        var result = await _service.GetProcessDefinitionGroups(
+        var result = await service.GetProcessDefinitionGroups(
             new PageRequest(Page: 3, PageSize: 2));
 
         Assert.AreEqual(1, result.Items.Count);
         Assert.AreEqual(5, result.TotalCount);
     }
 
-    [TestMethod]
-    public async Task GetProcessDefinitionGroups_SearchByKey_FiltersCorrectly()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetProcessDefinitionGroups_SearchByKey_FiltersCorrectly(PersistenceProvider provider)
     {
-        using var db = _commandDbContextFactory.CreateDbContext();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        using var db = commandFactory.CreateDbContext();
 
         await SeedProcessDefinition(db, "grpsrch:order:1:ts", "order-process", 1);
         await SeedProcessDefinition(db, "grpsrch:payment:1:ts", "payment-process", 1);
         await SeedProcessDefinition(db, "grpsrch:user:1:ts", "user-signup", 1);
 
-        var result = await _service.GetProcessDefinitionGroups(
+        var result = await service.GetProcessDefinitionGroups(
             new PageRequest(Filters: "ProcessDefinitionKey@=order"));
 
         Assert.AreEqual(1, result.Items.Count);
         Assert.AreEqual("order-process", result.Items[0].ProcessDefinitionKey);
     }
 
-    [TestMethod]
-    public async Task GetProcessDefinitionGroups_FilterByActive_FiltersCorrectly()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetProcessDefinitionGroups_FilterByActive_FiltersCorrectly(PersistenceProvider provider)
     {
-        using var db = _commandDbContextFactory.CreateDbContext();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        using var db = commandFactory.CreateDbContext();
 
         await SeedProcessDefinition(db, "grpact:active:1:ts", "grpactiveproc", 1);
         await SeedProcessDefinition(db, "grpact:inactive:1:ts", "grpinactiveproc", 1);
@@ -687,24 +826,29 @@ public class WorkflowQueryServiceTests
         def!.Disable();
         await db.SaveChangesAsync();
 
-        var result = await _service.GetProcessDefinitionGroups(
+        var result = await service.GetProcessDefinitionGroups(
             new PageRequest(Filters: "IsActive==true"));
 
         Assert.AreEqual(1, result.Items.Count);
         Assert.AreEqual("grpactiveproc", result.Items[0].ProcessDefinitionKey);
     }
 
-    [TestMethod]
-    public async Task GetProcessDefinitionGroups_SortByDeployedAt_CorrectOrder()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetProcessDefinitionGroups_SortByDeployedAt_CorrectOrder(PersistenceProvider provider)
     {
-        using var db = _commandDbContextFactory.CreateDbContext();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        using var db = commandFactory.CreateDbContext();
 
         await SeedProcessDefinition(db, "grpsort:old:1:ts", "grpsortold", 1,
             deployedAt: new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
         await SeedProcessDefinition(db, "grpsort:new:1:ts", "grpsortnew", 1,
             deployedAt: new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero));
 
-        var result = await _service.GetProcessDefinitionGroups(
+        var result = await service.GetProcessDefinitionGroups(
             new PageRequest(Sorts: "-DeployedAt"));
 
         Assert.AreEqual(2, result.Items.Count);
@@ -712,26 +856,36 @@ public class WorkflowQueryServiceTests
         Assert.AreEqual("grpsortold", result.Items[1].ProcessDefinitionKey);
     }
 
-    [TestMethod]
-    public async Task GetProcessDefinitionGroups_EmptyResult_ReturnsEmptyPage()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetProcessDefinitionGroups_EmptyResult_ReturnsEmptyPage(PersistenceProvider provider)
     {
-        var result = await _service.GetProcessDefinitionGroups(
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        var result = await service.GetProcessDefinitionGroups(
             new PageRequest(Filters: "ProcessDefinitionKey@=nonexistent"));
 
         Assert.AreEqual(0, result.Items.Count);
         Assert.AreEqual(0, result.TotalCount);
     }
 
-    [TestMethod]
-    public async Task GetProcessDefinitionGroups_GroupContainsAllVersions()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetProcessDefinitionGroups_GroupContainsAllVersions(PersistenceProvider provider)
     {
-        using var db = _commandDbContextFactory.CreateDbContext();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        using var db = commandFactory.CreateDbContext();
 
         await SeedProcessDefinition(db, "grpver:mykey:1:ts", "grpvermykey", 1);
         await SeedProcessDefinition(db, "grpver:mykey:2:ts", "grpvermykey", 2);
         await SeedProcessDefinition(db, "grpver:mykey:3:ts", "grpvermykey", 3);
 
-        var result = await _service.GetProcessDefinitionGroups(new PageRequest());
+        var result = await service.GetProcessDefinitionGroups(new PageRequest());
 
         Assert.AreEqual(1, result.Items.Count);
         var group = result.Items[0];
@@ -746,10 +900,15 @@ public class WorkflowQueryServiceTests
     // GetPendingUserTasks (paginated)
     // ─────────────────────────────────────────────────
 
-    [TestMethod]
-    public async Task GetPendingUserTasks_Paginated_ReturnsPagedResult()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetPendingUserTasks_Paginated_ReturnsPagedResult(PersistenceProvider provider)
     {
-        using var db = _commandDbContextFactory.CreateDbContext();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        using var db = commandFactory.CreateDbContext();
 
         var instanceId = Guid.NewGuid();
         await SeedWorkflowInstance(db, instanceId, isStarted: true);
@@ -757,7 +916,7 @@ public class WorkflowQueryServiceTests
         for (int i = 0; i < 5; i++)
             await SeedUserTask(db, Guid.NewGuid(), instanceId, $"task{i}");
 
-        var result = await _service.GetPendingUserTasks(null, null,
+        var result = await service.GetPendingUserTasks(null, null,
             new PageRequest(Page: 1, PageSize: 2));
 
         Assert.AreEqual(2, result.Items.Count);
@@ -766,10 +925,15 @@ public class WorkflowQueryServiceTests
         Assert.AreEqual(2, result.PageSize);
     }
 
-    [TestMethod]
-    public async Task GetPendingUserTasks_Paginated_FiltersByAssignee()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetPendingUserTasks_Paginated_FiltersByAssignee(PersistenceProvider provider)
     {
-        using var db = _commandDbContextFactory.CreateDbContext();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        using var db = commandFactory.CreateDbContext();
 
         var instanceId = Guid.NewGuid();
         await SeedWorkflowInstance(db, instanceId, isStarted: true);
@@ -779,17 +943,22 @@ public class WorkflowQueryServiceTests
         await SeedUserTask(db, Guid.NewGuid(), instanceId, "task3",
             candidateUsers: new List<string> { "alice", "charlie" });
 
-        var result = await _service.GetPendingUserTasks("alice", null, new PageRequest());
+        var result = await service.GetPendingUserTasks("alice", null, new PageRequest());
 
         // Should return task1 (direct assignment) and task3 (candidate user)
         Assert.AreEqual(2, result.Items.Count);
         Assert.AreEqual(2, result.TotalCount);
     }
 
-    [TestMethod]
-    public async Task GetPendingUserTasks_Paginated_FiltersByCandidateGroup()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetPendingUserTasks_Paginated_FiltersByCandidateGroup(PersistenceProvider provider)
     {
-        using var db = _commandDbContextFactory.CreateDbContext();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        using var db = commandFactory.CreateDbContext();
 
         var instanceId = Guid.NewGuid();
         await SeedWorkflowInstance(db, instanceId, isStarted: true);
@@ -799,16 +968,21 @@ public class WorkflowQueryServiceTests
         await SeedUserTask(db, Guid.NewGuid(), instanceId, "task2",
             candidateGroups: new List<string> { "engineers" });
 
-        var result = await _service.GetPendingUserTasks(null, "managers", new PageRequest());
+        var result = await service.GetPendingUserTasks(null, "managers", new PageRequest());
 
         Assert.AreEqual(1, result.Items.Count);
         Assert.AreEqual(1, result.TotalCount);
     }
 
-    [TestMethod]
-    public async Task GetPendingUserTasks_Paginated_ExcludesCompleted()
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetPendingUserTasks_Paginated_ExcludesCompleted(PersistenceProvider provider)
     {
-        using var db = _commandDbContextFactory.CreateDbContext();
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture);
+
+        using var db = commandFactory.CreateDbContext();
 
         var instanceId = Guid.NewGuid();
         await SeedWorkflowInstance(db, instanceId, isStarted: true);
@@ -820,7 +994,7 @@ public class WorkflowQueryServiceTests
 
         // Default Sieve filter is not set, but the existing behavior filters by
         // TaskState != Completed via Sieve filter
-        var result = await _service.GetPendingUserTasks(null, null,
+        var result = await service.GetPendingUserTasks(null, null,
             new PageRequest(Filters: "TaskState!=Completed"));
 
         Assert.AreEqual(1, result.Items.Count);
@@ -924,33 +1098,5 @@ public class WorkflowQueryServiceTests
         await db.SaveChangesAsync();
     }
 
-    private class TestCommandDbContextFactory : IDbContextFactory<FleanCommandDbContext>
-    {
-        private readonly DbContextOptions<FleanCommandDbContext> _options;
-
-        public TestCommandDbContextFactory(DbContextOptions<FleanCommandDbContext> options)
-        {
-            _options = options;
-        }
-
-        public FleanCommandDbContext CreateDbContext() => new(_options);
-
-        public Task<FleanCommandDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default)
-            => Task.FromResult(CreateDbContext());
-    }
-
-    private class TestQueryDbContextFactory : IDbContextFactory<FleanQueryDbContext>
-    {
-        private readonly DbContextOptions<FleanQueryDbContext> _options;
-
-        public TestQueryDbContextFactory(DbContextOptions<FleanQueryDbContext> options)
-        {
-            _options = options;
-        }
-
-        public FleanQueryDbContext CreateDbContext() => new(_options);
-
-        public Task<FleanQueryDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default)
-            => Task.FromResult(CreateDbContext());
-    }
 }
+

--- a/website/src/content/docs/reference/persistence.md
+++ b/website/src/content/docs/reference/persistence.md
@@ -79,3 +79,43 @@ Example `appsettings.json`:
 ## Aspire Auto-Provisioning (PostgreSQL)
 
 When `FLEANS_PERSISTENCE_PROVIDER=Postgres`, Aspire provisions a Docker-based Postgres container named `postgres` with a database named `fleans`. Connection strings are injected into all three services (`fleans-core`, `fleans-management`, `fleans-mcp`) automatically — no manual `ConnectionStrings` config is needed in development.
+
+## Test parity with SQLite
+
+Every EF/grain-storage test class in `Fleans.Persistence.Tests` is parametrised across both providers. A regression in PostgreSQL behaviour (JSON column, `timestamptz` round-trip, migration script) fails the build the same way a SQLite regression does.
+
+The pattern (see [`Infrastructure/PersistenceTestBase.cs`](https://github.com/nightBaker/fleans/blob/main/src/Fleans/Fleans.Persistence.Tests/Infrastructure/PersistenceTestBase.cs)):
+
+```csharp
+[DataTestMethod]
+[DataRow(PersistenceProvider.Sqlite)]
+[DataRow(PersistenceProvider.Postgres)]
+public async Task WriteAndRead_RoundTrip(PersistenceProvider provider)
+{
+    await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+    var storage = new EfCoreSignalCorrelationGrainStorage(fixture.CommandFactory);
+    // ... assertions identical for both providers ...
+}
+```
+
+### Default developer loop (no Docker)
+
+```bash
+cd src/Fleans
+dotnet test
+```
+
+The PostgreSQL rows surface as `Inconclusive` (a non-failing MSTest outcome). SQLite rows execute normally. No Docker is required.
+
+### Reproducing a PostgreSQL-only failure locally
+
+```bash
+cd src/Fleans
+FLEANS_PG_TESTS=1 dotnet test --filter "TestCategory=Postgres"
+```
+
+`Testcontainers.PostgreSql` boots a single `postgres:16-alpine` container per test assembly (lazy start on first PG fixture access). Each parametrised test class owns a fresh `fleans_test_<guid>` database that runs the production `MigrateAsync()` path and is dropped via `DROP DATABASE WITH (FORCE)` on `[ClassCleanup]`. Per-test isolation comes from `TRUNCATE TABLE … RESTART IDENTITY CASCADE` on the model-derived table list.
+
+### CI
+
+The dedicated [`PostgreSQL tests`](https://github.com/nightBaker/fleans/blob/main/.github/workflows/pg-tests.yml) GitHub Actions workflow runs on every PR + push to `main`, sets `FLEANS_PG_TESTS=1`, and executes `dotnet test --filter "TestCategory=Postgres"` against the Testcontainers-managed image.


### PR DESCRIPTION
## Summary

Phase 4 of PostgreSQL support — adds **Testcontainers-based test parity** so a PG-only regression (JSON column behaviour, `timestamptz` round-trip, broken migration) fails the build the same way a SQLite regression does.

Closes part of #278 (Steps 15–16; Step 17 deferred — see Followup below).

## What changes

### New `Fleans.Persistence.Tests/Infrastructure/` namespace

- `PersistenceProvider` enum (`Sqlite` | `Postgres`)
- `IPersistenceTestFixture` exposing `CommandFactory` / `QueryFactory`
- `PostgresContainerFixture` — single `postgres:16-alpine` container per assembly, lazy-started on first PG fixture access (Docker-less SQLite-only loops pay zero startup cost)
- `AssemblyInit` — `[AssemblyCleanup]` disposes the container
- `PersistenceTestBase` — abstract base owning the per-class lifecycle:
  - `[ClassInitialize]` `CREATE DATABASE fleans_test_<guid>` + `MigrateAsync()`
  - `[TestInitialize]` `TRUNCATE … RESTART IDENTITY CASCADE` (model-derived list)
  - `[ClassCleanup]` dispose `NpgsqlDataSource` + `DROP DATABASE WITH (FORCE)`
- `SqliteRowFixture` / `PostgresRowFixture` — per-row disposable handles
- `TestFixtureFactory` + `Skip` helper

### Parametrised test classes

All 7 EF/grain-storage/repository/query test classes now run via `[DataTestMethod] [DataRow(Sqlite)] [DataRow(Postgres)]`:

- `EfCoreSignalCorrelationGrainStorageTests`
- `EfCoreMessageCorrelationGrainStorageTests`
- `EfCoreProcessDefinitionGrainStorageTests`
- `EfCoreProcessDefinitionRepositoryTests`
- `EfCoreEventStoreTests`
- `EfCoreCustomTaskCatalogGrainStorageTests`
- `WorkflowQueryServiceTests` (40 methods — parametrised in-place since it had no pre-existing `[DataRow]` axes)

Each class carries `[TestCategory(\"Postgres\")]`.

### CI

New `.github/workflows/pg-tests.yml` — required PR check that sets `FLEANS_PG_TESTS=1` and runs `dotnet test --filter \"TestCategory=Postgres\"` against the Testcontainers-managed image. The default `dotnet.yml` job is unchanged (runs unfiltered; PG rows there surface as `Inconclusive`, never `Failed`).

### Docs

- `CLAUDE.md` § Persistence Providers gains a \"Test parity (Sqlite ↔ PostgreSQL)\" bullet covering the `FLEANS_PG_TESTS=1` toggle, the Inconclusive-on-no-Docker behaviour, and the `postgres:16-alpine` pin (with bump-when-prod-bumps note).
- `website/src/content/docs/reference/persistence.md` gains a \"Test parity with SQLite\" subsection with the pattern, local repro instructions, and a link to the CI workflow.

## Production parity

The PG fixture builds `DbContextOptions` via the production `UseFleansPostgres(NpgsqlDataSource)` extension so `MigrateAsync` runs the real `Fleans.Persistence.PostgreSql` migrations and the `PostgresModelCustomizer` is applied — not EF defaults. This is the load-bearing detail that lets these tests catch PG-only regressions.

## Test results (default loop, no Docker)

```
Passed:   123 — Skipped (Inconclusive): 109 — Total: 232
```

SQLite rows execute and assert; PG rows surface as `Inconclusive`. With `FLEANS_PG_TESTS=1` and Docker available the PG rows execute against the Testcontainers-managed image (verified locally to compile and the path through `MigrateAsync` against the per-class database is exercised by the design — final green-on-CI awaits the new `pg-tests` job's first run).

## Step 17 — explicitly deferred

The design (rework v6) allows splitting Step 17 (Orleans `TestCluster` E2E parametrisation: `HappyPath_StartWorkflow_completes` + `MessageStartEvent_AutoCreatesInstance`) into a follow-up issue. This PR ships Steps 15–16 + CI scaffolding + docs. The Step 17 work needs the `FleansSiloRowContext` AsyncLocal overlay + Orleans `ISiloConfigurator` plumbing and is best landed against a quiet `Fleans.Application.Tests` window.

## Stale comment from prior attempt

The `claude/keen-keller-XRvKe` comment at the top of #278 claiming the work was already done is stale — that branch only contains a docs fix and never landed any test files. Verified during analysis pass v1.

## Test plan

- [x] `cd src/Fleans && dotnet build` — 0 errors
- [x] `cd src/Fleans && dotnet test Fleans.Persistence.Tests/Fleans.Persistence.Tests.csproj` — 123 passed, 109 skipped (Inconclusive), 0 failed
- [ ] CI: new `pg-tests` job green on PR
- [ ] CI: existing `.NET` job green (unfiltered run, PG rows Inconclusive)

## Followup

- [ ] After merge, file follow-up issue for **Step 17** — Orleans `TestCluster` PG parametrisation (`HappyPath_StartWorkflow_completes` + `MessageStartEvent_AutoCreatesInstance`).
- [ ] After merge, file follow-up issue for the SQLite-only-fallback removal cleanup tracked under #277.

🤖 Generated with [Claude Code](https://claude.com/claude-code)