### PR TITLE
fix(#284): nested timer EventSubProcess scope completion

### DIFF
--- a/src/Fleans/Fleans.Application.Tests/EventSubProcessNestedInSubProcessTests.cs
+++ b/src/Fleans/Fleans.Application.Tests/EventSubProcessNestedInSubProcessTests.cs
@@ -1,0 +1,490 @@
+using Fleans.Application.Grains;
+using Fleans.Application.QueryModels;
+using Fleans.Domain;
+using Fleans.Domain.Activities;
+using Fleans.Domain.Sequences;
+using System.Dynamic;
+
+namespace Fleans.Application.Tests;
+
+/// <summary>
+/// Regression tests for issue #284: when an EventSubProcess (any variant) is
+/// declared inside a SubProcess, firing the start event used to throw
+/// "Expected at most one child scope for subprocess host …" from
+/// CompleteFinishedSubProcessScopes because the ESP handler scope shared a
+/// ParentVariablesId with the outer SubProcess's own execution scope.
+///
+/// The base "interrupting timer" variant is already covered by
+/// <see cref="EventSubProcessTimerTests.TimerEventSubProcess_NestedInsideSubProcess_CompletesScope"/>
+/// (re-enabled by this fix). This file adds the remaining variants:
+/// message, signal, error, non-interrupting timer, ESP-in-ESP, and Transaction.
+/// </summary>
+[TestClass]
+public class EventSubProcessNestedInSubProcessTests : WorkflowTestBase
+{
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private static SubProcess BuildOuterSubWith(EventSubProcess nestedEvtSub)
+    {
+        var innerStart = new StartEvent("innerStart");
+        var innerUserTask = new TaskActivity("innerUserTask");
+        var innerEnd = new EndEvent("innerEnd");
+
+        return new SubProcess("outerSub")
+        {
+            Activities = [innerStart, innerUserTask, innerEnd, nestedEvtSub],
+            SequenceFlows =
+            [
+                new SequenceFlow("outer_sf1", innerStart, innerUserTask),
+                new SequenceFlow("outer_sf2", innerUserTask, innerEnd),
+            ],
+        };
+    }
+
+    private static WorkflowDefinition BuildWorkflow(
+        string workflowId, SubProcess outerSub,
+        List<MessageDefinition>? messages = null,
+        List<SignalDefinition>? signals = null)
+    {
+        var start = new StartEvent("start");
+        var end = new EndEvent("end");
+
+        return new WorkflowDefinition
+        {
+            WorkflowId = workflowId,
+            Activities = [start, outerSub, end],
+            SequenceFlows =
+            [
+                new SequenceFlow("f1", start, outerSub),
+                new SequenceFlow("f2", outerSub, end),
+            ],
+            Messages = messages ?? new List<MessageDefinition>(),
+            Signals = signals ?? new List<SignalDefinition>()
+        };
+    }
+
+    // -------------------------------------------------------------------------
+    // Message ESP nested in SubProcess (interrupting)
+    // -------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task MessageEventSubProcess_NestedInsideSubProcess_CompletesScope()
+    {
+        var msgStart = new MessageStartEvent("nestedMsgStart", "cancelMsgDef");
+        var handlerEnd = new EndEvent("nestedHandlerEnd");
+        var nestedEvtSub = new EventSubProcess("nestedEvtSub")
+        {
+            Activities = [msgStart, handlerEnd],
+            SequenceFlows = [new SequenceFlow("nested_sf1", msgStart, handlerEnd)],
+            IsInterrupting = true,
+        };
+
+        var outerSub = BuildOuterSubWith(nestedEvtSub);
+        var workflow = BuildWorkflow(
+            "message-esp-nested-in-subprocess",
+            outerSub,
+            messages: [new MessageDefinition("cancelMsgDef", "cancelOrder", "= orderId")]);
+
+        var workflowInstance = Cluster.GrainFactory.GetGrain<IWorkflowInstanceGrain>(Guid.NewGuid());
+        await workflowInstance.SetWorkflow(workflow);
+
+        // Correlation key must be in the parent scope before the ESP registers.
+        dynamic initVars = new ExpandoObject();
+        initVars.orderId = "ORD-284";
+        await workflowInstance.SetInitialVariables((ExpandoObject)initVars);
+        await workflowInstance.StartWorkflow();
+
+        var instanceId = workflowInstance.GetPrimaryKey();
+        await Task.Delay(500);
+
+        // Act — deliver correlated message.
+        var correlationKey = MessageCorrelationKey.Build("cancelOrder", "ORD-284");
+        var correlationGrain = Cluster.GrainFactory.GetGrain<IMessageCorrelationGrain>(correlationKey);
+        var delivered = await correlationGrain.DeliverMessage(new ExpandoObject());
+
+        Assert.IsTrue(delivered, "Correlated message should deliver to nested ESP subscription");
+
+        var snapshot = await PollForNoActiveActivities(instanceId);
+        Assert.IsNotNull(snapshot);
+
+        Assert.IsTrue(snapshot!.IsCompleted, "Workflow must complete via nested message ESP");
+        AssertNestedHandlerCompletedAndOuterClosed(snapshot);
+    }
+
+    // -------------------------------------------------------------------------
+    // Signal ESP nested in SubProcess (interrupting)
+    // -------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task SignalEventSubProcess_NestedInsideSubProcess_CompletesScope()
+    {
+        var signalDef = new SignalDefinition("nestedSigDef", "nestedAlert");
+        var sigStart = new SignalStartEvent("nestedSignalStart", "nestedSigDef");
+        var handlerEnd = new EndEvent("nestedHandlerEnd");
+        var nestedEvtSub = new EventSubProcess("nestedEvtSub")
+        {
+            Activities = [sigStart, handlerEnd],
+            SequenceFlows = [new SequenceFlow("nested_sf1", sigStart, handlerEnd)],
+            IsInterrupting = true,
+        };
+
+        var outerSub = BuildOuterSubWith(nestedEvtSub);
+        var workflow = BuildWorkflow(
+            "signal-esp-nested-in-subprocess",
+            outerSub,
+            signals: [signalDef]);
+
+        var workflowInstance = Cluster.GrainFactory.GetGrain<IWorkflowInstanceGrain>(Guid.NewGuid());
+        await workflowInstance.SetWorkflow(workflow);
+        await workflowInstance.StartWorkflow();
+
+        var instanceId = workflowInstance.GetPrimaryKey();
+        await Task.Delay(500);
+
+        // Act — broadcast the signal.
+        var signalGrain = Cluster.GrainFactory.GetGrain<ISignalCorrelationGrain>("nestedAlert");
+        var deliveredCount = await signalGrain.BroadcastSignal();
+        Assert.IsTrue(deliveredCount >= 1,
+            $"Signal should reach at least one subscriber (got {deliveredCount})");
+
+        var snapshot = await PollForNoActiveActivities(instanceId);
+        Assert.IsNotNull(snapshot);
+        Assert.IsTrue(snapshot!.IsCompleted, "Workflow must complete via nested signal ESP");
+        AssertNestedHandlerCompletedAndOuterClosed(snapshot);
+    }
+
+    // -------------------------------------------------------------------------
+    // Error ESP nested in SubProcess (interrupting)
+    // -------------------------------------------------------------------------
+
+    [TestMethod]
+    [Ignore("Error propagation from a SubProcess child to a sibling EventSubProcess "
+        + "nested in the same SubProcess is a separate limitation (related to the "
+        + "child-error → parent-boundary gap tracked in regression test #11). The "
+        + "scope-completion guard fixed in #284 is exercised by the timer / message / "
+        + "signal nested variants here; the error variant requires error-propagation "
+        + "work that is out of scope for #284.")]
+    public async Task ErrorEventSubProcess_NestedInsideSubProcess_CompletesScope()
+    {
+        var start = new StartEvent("start");
+        var end = new EndEvent("end");
+
+        // Inside the outer SubProcess: a script task that fails so the inner
+        // error ESP can catch it. The "FAIL" marker is recognised by the test
+        // SimpleScriptExecutor; failure surfaces as code "500".
+        var innerStart = new StartEvent("innerStart");
+        var failingTask = new ScriptTask("failingTask", "FAIL");
+        var innerEnd = new EndEvent("innerEnd");
+
+        var errStart = new ErrorStartEvent("nestedErrStart", "500");
+        var handlerEnd = new EndEvent("nestedHandlerEnd");
+        var nestedEvtSub = new EventSubProcess("nestedEvtSub")
+        {
+            Activities = [errStart, handlerEnd],
+            SequenceFlows = [new SequenceFlow("nested_sf1", errStart, handlerEnd)],
+            IsInterrupting = true,
+        };
+
+        var outerSub = new SubProcess("outerSub")
+        {
+            Activities = [innerStart, failingTask, innerEnd, nestedEvtSub],
+            SequenceFlows =
+            [
+                new SequenceFlow("outer_sf1", innerStart, failingTask),
+                new SequenceFlow("outer_sf2", failingTask, innerEnd),
+            ],
+        };
+
+        var workflow = new WorkflowDefinition
+        {
+            WorkflowId = "error-esp-nested-in-subprocess",
+            Activities = [start, outerSub, end],
+            SequenceFlows =
+            [
+                new SequenceFlow("f1", start, outerSub),
+                new SequenceFlow("f2", outerSub, end),
+            ],
+        };
+
+        var workflowInstance = Cluster.GrainFactory.GetGrain<IWorkflowInstanceGrain>(Guid.NewGuid());
+        await workflowInstance.SetWorkflow(workflow);
+        await workflowInstance.StartWorkflow();
+
+        var instanceId = workflowInstance.GetPrimaryKey();
+        var snapshot = await PollForNoActiveActivities(instanceId);
+        Assert.IsNotNull(snapshot);
+        Assert.IsTrue(snapshot!.IsCompleted, "Workflow must complete via nested error ESP");
+
+        // failingTask retains its error state; nested ESP picked it up.
+        var failingEntry = snapshot.CompletedActivities.FirstOrDefault(a => a.ActivityId == "failingTask");
+        Assert.IsNotNull(failingEntry, "failingTask should appear in terminal list");
+        Assert.IsNotNull(failingEntry!.ErrorState);
+
+        Assert.IsTrue(snapshot.CompletedActivities.Any(a => a.ActivityId == "nestedHandlerEnd"
+                                                              && a.ErrorState == null
+                                                              && !a.IsCancelled),
+            "nestedHandlerEnd should be completed");
+        Assert.IsTrue(snapshot.CompletedActivities.Any(a => a.ActivityId == "nestedEvtSub"),
+            "nestedEvtSub host should be completed");
+        Assert.IsTrue(snapshot.CompletedActivities.Any(a => a.ActivityId == "outerSub"),
+            "outerSub should complete after the nested error ESP closes the scope");
+    }
+
+    // -------------------------------------------------------------------------
+    // Non-interrupting timer ESP nested in SubProcess
+    // -------------------------------------------------------------------------
+
+    [TestMethod]
+    [Ignore("Hits a separate variable-state lookup gap when externally completing the "
+        + "still-active inner TaskActivity AFTER a non-interrupting ESP handler scope "
+        + "has been queued for removal — the entry's VariablesId references a scope "
+        + "that was reaped by the ESP host's branch in CompleteFinishedSubProcessScopes. "
+        + "The scope-completion guard fixed in #284 is exercised by the interrupting "
+        + "timer / message / signal nested variants here; this concurrent-completion "
+        + "wrinkle is its own follow-up.")]
+    public async Task NonInterruptingTimerEventSubProcess_NestedInsideSubProcess_RunsHandlerInParallel()
+    {
+        // The handler runs without cancelling the inner user task; only after the
+        // user task is completed externally does the SubProcess scope close.
+        var timerStart = new TimerStartEvent("nestedTimerStart",
+            new TimerDefinition(TimerType.Duration, "PT5S"));
+        var handlerEnd = new EndEvent("nestedHandlerEnd");
+        var nestedEvtSub = new EventSubProcess("nestedEvtSub")
+        {
+            Activities = [timerStart, handlerEnd],
+            SequenceFlows = [new SequenceFlow("nested_sf1", timerStart, handlerEnd)],
+            IsInterrupting = false,
+        };
+
+        var outerSub = BuildOuterSubWith(nestedEvtSub);
+        var workflow = BuildWorkflow("non-interrupting-timer-esp-nested", outerSub);
+
+        var workflowInstance = Cluster.GrainFactory.GetGrain<IWorkflowInstanceGrain>(Guid.NewGuid());
+        await workflowInstance.SetWorkflow(workflow);
+        await workflowInstance.StartWorkflow();
+
+        var instanceId = workflowInstance.GetPrimaryKey();
+        await Task.Delay(500);
+
+        var running = await QueryService.GetStateSnapshot(instanceId);
+        Assert.IsNotNull(running);
+        var outerSubEntry = running!.ActiveActivities.FirstOrDefault(a => a.ActivityId == "outerSub");
+        Assert.IsNotNull(outerSubEntry, "outerSub must be active before timer fires");
+        var innerUserTaskEntry = running.ActiveActivities.FirstOrDefault(a => a.ActivityId == "innerUserTask");
+        Assert.IsNotNull(innerUserTaskEntry, "innerUserTask must be active");
+
+        // Fire the nested timer with the outer SubProcess host id (non-interrupting).
+        await workflowInstance.HandleTimerFired(
+            "nestedTimerStart", outerSubEntry!.ActivityInstanceId);
+
+        // Poll until the handler chain has run; the inner user task should still be active.
+        var afterHandler = await PollUntil(instanceId, s =>
+            s.CompletedActivities.Any(a => a.ActivityId == "nestedHandlerEnd"
+                                            && a.ErrorState == null
+                                            && !a.IsCancelled));
+        Assert.IsNotNull(afterHandler);
+        Assert.IsTrue(afterHandler!.ActiveActivities.Any(a => a.ActivityId == "innerUserTask"),
+            "innerUserTask must remain active — non-interrupting ESP must NOT cancel siblings");
+        Assert.IsFalse(afterHandler.IsCompleted,
+            "Workflow cannot complete while innerUserTask is active");
+
+        // Externally complete the inner user task to release the SubProcess.
+        await workflowInstance.CompleteActivity(
+            "innerUserTask", innerUserTaskEntry!.ActivityInstanceId, new ExpandoObject());
+
+        var snapshot = await PollForNoActiveActivities(instanceId);
+        Assert.IsNotNull(snapshot);
+        Assert.IsTrue(snapshot!.IsCompleted,
+            "Workflow must complete after innerUserTask finishes — no scope-completion exception");
+
+        Assert.IsTrue(snapshot.CompletedActivities.Any(a => a.ActivityId == "outerSub"),
+            "outerSub should complete cleanly with the nested non-interrupting handler scope discarded");
+        Assert.IsTrue(snapshot.CompletedActivities.Any(a => a.ActivityId == "innerUserTask"
+                                                              && !a.IsCancelled),
+            "innerUserTask must reach completion (not cancellation) under non-interrupting variant");
+    }
+
+    // -------------------------------------------------------------------------
+    // ESP-in-ESP-in-SubProcess (regression-guard for nested ESP-handler scopes)
+    // -------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task TimerEventSubProcessInsideEventSubProcess_NestedInSubProcess_CompletesScope()
+    {
+        // Inner ESP lives directly inside outer ESP: not the most realistic shape,
+        // but it stresses ownership disambiguation when multiple sibling
+        // ESP-handler scopes can hang off the same outer SubProcess on replay.
+        var innerTimerStart = new TimerStartEvent("innerTimerStart",
+            new TimerDefinition(TimerType.Duration, "PT5S"));
+        var innerHandlerEnd = new EndEvent("innerHandlerEnd");
+        var innerEvtSub = new EventSubProcess("innerEvtSub")
+        {
+            Activities = [innerTimerStart, innerHandlerEnd],
+            SequenceFlows = [new SequenceFlow("inner_sf1", innerTimerStart, innerHandlerEnd)],
+            IsInterrupting = true,
+        };
+
+        var outerTimerStart = new TimerStartEvent("outerTimerStart",
+            new TimerDefinition(TimerType.Duration, "PT30S"));
+        var outerHandlerEnd = new EndEvent("outerHandlerEnd");
+        var outerEvtSub = new EventSubProcess("outerEvtSub")
+        {
+            Activities = [outerTimerStart, outerHandlerEnd, innerEvtSub],
+            SequenceFlows = [new SequenceFlow("outer_evt_sf1", outerTimerStart, outerHandlerEnd)],
+            IsInterrupting = true,
+        };
+
+        // The outer SubProcess hosts BOTH the user task and the outer ESP.
+        var innerStart = new StartEvent("innerStart");
+        var innerUserTask = new TaskActivity("innerUserTask");
+        var innerEnd = new EndEvent("innerEnd");
+        var outerSub = new SubProcess("outerSub")
+        {
+            Activities = [innerStart, innerUserTask, innerEnd, outerEvtSub],
+            SequenceFlows =
+            [
+                new SequenceFlow("outer_sf1", innerStart, innerUserTask),
+                new SequenceFlow("outer_sf2", innerUserTask, innerEnd),
+            ],
+        };
+
+        var workflow = BuildWorkflow("esp-in-esp-in-subprocess", outerSub);
+
+        var workflowInstance = Cluster.GrainFactory.GetGrain<IWorkflowInstanceGrain>(Guid.NewGuid());
+        await workflowInstance.SetWorkflow(workflow);
+        await workflowInstance.StartWorkflow();
+
+        var instanceId = workflowInstance.GetPrimaryKey();
+        await Task.Delay(500);
+
+        var running = await QueryService.GetStateSnapshot(instanceId);
+        var outerSubEntry = running!.ActiveActivities.FirstOrDefault(a => a.ActivityId == "outerSub");
+        Assert.IsNotNull(outerSubEntry, "outerSub must be active before timer fires");
+
+        // Fire the OUTER ESP's timer (keyed to the outer SubProcess host).
+        await workflowInstance.HandleTimerFired(
+            "outerTimerStart", outerSubEntry!.ActivityInstanceId);
+
+        var snapshot = await PollForNoActiveActivities(instanceId);
+        Assert.IsNotNull(snapshot);
+        Assert.IsTrue(snapshot!.IsCompleted,
+            "Three-level nesting (ESP-in-ESP-in-SubProcess) must terminate cleanly");
+        Assert.IsTrue(snapshot.CompletedActivities.Any(a => a.ActivityId == "outerHandlerEnd"
+                                                              && !a.IsCancelled),
+            "outer ESP handler must reach its EndEvent");
+        Assert.IsTrue(snapshot.CompletedActivities.Any(a => a.ActivityId == "outerSub"),
+            "outerSub must complete after ESP handler chain closes");
+    }
+
+    // -------------------------------------------------------------------------
+    // Transaction → nested ESP (proves Transaction : SubProcess is in scope)
+    // -------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task TimerEventSubProcess_NestedInsideTransaction_CompletesScope()
+    {
+        // Same shape as the base nested-timer test, but the host is a Transaction
+        // (sealed subclass of SubProcess). The fix is supposed to cover this
+        // transparently because the dispatch is OpenSubProcessCommand for both.
+        var timerStart = new TimerStartEvent("nestedTimerStart",
+            new TimerDefinition(TimerType.Duration, "PT5S"));
+        var handlerEnd = new EndEvent("nestedHandlerEnd");
+        var nestedEvtSub = new EventSubProcess("nestedEvtSub")
+        {
+            Activities = [timerStart, handlerEnd],
+            SequenceFlows = [new SequenceFlow("nested_sf1", timerStart, handlerEnd)],
+            IsInterrupting = true,
+        };
+
+        var innerStart = new StartEvent("innerStart");
+        var innerUserTask = new TaskActivity("innerUserTask");
+        var innerEnd = new EndEvent("innerEnd");
+
+        var outerTx = new Transaction("outerTx")
+        {
+            Activities = [innerStart, innerUserTask, innerEnd, nestedEvtSub],
+            SequenceFlows =
+            [
+                new SequenceFlow("outer_sf1", innerStart, innerUserTask),
+                new SequenceFlow("outer_sf2", innerUserTask, innerEnd),
+            ],
+        };
+
+        var start = new StartEvent("start");
+        var end = new EndEvent("end");
+        var workflow = new WorkflowDefinition
+        {
+            WorkflowId = "timer-esp-nested-in-transaction",
+            Activities = [start, outerTx, end],
+            SequenceFlows =
+            [
+                new SequenceFlow("f1", start, outerTx),
+                new SequenceFlow("f2", outerTx, end),
+            ],
+        };
+
+        var workflowInstance = Cluster.GrainFactory.GetGrain<IWorkflowInstanceGrain>(Guid.NewGuid());
+        await workflowInstance.SetWorkflow(workflow);
+        await workflowInstance.StartWorkflow();
+
+        var instanceId = workflowInstance.GetPrimaryKey();
+        await Task.Delay(500);
+
+        var running = await QueryService.GetStateSnapshot(instanceId);
+        var outerTxEntry = running!.ActiveActivities.FirstOrDefault(a => a.ActivityId == "outerTx");
+        Assert.IsNotNull(outerTxEntry, "outerTx must be active before timer fires");
+
+        await workflowInstance.HandleTimerFired(
+            "nestedTimerStart", outerTxEntry!.ActivityInstanceId);
+
+        var snapshot = await PollForNoActiveActivities(instanceId);
+        Assert.IsNotNull(snapshot);
+        Assert.IsTrue(snapshot!.IsCompleted,
+            "Transaction with nested timer ESP must complete (Transaction : SubProcess inheritance)");
+        Assert.IsTrue(snapshot.CompletedActivities.Any(a => a.ActivityId == "outerTx"),
+            "outerTx host must complete after the nested ESP closes");
+        Assert.IsTrue(snapshot.CompletedActivities.Any(a => a.ActivityId == "innerUserTask"
+                                                              && a.IsCancelled),
+            "innerUserTask must be cancelled by the interrupting nested ESP");
+    }
+
+    // -------------------------------------------------------------------------
+    // Shared assertions
+    // -------------------------------------------------------------------------
+
+    private static void AssertNestedHandlerCompletedAndOuterClosed(InstanceStateSnapshot snapshot)
+    {
+        var inner = snapshot.CompletedActivities.FirstOrDefault(a => a.ActivityId == "innerUserTask");
+        Assert.IsNotNull(inner, "innerUserTask must appear in terminal list");
+        Assert.IsTrue(inner!.IsCancelled, "innerUserTask must be cancelled by interrupting ESP");
+
+        Assert.IsTrue(snapshot.CompletedActivities.Any(a => a.ActivityId == "nestedHandlerEnd"
+                                                              && a.ErrorState == null
+                                                              && !a.IsCancelled),
+            "nestedHandlerEnd must complete (handler chain runs after start event fires)");
+
+        Assert.IsTrue(snapshot.CompletedActivities.Any(a => a.ActivityId == "nestedEvtSub"),
+            "nestedEvtSub host must be marked completed");
+        Assert.IsTrue(snapshot.CompletedActivities.Any(a => a.ActivityId == "outerSub"),
+            "outerSub must complete cleanly without InvalidOperationException");
+        Assert.IsFalse(snapshot.CompletedActivities.Any(a => a.ActivityId == "innerEnd"),
+            "innerEnd should not be reached when the interrupting handler short-circuits the flow");
+    }
+
+    private async Task<InstanceStateSnapshot?> PollUntil(
+        Guid instanceId,
+        Func<InstanceStateSnapshot, bool> predicate,
+        int maxAttempts = 50,
+        int intervalMs = 100)
+    {
+        for (var i = 0; i < maxAttempts; i++)
+        {
+            var snapshot = await QueryService.GetStateSnapshot(instanceId);
+            if (snapshot is not null && predicate(snapshot)) return snapshot;
+            await Task.Delay(intervalMs);
+        }
+        return await QueryService.GetStateSnapshot(instanceId);
+    }
+}

--- a/src/Fleans/Fleans.Application.Tests/EventSubProcessTimerTests.cs
+++ b/src/Fleans/Fleans.Application.Tests/EventSubProcessTimerTests.cs
@@ -158,11 +158,6 @@ public class EventSubProcessTimerTests : WorkflowTestBase
     }
 
     [TestMethod]
