### PR TITLE
fix(#413): fail fast on unknown Persistence:Provider value

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,7 +270,7 @@ Website-specific manual tests live under `tests/manual/website/`. These run in a
 
 Two providers: **SQLite** (default, local dev) and **PostgreSQL** (production/load testing). Selected via configuration — no code changes needed.
 
-- **Config key:** `Persistence:Provider` (values: `Sqlite` | `Postgres`, case-insensitive, default `Sqlite`)
+- **Config key:** `Persistence:Provider` (values: `Sqlite` | `Postgres`, case-insensitive, default `Sqlite`). `AddFleansPersistence` throws `ArgumentException` on any other value (typos, empty, whitespace) so misconfigured deployments fail fast — mirrors the validation pattern in `FleanStreamingExtensions.cs:26`.
 - **Aspire:** set `FLEANS_PERSISTENCE_PROVIDER=Postgres` env var before launch to auto-provision a Postgres container
 - **Connection strings:** SQLite uses `FLEANS_SQLITE_CONNECTION` / `FLEANS_QUERY_CONNECTION` env vars. PostgreSQL uses `ConnectionStrings:fleans` (required) and `ConnectionStrings:fleans-query` (optional read replica).
 - **Migration strategy:** SQLite uses `EnsureCreated()`. PostgreSQL uses `MigrateAsync()` (migrations applied automatically by `Fleans.Api` on startup).

--- a/src/Fleans/Fleans.Persistence.Tests/Fleans.Persistence.Tests.csproj
+++ b/src/Fleans/Fleans.Persistence.Tests/Fleans.Persistence.Tests.csproj
@@ -19,9 +19,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Fleans.Persistence\Fleans.Persistence.csproj" />
     <ProjectReference Include="..\Fleans.Persistence.Sqlite\Fleans.Persistence.Sqlite.csproj" />
     <ProjectReference Include="..\Fleans.Persistence.PostgreSql\Fleans.Persistence.PostgreSql.csproj" />
+    <ProjectReference Include="..\Fleans.ServiceDefaults\Fleans.ServiceDefaults.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Fleans/Fleans.Persistence.Tests/FleansPersistenceExtensionsTests.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/FleansPersistenceExtensionsTests.cs
@@ -1,0 +1,121 @@
+using Fleans.Persistence;
+using Fleans.ServiceDefaults;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Fleans.Persistence.Tests;
+
+[TestClass]
+public class FleansPersistenceExtensionsTests
+{
+    private static HostApplicationBuilder NewBuilder(IDictionary<string, string?> configValues)
+    {
+        var builder = Host.CreateApplicationBuilder();
+        builder.Configuration.AddInMemoryCollection(configValues);
+        return builder;
+    }
+
+    [TestMethod]
+    public void Sqlite_provider_succeeds()
+    {
+        var builder = NewBuilder(new Dictionary<string, string?>
+        {
+            ["Persistence:Provider"] = "Sqlite",
+        });
+
+        builder.AddFleansPersistence();
+
+        using var host = builder.Build();
+        using var scope = host.Services.CreateScope();
+        var dbFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<FleanCommandDbContext>>();
+        using var db = dbFactory.CreateDbContext();
+        Assert.AreEqual("Microsoft.EntityFrameworkCore.Sqlite", db.Database.ProviderName);
+    }
+
+    [TestMethod]
+    public void SQLITE_provider_succeeds_case_insensitive()
+    {
+        var builder = NewBuilder(new Dictionary<string, string?>
+        {
+            ["Persistence:Provider"] = "SQLITE",
+        });
+
+        builder.AddFleansPersistence();
+
+        using var host = builder.Build();
+        using var scope = host.Services.CreateScope();
+        var dbFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<FleanCommandDbContext>>();
+        using var db = dbFactory.CreateDbContext();
+        Assert.AreEqual("Microsoft.EntityFrameworkCore.Sqlite", db.Database.ProviderName);
+    }
+
+    [TestMethod]
+    public void Postgres_provider_with_connection_string_succeeds()
+    {
+        var builder = NewBuilder(new Dictionary<string, string?>
+        {
+            ["Persistence:Provider"] = "Postgres",
+            ["ConnectionStrings:fleans"] = "Host=test;Database=fleans;Username=fleans;Password=stub;",
+        });
+
+        builder.AddFleansPersistence();
+
+        using var host = builder.Build();
+        using var scope = host.Services.CreateScope();
+        var dbFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<FleanCommandDbContext>>();
+        using var db = dbFactory.CreateDbContext();
+        Assert.AreEqual("Npgsql.EntityFrameworkCore.PostgreSQL", db.Database.ProviderName);
+    }
+
+    [TestMethod]
+    public void Postgres_without_connection_string_throws_invalidOperation()
+    {
+        var builder = NewBuilder(new Dictionary<string, string?>
+        {
+            ["Persistence:Provider"] = "Postgres",
+        });
+
+        var ex = Assert.ThrowsExactly<InvalidOperationException>(() => builder.AddFleansPersistence());
+        StringAssert.Contains(ex.Message, "Connection string 'fleans' is required");
+    }
+
+    [TestMethod]
+    public void Unknown_provider_throws_argumentException()
+    {
+        var builder = NewBuilder(new Dictionary<string, string?>
+        {
+            ["Persistence:Provider"] = "PostgreSQL",
+        });
+
+        var ex = Assert.ThrowsExactly<ArgumentException>(() => builder.AddFleansPersistence());
+        StringAssert.Contains(ex.Message, "'PostgreSQL'");
+        StringAssert.Contains(ex.Message, "Sqlite, Postgres");
+    }
+
+    [TestMethod]
+    public void Whitespace_provider_throws_argumentException()
+    {
+        var builder = NewBuilder(new Dictionary<string, string?>
+        {
+            ["Persistence:Provider"] = " ",
+        });
+
+        var ex = Assert.ThrowsExactly<ArgumentException>(() => builder.AddFleansPersistence());
+        StringAssert.Contains(ex.Message, "Sqlite, Postgres");
+    }
+
+    [TestMethod]
+    public void Empty_string_provider_throws_argumentException()
+    {
+        var builder = NewBuilder(new Dictionary<string, string?>
+        {
+            ["Persistence:Provider"] = "",
+        });
+
+        var ex = Assert.ThrowsExactly<ArgumentException>(() => builder.AddFleansPersistence());
+        StringAssert.Contains(ex.Message, "''");
+        StringAssert.Contains(ex.Message, "Sqlite, Postgres");
+    }
+}

--- a/src/Fleans/Fleans.ServiceDefaults/FleansPersistenceExtensions.cs
+++ b/src/Fleans/Fleans.ServiceDefaults/FleansPersistenceExtensions.cs
@@ -32,11 +32,17 @@ public static class FleansPersistenceExtensions
             var queryConnStr = builder.Configuration.GetConnectionString("fleans-query");
             builder.Services.AddPostgresPersistence(connStr, queryConnStr);
         }
