### PR TITLE
docs(#390): clarify Aspire is dev-only in Quick Start + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ It runs 2 applications :
 - Fleans.Api - workflow engine - orleans silo 
 - Fleans.Web - blazor application - admin panel for workflow
 
+> **Note:** Aspire is the dev orchestrator. For production deployments (Docker Compose, Kubernetes, bare VM), see the [deployment guide](https://nightbaker.github.io/fleans/reference/self-hosting/) on the website.
+
 ## Bpmn elements 
 For now, next elements are implemented 
 

--- a/website/src/content/docs/guides/quick-start.md
+++ b/website/src/content/docs/guides/quick-start.md
@@ -10,6 +10,10 @@ description: Run Fleans locally in under 5 minutes.
 
 ## Clone and run
 
+:::tip[Aspire is for development, not production]
+`dotnet run --project Fleans.Aspire` boots Fleans on your laptop with everything wired up — perfect for trying things out and developing workflows. To deploy Fleans for staging or production, see the [Self-Hosting on Kubernetes](/fleans/reference/self-hosting/) guide for the recommended Helm-chart path.
+:::
+
 ```bash
 git clone https://github.com/nightBaker/fleans.git
 cd fleans/src/Fleans


### PR DESCRIPTION
Closes #390

## Summary
- **Quick Start callout** — added a Starlight `:::tip` block under `## Clone and run` in `website/src/content/docs/guides/quick-start.md` flagging that `dotnet run --project Fleans.Aspire` is the dev path and pointing readers to the Self-Hosting on Kubernetes guide for production.
- **README addendum** — added a one-line `> **Note:** ...` under `## Running the Application` in `README.md` linking to the same self-hosting page on the published docs site.

## Cross-link target
PR #460 (the upcoming `reference/deployment/` page from #389) was still **OPEN** at branch time (`gh pr view 460 --json state,mergedAt` → `state: OPEN, mergedAt: null`), so per the v1 plan both edits link to `reference/self-hosting/`. No "swap once #389 lands" parenthetical was included — that becomes a separate trivial follow-up if/when #460 merges.

## Test plan
- [x] `cd website && npm run build` — passes cleanly (19 pages, no warnings touching the edited file).
- [ ] Visual inspection of `/fleans/guides/quick-start/` after deploy — callout renders as a Starlight tip; link to `/fleans/reference/self-hosting/` resolves.
- [ ] README renders correctly on github.com — note block renders as Markdown blockquote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
