### PR TITLE
fix(#385): make Instances page FluentDataGrid full-width

### DIFF
--- a/src/Fleans/Fleans.Web/Components/Pages/ProcessInstances.razor
+++ b/src/Fleans/Fleans.Web/Components/Pages/ProcessInstances.razor
@@ -23,7 +23,8 @@
     <FluentDataGrid ItemsProvider="@instancesProvider"
                     Pagination="@pagination"
                     TGridItem="WorkflowInstanceInfo"
-                    Loading="@isLoading">
+                    Loading="@isLoading"
+                    Style="width: 100%">
         <TemplateColumn Title="Instance ID">
             <span title="@context.InstanceId">@context.InstanceId.ToString()[..8]...</span>
         </TemplateColumn>


### PR DESCRIPTION
## Summary
- Adds `Style="width: 100%"` to the `<FluentDataGrid>` on `ProcessInstances.razor` so the Instances grid fills its parent the same way the Workflows grid does.
- Root cause: FluentDataGrid's default CSS grid `grid-template-columns` resolves to `max-content`. The Instances grid carries very short cell content (8-char truncated ID, single small badge, single View button), so its natural row width was substantially less than the FluentBodyContent it sat in. Workflows looks wide because its cells (long process keys + badges + 4-button Actions column + `HierarchicalToggle`) already approach the body width.
- Scoped to the Instances page only — no `app.css` rule, no change to Workflows, no change to other admin grids (CustomTaskCatalog, instance activity tables).

Closes #385.

## Key decisions
- Used `Style="width: 100%"` (the plan's primary fix) rather than `GridTemplateColumns`. The reviewer flagged that `GridTemplateColumns` is the canonical way to redistribute *column* tracks; here the goal is the *outer* grid extent, which `width: 100%` covers — column tracks remain auto-sized, which preserves the intentional sizing of the small Status / Actions columns.
- No edit to `Workflows.razor` — its current rendering is correct and the plan calls for a minimum diff unless Workflows demonstrably also needed it.
- No `ProcessInstances.razor.css` — single-property, single-element change matches the inline-style pattern already used elsewhere (e.g. `PageHeader.razor`).

## How to test
1. Run `dotnet run --project src/Fleans/Fleans.Aspire`.
2. Open Admin UI in Chrome at the Aspire-published URL; deploy any `.bpmn` and start an instance (e.g. `tests/manual/01-basic-workflow/simple-workflow.bpmn`).
3. Compare `/workflows` and `/process-instances/<process-key>` side by side at 1920×1080 and at 1280×800. The Instances grid should occupy the same horizontal extent as the Workflows grid.
4. Verify both light and dark theme (theme toggle). No regression on `/process-instance/{instanceId}` (singular) which uses its own `instance-content` rule.
5. `dotnet build` from `src/Fleans/` clean.

## Test plan
- [ ] Instances grid spans full FluentBodyContent width on a 1920-wide viewport (light theme)
- [ ] Instances grid spans full FluentBodyContent width on a 1920-wide viewport (dark theme)
- [ ] No horizontal scroll bar at 1280-wide viewport (light + dark)
- [ ] `/workflows` rendering unchanged
- [ ] `/process-instance/{instanceId}` (singular) rendering unchanged
- [ ] CustomTaskCatalog grid (`/admin/custom-tasks`) rendering unchanged
- [ ] `dotnet build` from `src/Fleans/` succeeds with no new warnings