-    [Ignore("Tracks a newly discovered nested-scope defect — see #284. "
-        + "When a timer EventSubProcess is declared inside a SubProcess, firing "
-        + "the timer throws 'Expected at most one child scope for subprocess host' "
-        + "from WorkflowExecution.CompleteFinishedSubProcessScopes. Re-enable when "
-        + "#284 is fixed.")]
     public async Task TimerEventSubProcess_NestedInsideSubProcess_CompletesScope()
     {
         // Regression for #283 review round 2: ensures scope-id resolution and

--- a/src/Fleans/Fleans.Domain.Tests/WorkflowExecutionScopeCompletionTests.cs
+++ b/src/Fleans/Fleans.Domain.Tests/WorkflowExecutionScopeCompletionTests.cs
@@ -721,6 +721,140 @@ public class WorkflowExecutionScopeCompletionTests
         Assert.IsFalse(hostEntry.IsCompleted);
     }
 
+    // ===== Issue #284: Nested EventSubProcess fail-fast / disambiguation =====
+
+    [TestMethod]
+    public void CompleteFinishedSubProcessScopes_SubProcessWithMultipleChildScopes_LookupResolvesOwnScope()
+    {
+        // Regression for issue #284. Build a SubProcess host that has a sibling
+        // EventSubProcess handler scope (same ParentVariablesId as its own
+        // execution scope). With ScopeHostExecutionScopes populated, the host's
+        // own execution-scope must be unambiguously merged into the parent and
+        // the ESP handler scope must be discarded — no exception thrown.
+        var subStart = new StartEvent("subStart1");
+        var subEnd = new EndEvent("subEnd1");
+        var subProcess = new SubProcess("sub1")
+        {
+            Activities = [subStart, subEnd],
+            SequenceFlows = [new SequenceFlow("subSeq1", subStart, subEnd)]
+        };
+        var start = new StartEvent("start1");
+        var end = new EndEvent("end1");
+
+        var (execution, state, hostEntry) = CreateWithExecutingHost(
+            [start, subProcess, end],
+            [new("seq1", start, subProcess), new("seq2", subProcess, end)],
+            subProcess);
+
+        // Open the SubProcess via the proper command path so ScopeHostExecutionScopes
+        // is populated by the new ScopeHostExecutionScopeOpened projection.
+        execution.ProcessCommands(
+            [new OpenSubProcessCommand(subProcess, hostEntry.VariablesId)],
+            hostEntry.ActivityInstanceId);
+
+        // Manually emulate a sibling EventSubProcess handler scope hung off
+        // hostEntry.VariablesId (this is what TryActivateXxxEventSubProcess does
+        // when an ESP nested in this SubProcess fires).
+        var espHandlerScopeId = Guid.NewGuid();
+        state.AddChildVariableState(espHandlerScopeId, hostEntry.VariablesId);
+
+        // Complete the subStart so the SubProcess's only inner activity is done.
+        var subStartEntry = state.Entries.First(e => e.ActivityId == "subStart1");
+        execution.MarkExecuting(subStartEntry.ActivityInstanceId);
+        execution.MarkCompleted(subStartEntry.ActivityInstanceId, new ExpandoObject());
+        execution.ResolveTransitions(
+        [
+            new CompletedActivityTransitions(subStartEntry.ActivityInstanceId, "subStart1",
+                [new ActivityTransition(subEnd)])
+        ]);
+        var subEndEntry = state.Entries.First(e => e.ActivityId == "subEnd1");
+        execution.MarkExecuting(subEndEntry.ActivityInstanceId);
+        execution.MarkCompleted(subEndEntry.ActivityInstanceId, new ExpandoObject());
+        execution.ClearUncommittedEvents();
+
+        // Two child scopes share hostEntry.VariablesId: the SubProcess's own
+        // execution scope (registered via ScopeHostExecutionScopeOpened) and
+        // the simulated ESP handler scope. The lookup must pick the right one.
+        var siblingCount = state.VariableStates.Count(vs => vs.ParentVariablesId == hostEntry.VariablesId);
+        Assert.AreEqual(2, siblingCount,
+            "Test scenario must have two sibling child scopes under the SubProcess host");
+        Assert.IsTrue(state.ScopeHostExecutionScopes.ContainsKey(hostEntry.ActivityInstanceId),
+            "ScopeHostExecutionScopes must record the host's own execution scope");
+
+        var (effects, completedHostIds, orphanedScopeIds) = execution.CompleteFinishedSubProcessScopes();
+
+        Assert.AreEqual(1, completedHostIds.Count, "Host must complete with two child scopes present");
+        Assert.IsTrue(hostEntry.IsCompleted);
+        // Both child scopes should be queued for removal.
+        Assert.AreEqual(2, orphanedScopeIds.Count,
+            "Both the own execution scope and the ESP handler scope should be queued for removal");
+        Assert.IsTrue(orphanedScopeIds.Contains(espHandlerScopeId),
+            "ESP handler scope must be discarded");
+    }
+
+    [TestMethod]
+    public void CompleteFinishedSubProcessScopes_FallbackFailsFast_WhenLookupAndTopologyDisagree()
+    {
+        // Regression for issue #284 fail-fast branch. Build a SubProcess host
+        // whose ScopeHostExecutionScopes lookup misses (simulating replay over
+        // an event log produced before the fix shipped) AND whose only inner
+        // activities are EventSubProcess hosts (so the topology fallback can
+        // not pick a non-ESP scope). The new structured exception must fire.
+        var espStart = new TimerStartEvent("espTimer",
+            new TimerDefinition(TimerType.Duration, "PT5S"));
+        var espEnd = new EndEvent("espEnd");
+        var nestedEsp = new EventSubProcess("nestedEsp")
+        {
+            Activities = [espStart, espEnd],
+            SequenceFlows = [new SequenceFlow("esp_sf1", espStart, espEnd)],
+            IsInterrupting = true,
+        };
+
+        var subProcess = new SubProcess("sub1")
+        {
+            Activities = [nestedEsp],
+            SequenceFlows = []
+        };
+        var start = new StartEvent("start1");
+        var end = new EndEvent("end1");
+
+        var (execution, state, hostEntry) = CreateWithExecutingHost(
+            [start, subProcess, end],
+            [new("seq1", start, subProcess), new("seq2", subProcess, end)],
+            subProcess);
+
+        // Hand-build the SubProcess host's child scopes WITHOUT going through
+        // OpenSubProcessCommand so ScopeHostExecutionScopes stays empty.
+        var ownScopeId = Guid.NewGuid();
+        state.AddChildVariableState(ownScopeId, hostEntry.VariablesId);
+        var espHandlerScopeId = Guid.NewGuid();
+        state.AddChildVariableState(espHandlerScopeId, hostEntry.VariablesId);
+
+        // Spawn an ESP host entry inside the SubProcess so the topology fallback
+        // sees only ESP children — and therefore returns null.
+        var espEntry = new ActivityInstanceEntry(
+            Guid.NewGuid(), nestedEsp.ActivityId, state.Id, hostEntry.ActivityInstanceId);
+        espEntry.SetActivityType(nameof(EventSubProcess));
+        espEntry.SetVariablesId(espHandlerScopeId);
+        state.AddEntries([espEntry]);
+        // Mark the only inner entry as completed so the SubProcess "all
+        // children completed" gate passes.
+        espEntry.Execute();
+        espEntry.Complete();
+        execution.ClearUncommittedEvents();
+
+        Assert.IsFalse(state.ScopeHostExecutionScopes.ContainsKey(hostEntry.ActivityInstanceId),
+            "Test scenario must have an empty ScopeHostExecutionScopes lookup");
+
+        var ex = Assert.ThrowsExactly<InvalidOperationException>(() =>
+            execution.CompleteFinishedSubProcessScopes());
+
+        Assert.IsTrue(ex.Message.Contains("Cannot identify own execution scope"),
+            $"Fail-fast message must explain the disambiguation gap. Got: {ex.Message}");
+        Assert.IsTrue(ex.Message.Contains("ScopeHostExecutionScopes lookup missed"),
+            "Fail-fast message must point at the lookup miss as the root cause");
+    }
+
     // ===== Apply VariableScopesRemoved Tests =====
 
     [TestMethod]

