### PR TITLE
feat(#410): cosign keyless signing for release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,6 +151,20 @@ jobs:
             --tag ghcr.io/nightbaker/${{ matrix.service.repo }}:latest \
             ghcr.io/nightbaker/${{ matrix.service.repo }}:${{ needs.setup.outputs.version }}
 
+      - name: Resolve image digest
+        id: digest
+        run: |
+          set -euo pipefail
+          REF="ghcr.io/nightbaker/${{ matrix.service.repo }}:${{ needs.setup.outputs.version }}"
+          DIGEST=$(docker buildx imagetools inspect "$REF" --format '{{.Manifest.Digest}}')
+          echo "ref_digest=ghcr.io/nightbaker/${{ matrix.service.repo }}@$DIGEST" >> "$GITHUB_OUTPUT"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign container image (keyless)
+        run: cosign sign --yes "${{ steps.digest.outputs.ref_digest }}"
+
   compose:
     name: Aspire docker-compose bundle
     needs: setup
@@ -339,10 +353,26 @@ jobs:
           helm package charts/fleans --version "${{ needs.setup.outputs.version }}" --app-version "${{ needs.setup.outputs.version }}" -d /tmp/
           ls -la /tmp/fleans-*.tgz
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign helm chart tarball (keyless blob)
+        run: |
+          set -euo pipefail
+          cd /tmp
+          cosign sign-blob --yes \
+            --output-signature   "fleans-${{ needs.setup.outputs.version }}.tgz.sig" \
+            --output-certificate "fleans-${{ needs.setup.outputs.version }}.tgz.crt" \
+            "fleans-${{ needs.setup.outputs.version }}.tgz"
+          ls -la fleans-${{ needs.setup.outputs.version }}.tgz*
+
       - uses: actions/upload-artifact@v4
         with:
           name: fleans-helm-v${{ needs.setup.outputs.version }}
-          path: /tmp/fleans-*.tgz
+          path: |
+            /tmp/fleans-*.tgz
+            /tmp/fleans-*.tgz.sig
+            /tmp/fleans-*.tgz.crt
           retention-days: 90
 
   release:
@@ -386,4 +416,6 @@ jobs:
             --generate-notes \
             $PRE_FLAG \
             ./artifacts/*.zip \
-            ./artifacts/*.tgz
+            ./artifacts/*.tgz \
+            ./artifacts/*.sig \
+            ./artifacts/*.crt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,6 +209,26 @@ The release workflow runs setup → images → compose → helm-drift → releas
 3. **Release assets attached** — `gh release view v0.1.0-beta --json assets` should list `docker-compose-v0.1.0-beta.zip` + `fleans-0.1.0-beta.tgz`.
 4. **Notes look right** — auto-generated notes group commits per `.github/release.yml` categories.
 5. **NuGet publish triggered + green** — the `release.published` event triggers `nuget-publish.yml`. Verify via `gh run list --workflow=nuget-publish.yml --limit 1`. Verify each of the 3 packages on nuget.org: `Fleans.Application.Abstractions`, `Fleans.Worker`, `Fleans.Plugins.RestCaller`.
+6. **Cosign verify smoke test** — pick one of the published images and verify the signature against Sigstore. The output should include a `Bundle` block with a `tlogEntries[0].logIndex` proving the signature was logged to the public Rekor transparency log.
+
+   ```bash
+   cosign verify \
+     --certificate-identity-regexp "https://github.com/nightBaker/fleans/.github/workflows/release.yml@refs/tags/v.*" \
+     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+     ghcr.io/nightbaker/fleans-api:0.1.0-beta | jq
+   ```
+
+   For the helm chart, verify the blob signature using the `.sig` and `.crt` attached to the release (see `self-host-helm.md` for the exact command):
+
+   ```bash
+   gh release download v0.1.0-beta -p 'fleans-0.1.0-beta.tgz*'
+   cosign verify-blob \
+     --certificate fleans-0.1.0-beta.tgz.crt \
+     --signature   fleans-0.1.0-beta.tgz.sig \
+     --certificate-identity-regexp "https://github.com/nightBaker/fleans/.github/workflows/release.yml@refs/tags/v.*" \
+     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+     fleans-0.1.0-beta.tgz
+   ```
 
 ### Rollback
 
@@ -328,6 +348,7 @@ Website-specific manual tests live under `tests/manual/website/`. These run in a
 13. **Kafka production-readiness warning** — `tests/manual/website/kafka-production-warning/test-plan.md`. The `reference/streaming/` page surfaces a top `:::caution[Kafka provider is not production-ready]` admonition before `## Provider switch` naming Confluent Cloud, MSK, Aiven, Redpanda Cloud and quoting the librdkafka error string `Disconnected: SASL authentication required`; the new `## Production-readiness gaps` section renders three severity-tiered tables (🔴 4 rows / 🟡 3 rows / 🟢 4 rows); `deployment.md` carries a one-line `:::caution` cross-linking back to the streaming.md anchor; tracking issue [#474](https://github.com/nightBaker/fleans/issues/474) is referenced and resolves; `grep -rE 'SecurityProtocol|SaslMechanism|SaslUsername|SslCa' src/Fleans/Fleans.Streaming.Kafka/` returns 0 matches (the load-bearing claim). Source-line drift-guard pins live inside the test-plan.
 14. **Quick Start sample BPMN link** — `tests/manual/website/quick-start-sample-link/test-plan.md`. The Quick Start guide's link to the sample BPMN file resolves under the `/fleans/` base path: `dist/guides/quick-start/index.html` contains `href="/fleans/samples/my-process.bpmn"` (≥1) and does NOT contain the broken form `href="/samples/my-process.bpmn"` (=0); `dist/samples/my-process.bpmn` is deployed alongside the page; clicking the link in dev-server mode downloads the file. Note: if `base` in `astro.config.mjs` ever changes, sweep `src/content/docs/**/*.{md,mdx}` for the `/fleans/` literal in the same PR. Source-line drift-guard pins live inside the test-plan.
 15. **Self-host runbook + release pipeline** — `tests/manual/website/self-host-runbook/test-plan.md`. The `guides/self-host-docker-compose.md` and `guides/self-host-helm.md` pages render under the *Self-host* sidebar group (between *Patterns* and *Reference*, 2 items: Docker Compose, Helm Chart); both guides cite the current release tag for `gh release download` examples and cross-link to `reference/{deployment,self-hosting,configuration,persistence,authentication,streaming}/`; the Helm guide's values-table has ≥20 rows extracted from `charts/fleans/values.yaml`; the Compose guide's `.env`-table has ≥10 rows; both guides match the `reference/self-hosting.md` floor of *Helm 3.12+*. CLAUDE.md's `## Cutting a Release` section is intact (Pre-tag checklist, Tag command, Post-tag verification, Rollback, Documentation rule reminder). Source-line drift-guard pins live inside the test-plan.
+16. **Cosign keyless signing for release artifacts** — `tests/manual/website/cosign-signing/test-plan.md`. The release pipeline signs all 4 container images by manifest digest and the Helm chart tarball as a blob using cosign keyless (Sigstore Fulcio CA, public Rekor transparency log). The `images` matrix job at `release.yml` runs `Resolve image digest` → `Install cosign` → `Sign container image (keyless)` for each of `api / web / worker / mcp`; the `helm-drift` job runs `Install cosign` → `Sign helm chart tarball (keyless blob)` after `helm package` and the `actions/upload-artifact` `path:` includes `*.tgz.sig` and `*.tgz.crt`; the `release` job's `gh release create` asset list adds `./artifacts/*.sig` and `./artifacts/*.crt`. The `self-host-docker-compose.md` "Verify the images the bundle pulls" section iterates 4 services with a `cosign verify` loop; the `self-host-helm.md` "Verify the chart and images" section runs `cosign verify-blob` for the chart plus the same 4-service `cosign verify` loop. The `## Cutting a Release` Post-tag verification step 6 runs a `cosign verify | jq` smoke test for the api image plus a `cosign verify-blob` for the chart. Source-line drift-guard pins live inside the test-plan.
 
 > When adding a new website test folder, append a numbered entry here.
 

--- a/tests/manual/website/cosign-signing/test-plan.md
+++ b/tests/manual/website/cosign-signing/test-plan.md
@@ -1,0 +1,93 @@
+# Cosign keyless signing — release artifacts
+
+Manual verification that the release pipeline (`.github/workflows/release.yml`) signs every published artifact with cosign keyless and that the documented `cosign verify` / `cosign verify-blob` recipes succeed.
+
+## Prerequisites
+
+- `gh` CLI authenticated as a maintainer of `nightBaker/fleans`.
+- `cosign` v2.x installed locally.
+- `jq` installed (for inspecting the verify output).
+- A throwaway Sigstore identity is fine — the verify path uses public Rekor.
+
+## Scenarios
+
+1. **Dry-run signs images successfully.** Trigger `gh workflow run release.yml -f version=0.0.0-rc-test` and `gh run watch <run-id>`. The `images` matrix job logs lines containing `Successfully verified SCT receipt` and `tlog entry created with index:` for **all 4** services (`api`, `web`, `worker`, `mcp`). No `secret not found` / `gpg-key not configured` errors. The `helm-drift` job emits the same Rekor lines for the chart blob.
+
+2. **Real tag produces signed images.** `git tag v0.1.0-beta && git push origin v0.1.0-beta`. After the workflow completes:
+
+   ```bash
+   cosign verify \
+     --certificate-identity-regexp "https://github.com/nightBaker/fleans/.github/workflows/release.yml@refs/tags/v.*" \
+     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+     ghcr.io/nightbaker/fleans-api:0.1.0-beta | jq
+   ```
+
+   Exits 0 and prints a JSON object with at least one `Bundle.tlogEntries[].logIndex`.
+
+3. **Repeat for all 4 services.** All four `cosign verify` invocations succeed:
+
+   ```bash
+   for SVC in api web worker mcp; do
+     cosign verify \
+       --certificate-identity-regexp "https://github.com/nightBaker/fleans/.github/workflows/release.yml@refs/tags/v.*" \
+       --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+       ghcr.io/nightbaker/fleans-$SVC:0.1.0-beta
+   done
+   ```
+
+   The release pipeline publishes 4 distinct signed images. The Helm chart's runtime topology — re-using `image.api` for both `core` and `worker` Deployments — is a separate concern; on the registry side every matrix-built image gets signed and verified independently.
+
+4. **Verify the helm chart blob.** `gh release download v0.1.0-beta -p 'fleans-0.1.0-beta.tgz*'` (downloads `.tgz`, `.sig`, `.crt`); run the `cosign verify-blob` from `self-host-helm.md`:
+
+   ```bash
+   cosign verify-blob \
+     --certificate fleans-0.1.0-beta.tgz.crt \
+     --signature   fleans-0.1.0-beta.tgz.sig \
+     --certificate-identity-regexp "https://github.com/nightBaker/fleans/.github/workflows/release.yml@refs/tags/v.*" \
+     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+     fleans-0.1.0-beta.tgz
+   ```
+
+   Exits 0.
+
+5. **Wrong identity is rejected (negative control).** Run:
+
+   ```bash
+   cosign verify \
+     --certificate-identity-regexp "wrong" \
+     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+     ghcr.io/nightbaker/fleans-api:0.1.0-beta
+   ```
+
+   Exits non-zero with a clear identity-mismatch error. Confirms the regex actually filters.
+
+6. **Tampered chart is rejected.** Append a byte to a copy of the `.tgz` (`cp fleans-0.1.0-beta.tgz tampered.tgz && printf 'X' >> tampered.tgz`), run `cosign verify-blob` against the tampered file with the original `.sig` and `.crt`. Exits non-zero with a signature-mismatch error.
+
+7. **No `cosign-installer` cache miss in CI.** Confirm via timing in the workflow run summary that the `Install cosign` step completes in ~2s.
+
+## Cleanup after dry-run
+
+Each `0.0.0-rc-test` invocation publishes 4 images tagged `0.0.0-rc-test` to ghcr.io and emits 4 immutable Rekor entries. Use the `## Cutting a Release` rollback loop to clean up ghcr.io after each dry-run iteration:
+
+```bash
+for IMG in fleans-api fleans-web fleans-worker fleans-mcp; do
+  VID=$(gh api "/user/packages/container/$IMG/versions" \
+    --jq '.[] | select(.metadata.container.tags | index("0.0.0-rc-test")) | .id' \
+    | head -1)
+  [ -n "$VID" ] && gh api -X DELETE "/user/packages/container/$IMG/versions/$VID"
+done
+```
+
+Rekor entries cannot be deleted — that's by design (transparency-log invariant). Repeated dry-runs leave orphan attestations linked to no current image, which is harmless but visible in `rekor-cli search` for the workflow's identity.
+
+## Drift-guard pins
+
+These line-pinned references back the CLAUDE.md regression entry. If any pin no longer resolves to the named symbol at the current branch SHA, update the test-plan and the regression entry together.
+
+- `release.yml:154-166` — `Resolve image digest` → `Install cosign` → `Sign container image (keyless)` block inside the `images` matrix job.
+- `release.yml:356-374` — `Install cosign` + `Sign helm chart tarball (keyless blob)` block in the `helm-drift` job, plus the `actions/upload-artifact` `path:` glob that picks up `*.tgz.sig` / `*.tgz.crt`.
+- `release.yml:420-421` — `gh release create` asset list inside the `release` job (`./artifacts/*.sig` and `./artifacts/*.crt`).
+
+## Reporting
+
+Use the `PASSED` / `FAILED` / `BUG` / `KNOWN BUG` convention from the website regression list in `CLAUDE.md`.

--- a/website/src/content/docs/guides/self-host-docker-compose.md
+++ b/website/src/content/docs/guides/self-host-docker-compose.md
@@ -40,6 +40,23 @@ current release tag when you run these commands — see the `## Cutting a
 Release` runbook in `CLAUDE.md` for the maintainer-side bump cadence.
 :::
 
+## Verify the images the bundle pulls
+
+The compose bundle itself is just declarative YAML — its bytes aren't signed. The substantive supply-chain risk lives in the four container images the YAML references; those images ARE signed by the release pipeline using cosign keyless signing (Sigstore Fulcio CA). Verify each image before `docker compose up`:
+
+```bash
+for SVC in api web worker mcp; do
+  cosign verify \
+    --certificate-identity-regexp "https://github.com/nightBaker/fleans/.github/workflows/release.yml@refs/tags/v.*" \
+    --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+    ghcr.io/nightbaker/fleans-$SVC:0.1.0-beta
+done
+```
+
+Each `cosign verify` exits 0 and prints a JSON object containing a `Bundle` block with `tlogEntries` proving the signature was logged to the public Rekor transparency log.
+
+`docker compose pull` does NOT verify signatures by default; for enforcement, run an admission controller (Kyverno + Sigstore policy) or pre-pull via `docker pull --policy=verify` (Docker 25+ with content trust enabled).
+
 ## 2. Run the stack
 
 ```bash

--- a/website/src/content/docs/guides/self-host-helm.md
+++ b/website/src/content/docs/guides/self-host-helm.md
@@ -42,6 +42,34 @@ is tracked in [#410](https://github.com/nightBaker/fleans/issues/410). Until
 then, the GitHub-Release-asset path is the supported install vector.
 :::
 
+## Verify the chart and images
+
+The release pipeline signs both the chart tarball (as a blob) and every container image (by manifest digest). Run two checks before `helm install`:
+
+**1. Verify the helm chart tarball.** Download `fleans-0.1.0-beta.tgz`, `fleans-0.1.0-beta.tgz.sig`, and `fleans-0.1.0-beta.tgz.crt` from the same GitHub Release, then:
+
+```bash
+cosign verify-blob \
+  --certificate fleans-0.1.0-beta.tgz.crt \
+  --signature   fleans-0.1.0-beta.tgz.sig \
+  --certificate-identity-regexp "https://github.com/nightBaker/fleans/.github/workflows/release.yml@refs/tags/v.*" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  fleans-0.1.0-beta.tgz
+```
+
+**2. Verify each container image.** The chart pulls four images (one of which — `fleans-api` — is reused by the `core` and `worker` Deployments per the chart's `values.yaml` design; even though the Helm chart pulls only `image.api` for both `core` and `worker` Deployments at runtime, the release pipeline publishes all four as distinct signed images for users who want a Worker silo deployable in non-chart deployments):
+
+```bash
+for SVC in api web worker mcp; do
+  cosign verify \
+    --certificate-identity-regexp "https://github.com/nightBaker/fleans/.github/workflows/release.yml@refs/tags/v.*" \
+    --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+    ghcr.io/nightbaker/fleans-$SVC:0.1.0-beta
+done
+```
+
+For production Kubernetes installs, the recommended enforcement is the Sigstore Policy Controller (`policy.sigstore.dev/v1beta1 ClusterImagePolicy`) or Kyverno's `verifyImages`/`verifyManifests` rules.
+
 ## 2. Quick install
 
 ```bash


### PR DESCRIPTION
Closes #410.

## Summary

Adds Sigstore keyless cosign signing to the release pipeline so every published artifact (4 ghcr.io container images + 1 Helm chart tarball) carries a verifiable cryptographic attestation linking it back to a specific `release.yml` workflow run on a tag. Also refreshes the self-host docs and the `## Cutting a Release` runbook with `cosign verify` / `cosign verify-blob` examples.

Implements the v2 Design & Plan approved at https://github.com/nightBaker/fleans/issues/410#issuecomment-2982569099.

## Workflow changes (`.github/workflows/release.yml`)

- **`images` job:** capture manifest-LIST digest via `docker buildx imagetools inspect`, install `sigstore/cosign-installer@v3`, sign each image by digest with `cosign sign --yes repo@sha256:<digest>`. Runs for all 4 services (`api`/`web`/`worker`/`mcp`) via the existing matrix.
- **`helm-drift` job:** install cosign-installer@v3 after `helm package`, then `cosign sign-blob --yes` to emit `.tgz.sig` and `.tgz.crt`. The `actions/upload-artifact` `path:` is expanded to a multi-line list including the new files.
- **`release` job:** extend `gh release create` asset list with `./artifacts/*.sig` and `./artifacts/*.crt` so users can fetch the chart blob signature alongside the tarball. Container-image signatures are NOT release assets — they live as adjacent manifests in the ghcr.io registry, retrievable via `cosign verify`.

The `id-token: write` permission was already declared at `release.yml:37` (reserved by #408 for this work).

## Docs updates

- `website/src/content/docs/guides/self-host-docker-compose.md`: new "Verify the images the bundle pulls" section between §1 (Download) and §2 (Run the stack), with a 4-service `cosign verify` loop and a `docker compose pull` / Kyverno enforcement note.
- `website/src/content/docs/guides/self-host-helm.md`: new "Verify the chart and images" section between §1 (Download) and §2 (Quick install), with `cosign verify-blob` for the chart blob and the same 4-service loop. Notes that the chart pulls 4 images even though the chart's `core` and `worker` Deployments share `image.api` at runtime.
- `CLAUDE.md` `## Cutting a Release` Post-tag verification: append step 6 with `cosign verify | jq` smoke test for the api image and a `cosign verify-blob` example for the chart.
- New `tests/manual/website/cosign-signing/test-plan.md` (manual e2e scenarios per §6 of the plan, including a dry-run cleanup loop) and CLAUDE.md website regression list entry #16.

## Key decisions (from plan §3)

- **Keyless over keyed** — no secret rotation, no key escrow, OIDC-token-to-Fulcio exchange (workflow identity + 10min cert).
- **Sign images by digest, not tag** — tags are mutable; cosign refuses to sign mutable refs. Digest captured via `docker buildx imagetools inspect --format '{{.Manifest.Digest}}'`.
- **Sign chart as a blob, not OCI** — the chart is a GitHub Release asset; OCI publishing is a deferred follow-up. `cosign sign-blob` / `verify-blob` is the right pair for blob-shaped assets.
- **Compose `.zip` deliberately not signed** — the bundle is declarative YAML; the substantive supply-chain risk lives in the 4 container images it references, which ARE signed. Docs explain the rationale.

## Test plan

- [ ] **Dry-run signs images successfully.** `gh workflow run release.yml -f version=0.0.0-rc-test`. Workflow run summary shows the `Resolve image digest` → `Install cosign` → `Sign container image (keyless)` triplet for all 4 services in the `images` matrix; `helm-drift` shows `Install cosign` → `Sign helm chart tarball (keyless blob)`. Both jobs emit `Successfully verified SCT receipt` and `tlog entry created with index:` lines (Rekor confirmation).
- [ ] **Dry-run cleanup.** Run the §"Cleanup after dry-run" loop in `tests/manual/website/cosign-signing/test-plan.md` to remove the `0.0.0-rc-test`-tagged image versions from ghcr.io. Rekor entries persist (transparency-log invariant).
- [ ] **Real-tag verify (post-merge, after a real release tag).** Run scenarios 2-7 from `tests/manual/website/cosign-signing/test-plan.md` against `v0.1.0-beta` once it ships.
- [x] **Local verification:** `release.yml` YAML parses cleanly; website build is green (31 pages, 2.99s); all 3 docs surfaces consistently iterate `api web worker mcp`; the forbidden parenthetical "fleans-worker shares the api image" appears 0 times.

## Maintainer notes

- The plan's §4 step 9 (local dry-run before opening PR) was **not** executed by this PR author — running it publishes 4 images to ghcr.io and emits 4 immutable Rekor entries that need cleanup. Recommend the maintainer trigger the dry-run before merging if signing-flow validation against live Sigstore is wanted; the cleanup loop is in the manual test plan.
- The `:::note[OCI publishing is deferred]` callout in `self-host-helm.md` still references #410 as the tracking issue. That reference is misattributed (this PR is cosign signing, not OCI publishing); fixing the misattribution is intentionally out of scope and can be addressed in a follow-up when an OCI publishing issue is filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)