-        else
+        else if (provider.Equals("Sqlite", StringComparison.OrdinalIgnoreCase))
         {
             var connStr = builder.Configuration["FLEANS_SQLITE_CONNECTION"] ?? "DataSource=fleans-dev.db";
             var queryConnStr = builder.Configuration["FLEANS_QUERY_CONNECTION"];
             builder.Services.AddSqlitePersistence(connStr, queryConnStr);
+        }
+        else
+        {
+            throw new ArgumentException(
+                $"Unknown persistence provider '{provider}'. Supported: Sqlite, Postgres. " +
+                $"Set Persistence:Provider in configuration.");
         }
 
         return builder;

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -81,7 +81,7 @@ Allowed values: `Core`, `Worker`, `Combined` (case-insensitive). Invalid values 
 | --- | --- | --- | --- |
 | `Persistence__Provider` | `Persistence:Provider` | `Fleans.ServiceDefaults/FleansPersistenceExtensions.cs:23` | `"Sqlite"` (case-insensitive; accepts `Sqlite` or `Postgres`) |
 
-The provider toggle. `Postgres` runs `MigrateAsync()` at startup; `Sqlite` runs `EnsureCreated()`. SQLite is dev-only and ignored in container/k8s deployments.
+The provider toggle. `Postgres` runs `MigrateAsync()` at startup; `Sqlite` runs `EnsureCreated()`. SQLite is dev-only and ignored in container/k8s deployments. Any other value (typo like `PostgreSQL`, empty string, whitespace) throws `ArgumentException` at silo startup so misconfigured deployments fail fast instead of silently falling back to an in-pod SQLite file.
 
 ### Streaming
 