--- a/src/Fleans/Fleans.Domain/Aggregates/WorkflowExecution.cs
+++ b/src/Fleans/Fleans.Domain/Aggregates/WorkflowExecution.cs
@@ -884,6 +884,11 @@ public class WorkflowExecution
     {
         var newScopeId = Guid.NewGuid();
         Emit(new ChildVariableScopeCreated(newScopeId, openSub.ParentVariablesId));
+        // Bind the host activity instance to its own execution scope so that
+        // CompleteFinishedSubProcessScopes can disambiguate the host scope
+        // from sibling EventSubProcess handler scopes that share the same
+        // ParentVariablesId. See issue #284.
+        Emit(new ScopeHostExecutionScopeOpened(hostActivityInstanceId, newScopeId));
 
         var startEvent = openSub.SubProcess.Activities.OfType<StartEvent>().FirstOrDefault()
             ?? throw new InvalidOperationException(
@@ -1384,22 +1389,49 @@ public class WorkflowExecution
 
                 if (isSubProcess)
                 {
-                    // SubProcess: merge child scope variables into parent before completing.
-                    // Use ParentVariablesId lookup (not entry-based collection) because
-                    // internal fork-join may have already removed branch scopes from state.
-                    var childScopes = _state.VariableStates
+                    // SubProcess: merge the host's OWN execution-scope into the
+                    // parent before completing. A nested EventSubProcess may have
+                    // emitted a sibling handler scope with the same ParentVariablesId
+                    // (issue #284), so we cannot assume Count <= 1 here. Resolve the
+                    // host's own scope by ownership lookup; fall back to topology if
+                    // the lookup is empty (e.g., replay before the fix shipped).
+                    var allChildScopes = _state.VariableStates
                         .Where(vs => vs.ParentVariablesId == entry.VariablesId)
                         .ToList();
-                    if (childScopes.Count > 1)
-                        throw new InvalidOperationException(
-                            $"Expected at most one child scope for subprocess host {entry.ActivityId}, found {childScopes.Count}");
-                    var childScope = childScopes.FirstOrDefault();
-                    if (childScope is not null)
+
+                    WorkflowVariablesState? ownExecutionScope = null;
+                    if (_state.ScopeHostExecutionScopes.TryGetValue(entry.ActivityInstanceId, out var ownId))
                     {
-                        Emit(new VariablesMerged(entry.VariablesId, childScope.Variables));
+                        ownExecutionScope = allChildScopes.FirstOrDefault(s => s.Id == ownId);
+                    }
+                    if (ownExecutionScope is null)
+                    {
+                        ownExecutionScope = DeriveOwnExecutionScopeFallback(entry, allChildScopes);
+                    }
+
+                    if (ownExecutionScope is null && allChildScopes.Count > 0)
+                    {
+                        throw new InvalidOperationException(
+                            $"Cannot identify own execution scope for SubProcess host {entry.ActivityId} " +
+                            $"(instance {entry.ActivityInstanceId}); candidates: " +
+                            $"[{string.Join(", ", allChildScopes.Select(c => c.Id))}]. " +
+                            "ScopeHostExecutionScopes lookup missed and fallback could not disambiguate.");
+                    }
+
+                    if (ownExecutionScope is not null)
+                    {
+                        Emit(new VariablesMerged(entry.VariablesId, ownExecutionScope.Variables));
                         // Defer scope removal: nested subprocess transitions (resolved after
                         // this method returns) may still reference the child scope.
-                        allOrphanedScopeIds.Add(childScope.Id);
+                        allOrphanedScopeIds.Add(ownExecutionScope.Id);
+                    }
+
+                    // Any other child scopes are sibling EventSubProcess handler scopes —
+                    // discard them (mirrors the EventSubProcess branch below).
+                    foreach (var orphan in allChildScopes)
+                    {
+                        if (ownExecutionScope is not null && orphan.Id == ownExecutionScope.Id) continue;
+                        allOrphanedScopeIds.Add(orphan.Id);
                     }
                 }
                 else if (isEventSubProcess)
@@ -1475,6 +1507,32 @@ public class WorkflowExecution
         }
 
         return (allEffects.AsReadOnly(), allCompletedHostIds.AsReadOnly(), allOrphanedScopeIds.AsReadOnly());
+    }
+
+    /// <summary>
+    /// Topology-based deterministic fallback used when
+    /// <see cref="WorkflowInstanceState.ScopeHostExecutionScopes"/> does not
+    /// resolve a SubProcess host's own execution scope (e.g. replay over an
+    /// event log produced before issue #284's fix shipped). Walks the entries
+    /// in the host's child container, skipping any whose definition is an
+    /// <see cref="EventSubProcess"/>, and returns the first candidate scope
+    /// that matches a non-ESP child entry's <c>VariablesId</c>.
+    /// </summary>
+    private WorkflowVariablesState? DeriveOwnExecutionScopeFallback(
+        ActivityInstanceEntry hostEntry,
+        IReadOnlyList<WorkflowVariablesState> candidates)
+    {
+        if (candidates.Count == 0) return null;
+        if (candidates.Count == 1) return candidates[0];
+
+        foreach (var e in _state.GetEntriesInScope(hostEntry.ActivityInstanceId))
+        {
+            var act = _definition.GetActivityAcrossScopes(e.ActivityId);
+            if (act is EventSubProcess) continue;
+            var hit = candidates.FirstOrDefault(c => c.Id == e.VariablesId);
+            if (hit is not null) return hit;
+        }
+        return null;
     }
 
     // --- User Task Handling ---
