### PR TITLE
feat(#386): add deployment-posture hero cards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,6 +214,7 @@ Website-specific manual tests live under `tests/manual/website/`. These run in a
 
 1. **3D Silo Landing Background** — `tests/manual/website/3d-landing/test-plan.md`. Splash page renders birds-eye Three.js silo scene as background; clicking outside the hero enters interactive orbit/zoom/pan mode with a close (×) button; mobile and reduced-motion users see a static WebP poster instead.
 2. **Hero BPMN SVG** — `tests/manual/website/hero-bpmn-svg/test-plan.md`. The pre-rendered `public/hero-workflow-{light,dark}.svg` files parse as strict XML (no `</g>` imbalance, no leftover `djs-hit` / `djs-outline` / `djs-dragger` classes, XML prolog + SVG 1.1 DOCTYPE preserved); landing page hero renders in both themes; regeneration is reproducible. Regression home for #366.
+3. **Landing Deployment-Posture Cards** — `tests/manual/website/landing-deployment-cards/test-plan.md`. The "Why Fleans?" `<CardGrid>` on `/fleans/` renders 9 cards (six runtime/engine + three deployment-posture); the `setting`, `list-format`, `puzzle` icons resolve to real glyphs in light AND dark themes (not silent Starlight fallbacks); each new card's "Learn how →" link returns 200 to `reference/self-hosting/`, `reference/persistence/`, `reference/streaming/`; mobile (≤ 480 px) single-column flow is readable.
 
 > When adding a new website test folder, append a numbered entry here.
 

--- a/tests/manual/website/landing-deployment-cards/test-plan.md
+++ b/tests/manual/website/landing-deployment-cards/test-plan.md
@@ -1,0 +1,73 @@
+# Landing page — Deployment-posture hero cards
+
+## Scenario
+
+The website splash (`/fleans/`) communicates Fleans's deployment posture — self-hosted runtime, pluggable persistence, pluggable streaming — directly in the "Why Fleans?" `<CardGrid>`. Three additional cards are appended after the existing six (positions 7–9), each linking to the relevant reference page (`reference/self-hosting/`, `reference/persistence/`, `reference/streaming/`).
+
+This plan verifies that the cards render in both themes, that their icons resolve to real glyphs (not silently substituted fallbacks), that each link target returns 200, and that the 9-card single-column flow is acceptable on a narrow viewport.
+
+> **Note:** issue #406 (release pipeline + container builds) governs whether the `ghcr.io/nightbaker/fleans-*` images referenced by `reference/self-hosting/` are actually published. The card copy itself is unconditionally correct ("ships as a container image"), but if a tester clicks through to the linked page and follows the `docker pull` instructions before #406 lands, the pull will 404 — that is a known, out-of-scope dependency.
+
+## Prerequisites
+
+- `cd website && npm install` has been run at least once.
+- Dev server NOT already running on ports 4321/4327/4328.
+
+## Steps
+
+1. **Start the dev server.**
+   ```bash
+   cd website
+   npm run dev
+   ```
+   Open `http://localhost:4321/fleans/` in a desktop browser.
+
+2. **Verify card count and order in light theme.**
+   - Toggle theme to light if not already.
+   - Scroll to "Why Fleans?".
+   - Count cards. Expect **9** total.
+   - The new cards appear in positions 7, 8, 9 in this order:
+     - "Run in your infrastructure"
+     - "Bring your own database"
+     - "Plug in your stream provider"
+   - The original six cards (Actors / Scale reads / Event-sourced / Typed BPMN / In-memory / Materialized projections) are unchanged and appear first.
+
+3. **Verify icons render as real glyphs in light theme.**
+   - For each of the three new cards, inspect the icon at the top of the card.
+   - Each icon must be a real glyph (gear/cog for `setting`, list-rows for `list-format`, puzzle piece for `puzzle`).
+   - **Reject any** icon that renders as a generic placeholder (e.g., a default fallback square / open-book / question mark) — this indicates Starlight silently substituted because the requested name does not resolve. `npm run build` does NOT catch silent fallbacks.
+
+4. **Switch to dark theme and re-verify.**
+   - Toggle theme to dark.
+   - All 9 cards still render.
+   - All three new icons remain real glyphs (no fallback rectangles, no broken-image symbol, no inverted-color artifacts).
+   - Card body copy is readable against the dark background.
+
+5. **Verify each new card's link target.**
+   - Click "Learn how →" on **"Run in your infrastructure"** → lands on `/fleans/reference/self-hosting/` (page title: "Self-Hosting on Kubernetes" or similar). Returns 200.
+   - Back to splash. Click "Learn how →" on **"Bring your own database"** → lands on `/fleans/reference/persistence/`. Returns 200.
+   - Back to splash. Click "Learn how →" on **"Plug in your stream provider"** → lands on `/fleans/reference/streaming/`. Returns 200.
+
+6. **Mobile-viewport scroll-length sanity check.**
+   - Resize browser to ≤ 480 px width (or use DevTools mobile emulation).
+   - Scroll the "Why Fleans?" section.
+   - The grid collapses to a single column (existing behaviour, inherited).
+   - Each card's body copy fits inside the card — no horizontal overflow, no clipped text.
+   - Total scroll length is acceptable (no card stretches absurdly tall, no excessive whitespace).
+
+7. **Production build sanity.**
+   - `Ctrl+C` the dev server.
+   - Run `npm run build` from `website/`.
+   - Build must complete without errors. (Build does **not** catch silent icon fallback — that is what step 3/4 covers.)
+
+## Expected outcomes (checklist)
+
+- [ ] Splash shows 9 cards in light theme, in the correct order.
+- [ ] Splash shows 9 cards in dark theme, in the correct order.
+- [ ] `setting`, `list-format`, `puzzle` icons render as real glyphs (not fallbacks) in light theme.
+- [ ] `setting`, `list-format`, `puzzle` icons render as real glyphs (not fallbacks) in dark theme.
+- [ ] "Run in your infrastructure" link → `/fleans/reference/self-hosting/` (200).
+- [ ] "Bring your own database" link → `/fleans/reference/persistence/` (200).
+- [ ] "Plug in your stream provider" link → `/fleans/reference/streaming/` (200).
+- [ ] Mobile (≤ 480 px) viewport: 9-card single-column flow is readable; no overflow; no clipped copy.
+- [ ] `npm run build` completes without errors.

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -63,4 +63,23 @@ import SiloBackground from '../../components/SiloBackground.astro';
     Admin UI and state queries read a pre-built EF projection.
     No event replay to render a list or poll for completion.
   </Card>
+  <Card title="Run in your infrastructure" icon="setting">
+    Fleans ships as a container image you can run anywhere — laptop, VM, or
+    Kubernetes. Your data never leaves your network, and there is no SaaS
+    dependency to ramp.
+    [Learn how →](/fleans/reference/self-hosting/)
+  </Card>
+  <Card title="Bring your own database" icon="list-format">
+    SQLite for laptops, PostgreSQL for production — selected at startup via a
+    single config key, no code change. The provider model is open if you need
+    to add another.
+    [Learn how →](/fleans/reference/persistence/)
+  </Card>
+  <Card title="Plug in your stream provider" icon="puzzle">
+    Domain events flow through Orleans Streams. Default is in-memory; flip
+    `Fleans:Streaming:Provider=kafka` to use the bundled Kafka adapter for
+    cross-silo durability — or ship your own provider against the same
+    extension point.
+    [Learn how →](/fleans/reference/streaming/)
+  </Card>
 </CardGrid>


### PR DESCRIPTION
Closes #386.

## Summary

Append three new `<Card>` blocks to the "Why Fleans?" `<CardGrid>` on the splash page (`website/src/content/docs/index.mdx`). The grid grows 6 → 9 cards. Original six cards are unchanged. Card copy is the locked v2 design from issue #386.

| # | Title | Icon | Link |
|---|-------|------|------|
| 7 | Run in your infrastructure | `setting` | `/fleans/reference/self-hosting/` |
| 8 | Bring your own database | `list-format` | `/fleans/reference/persistence/` |
| 9 | Plug in your stream provider | `puzzle` | `/fleans/reference/streaming/` |

## Notes from analysis-review v2

- **Card #7 forward-leans on container builds.** Issue #406 (release pipeline + container builds) is currently in *Review by human*; the `ghcr.io/nightbaker/fleans-*` images referenced from `reference/self-hosting/` aren't published yet. Card copy ("ships as a container image") is unconditionally correct, but a tester following the linked page's `docker pull` instructions before #406 lands will 404. Out-of-scope dependency, called out so it isn't a post-merge surprise.
- **Self-hosting target is Kubernetes-focused.** `reference/self-hosting/` is titled "Self-Hosting on Kubernetes". Card #7 pitches "laptop, VM, or Kubernetes" — the linked page covers the Kubernetes path most thoroughly. Acceptable today; can split into a deployment-overview page later if VM/laptop walkthroughs become a priority.
- **Icon-name fallbacks are guarded by visual inspection.** `npm run build` does not catch silent icon fallbacks; the manual test plan's step 3/4 explicitly verifies real glyphs in light AND dark themes. All three primary icon names (`setting`, `list-format`, `puzzle`) are confirmed present in `node_modules/@astrojs/starlight/components-internals/Icons.ts`, so no substitution was required.

## Verification

- `cd website && npm run build` — passes; 18 pages built, no errors.
- DOM check on `npm run dev`: 9 `article.card` elements rendered, each with a real inlined `<svg><path>` (positions 7/8/9 paths are 889/770/457 chars respectively — non-fallback).
- Each new card's link target returns 200 against the dev server (`/fleans/reference/{self-hosting,persistence,streaming}/`).

## Test plan

- [x] Build passes (`npm run build`).
- [x] All 9 cards render with real SVG icons (DOM-verified in dev server).
- [x] Each new card's link target returns 200.
- [ ] Manual: light + dark theme visual icon check (covered by `tests/manual/website/landing-deployment-cards/test-plan.md`).
- [ ] Manual: mobile (≤ 480 px) single-column scroll length sanity (covered by same test plan).

## Files changed

- `website/src/content/docs/index.mdx` — append 3 cards before `</CardGrid>`.
- `tests/manual/website/landing-deployment-cards/test-plan.md` — new manual regression plan.
- `CLAUDE.md` — append entry #3 under **Website regression tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)