### PR DESCRIPTION
## Summary

Closes #413.

`FleansPersistenceExtensions.AddFleansPersistence` previously fell back to
SQLite for any non-`Postgres` value of `Persistence:Provider` (typo, empty,
whitespace). In a production Kubernetes pod the default SQLite path
resolves to a writable in-pod temp file, so the silo started successfully,
passed health checks, and accepted traffic — while losing all workflow
state across pod restarts. There was no log warning, no startup failure,
no observable signal.

The fix mirrors the sister `FleanStreamingExtensions.cs:26-28` pattern:
explicit `if (Postgres) / else if (Sqlite) / else throw ArgumentException`.

```csharp
else
{
    throw new ArgumentException(
        $"Unknown persistence provider '{provider}'. Supported: Sqlite, Postgres. " +
        $"Set Persistence:Provider in configuration.");
}
```

Single-string `ArgumentException(message)` overload — no `paramName`
argument (per v2 plan §2.1; matches the streaming sister exactly).

## Tests (7 new, all pass)

- `Sqlite_provider_succeeds`
- `SQLITE_provider_succeeds_case_insensitive`
- `Postgres_provider_with_connection_string_succeeds`
- `Postgres_without_connection_string_throws_invalidOperation` (regression fence for existing safety net)
- `Unknown_provider_throws_argumentException` (`PostgreSQL` typo)
- `Whitespace_provider_throws_argumentException`
- `Empty_string_provider_throws_argumentException`

```text
Passed!  - Failed: 0, Passed: 7, Skipped: 0, Total: 7, Duration: 3 s
```

`Fleans.Persistence.Tests.csproj` gains `<FrameworkReference Include="Microsoft.AspNetCore.App" />`
and `<ProjectReference>` to `Fleans.ServiceDefaults` to access
`HostApplicationBuilder` — mirrors the pattern from `Fleans.Application.Tests.csproj`.

Note: `IHostApplicationBuilder` is the abstraction; the concrete
`HostApplicationBuilder` returned by `Host.CreateApplicationBuilder()`
exposes the `Build()` method the tests use. The helper signature is
`HostApplicationBuilder NewBuilder(...)` to keep `Build()` reachable.

## Docs

- `website/src/content/docs/reference/configuration.md` — appended a
  sentence to the `Persistence__Provider` row clarifying that unknown
  values throw at startup.
- `src/Fleans/CLAUDE.md` — Persistence Providers section's first bullet
  appended a one-line note about the fail-fast validation, with a
  cross-reference to `FleanStreamingExtensions.cs:26` as the pattern source.

## Empty-string vs whitespace handling

`?? "Sqlite"` only fires on `null` (configuration missing). After this
change:

- `Persistence:Provider` missing → `null` → `?? "Sqlite"` → SQLite (existing default).
- `Persistence:Provider=""` → `""` → reaches throw arm → **fails fast**.
- `Persistence:Provider="   "` → reaches throw arm → **fails fast**.

An operator setting `Persistence:Provider=""` (e.g.
`helm install --set persistence.provider=""`) is making a misconfiguration
mistake; throwing surfaces it. Per v2 §3.4.

## Test plan

- [x] `dotnet build` succeeds.
- [x] 7 new tests pass.
- [x] Existing `Fleans.Persistence.Tests` still pass (changes are additive).
- [ ] Maintainer human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