@@ -2803,6 +2861,9 @@ public class WorkflowExecution
             case ChildVariableScopeCreated e:
                 _state.AddChildVariableState(e.ScopeId, e.ParentScopeId);
                 break;
+            case ScopeHostExecutionScopeOpened e:
+                _state.ScopeHostExecutionScopes[e.HostInstanceId] = e.ExecutionScopeId;
+                break;
             case VariableScopeCloned e:
                 _state.AddCloneOfVariableState(e.NewScopeId, e.SourceScopeId);
                 break;
@@ -2935,6 +2996,13 @@ public class WorkflowExecution
     private void ApplyActivityCompleted(ActivityCompleted e)
     {
         _state.CompleteEntry(e.ActivityInstanceId, e.Variables, e.VariablesId);
+        // Bound ScopeHostExecutionScopes growth across long-running workflows
+        // by removing the host's entry on terminal transition. Idempotent on
+        // replay: Remove is a no-op when the key is absent. The ActivityType
+        // check is replay-safe (no dependency on _definition, which is null
+        // during replay-mode reconstruction).
+        if (IsSubProcessActivityType(_state.GetEntry(e.ActivityInstanceId).ActivityType))
+            _state.ScopeHostExecutionScopes.Remove(e.ActivityInstanceId);
     }
 
     private void ApplyActivityFailed(ActivityFailed e)
@@ -2945,7 +3013,20 @@ public class WorkflowExecution
     private void ApplyActivityCancelled(ActivityCancelled e)
     {
         _state.CancelEntry(e.ActivityInstanceId, e.Reason);
+        if (IsSubProcessActivityType(_state.GetEntry(e.ActivityInstanceId).ActivityType))
+            _state.ScopeHostExecutionScopes.Remove(e.ActivityInstanceId);
     }
+
+    /// <summary>
+    /// Returns true when the activity-instance entry's <c>ActivityType</c>
+    /// (set from <c>GetType().Name</c> at spawn time) matches a SubProcess host
+    /// — i.e. <see cref="SubProcess"/> or its sealed subclass <see cref="Transaction"/>.
+    /// Used to keep the <see cref="WorkflowInstanceState.ScopeHostExecutionScopes"/>
+    /// dictionary bounded as host activity instances reach a terminal state.
+    /// Replay-safe: does not touch <c>_definition</c>.
+    /// </summary>
+    private static bool IsSubProcessActivityType(string? activityType)
+        => activityType == nameof(SubProcess) || activityType == nameof(Transaction);
 
     private void ApplyGatewayForkTokenAdded(GatewayForkTokenAdded e)
     {

--- a/src/Fleans/Fleans.Domain/Events/WorkflowDomainEvents.cs
+++ b/src/Fleans/Fleans.Domain/Events/WorkflowDomainEvents.cs
@@ -28,6 +28,16 @@ public record ChildVariableScopeCreated(Guid ScopeId, Guid ParentScopeId) : IDom
 public record VariableScopeCloned(Guid NewScopeId, Guid SourceScopeId) : IDomainEvent;
 public record VariableScopesRemoved(IReadOnlyList<Guid> ScopeIds) : IDomainEvent;
 
+/// <summary>
+/// Tracks the binding between a scope-host activity instance (SubProcess or
+/// Transaction) and its own execution-scope variables id, so that scope
+/// completion can disambiguate the host's own scope from sibling
+/// EventSubProcess handler scopes that share the host's parent variables id.
+/// Emitted from <c>ProcessOpenSubProcess</c>; cleanup is folded into
+/// <c>ApplyActivityCompleted</c>/<c>ApplyActivityCancelled</c>.
+/// </summary>
+public record ScopeHostExecutionScopeOpened(Guid HostInstanceId, Guid ExecutionScopeId) : IDomainEvent;
+
 // Gateway/token management
 public record ConditionSequencesAdded(
     Guid GatewayInstanceId, string[] SequenceFlowIds) : IDomainEvent;

--- a/src/Fleans/Fleans.Domain/States/WorkflowInstanceState.cs
+++ b/src/Fleans/Fleans.Domain/States/WorkflowInstanceState.cs
@@ -125,6 +125,17 @@ public class WorkflowInstanceState
     public List<ConditionalEventWatcherState> ConditionalWatchers { get; private set; } = [];
 
     /// <summary>
+    /// Maps each open SubProcess (and Transaction) host's ActivityInstanceId →
+    /// its own execution-scope variables id. Populated by the
+    /// <c>ScopeHostExecutionScopeOpened</c> projection; pruned by
+    /// <c>ApplyActivityCompleted</c>/<c>ApplyActivityCancelled</c> for SubProcess
+    /// hosts. In-memory — excluded from EF Core schema; rebuilt from the event
+    /// log on activation, like <see cref="TransactionOutcomes"/>.
+    /// </summary>
+    [Id(24)]
+    public Dictionary<Guid, Guid> ScopeHostExecutionScopes { get; private set; } = new();
+
+    /// <summary>
     /// Append-only log of completed, compensable activities (those with a CompensationBoundaryEvent attached).
     /// Keyed implicitly by ScopeId on each entry. Used as input to compensation walks.
     /// </summary>

--- a/src/Fleans/Fleans.Persistence/FleanModelConfiguration.cs
+++ b/src/Fleans/Fleans.Persistence/FleanModelConfiguration.cs
@@ -57,6 +57,11 @@ internal static class FleanModelConfiguration
             // TransactionOutcomes is rebuilt from TransactionOutcomeSet events on grain activation.
             entity.Ignore(e => e.TransactionOutcomes);
 
+            // ScopeHostExecutionScopes is rebuilt from ScopeHostExecutionScopeOpened events
+            // (and pruned by ApplyActivityCompleted/ApplyActivityCancelled) on grain activation.
+            // See issue #284.
+            entity.Ignore(e => e.ScopeHostExecutionScopes);
+
             entity.HasMany(e => e.TimerCycleTracking)
                 .WithOne()
                 .HasForeignKey(e => e.WorkflowInstanceId)


### PR DESCRIPTION
Closes #284.

## Summary

When an `EventSubProcess` (timer / message / signal) is nested inside a `SubProcess`, firing its start event used to throw `Expected at most one child scope for subprocess host …` because the ESP handler scope shares its `ParentVariablesId` with the SubProcess's own execution scope, and the single-child-scope guard in `CompleteFinishedSubProcessScopes` treated both as ambiguous.

Implementation follows the Round 5 design approved on #284 (selection-by-ownership + symmetric Open / projection-driven cleanup):

- New domain event `ScopeHostExecutionScopeOpened` binds a `SubProcess` / `Transaction` host's `ActivityInstanceId` to its own execution-scope variables id. Emitted from `ProcessOpenSubProcess` right after `ChildVariableScopeCreated`.
- New `WorkflowInstanceState.ScopeHostExecutionScopes` (`[Id(24)]`, in-memory, EF-`Ignore`d, rebuildable from the event log on activation like `TransactionOutcomes`).
- Cleanup is folded into the existing `ApplyActivityCompleted` / `ApplyActivityCancelled` projections via a replay-safe `ActivityType` check (no `_definition` dependency, so it works during replay-mode reconstruction).
- The SubProcess branch of `CompleteFinishedSubProcessScopes` resolves the host's own scope by ownership lookup, falling back to a deterministic topology-based `DeriveOwnExecutionScopeFallback` that ignores `EventSubProcess` child entries when the lookup misses (e.g. replay over an event log produced before this fix shipped). Sibling ESP handler scopes are discarded the same way the existing `EventSubProcess` branch already discards them.
- `Transaction` is covered transparently by `Transaction : SubProcess` inheritance — no separate code path.

## Test plan

- [x] `dotnet build` clean (0 errors)
- [x] Full `dotnet test`: 1031 passed, 0 failed, 115 skipped (2 new ignored variants + pre-existing skips)
- [x] Re-enabled `TimerEventSubProcess_NestedInsideSubProcess_CompletesScope` (original repro from #284) — passes
- [x] New `EventSubProcessNestedInSubProcessTests` covers nested message ESP, signal ESP, ESP-in-ESP-in-SubProcess, and Transaction → nested timer ESP — all pass
- [x] New unit tests in `WorkflowExecutionScopeCompletionTests` cover (a) ownership-based scope resolution with two sibling child scopes and (b) fail-fast `InvalidOperationException` when both lookup and topology fallback miss
- [ ] Manual regression sweep against the live stack (deferred to the regression-testing skill — Phase D fixtures under `tests/manual/31-nested-event-subprocess/` not added in this PR; tracked as a follow-up if needed)

### Out of scope for this PR

- Two regression-guard test variants (`ErrorEventSubProcess_NestedInsideSubProcess` and `NonInterruptingTimerEventSubProcess_NestedInsideSubProcess`) are filed `[Ignore]` with explanatory comments — they exercise pre-existing, unrelated limitations (BPMN-error propagation across SubProcess boundaries; concurrent variable-scope reaping during a non-interrupting handler completion). The four passing variants here cover the exact failure mode reported in #284.

🤖 Generated with [Claude Code](https://claude.com/claude-code)