### PR TITLE
fix(release): aspire CLI install + escape ; in ContainerRuntimeIdentifiers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,7 @@ jobs:
             /p:ContainerRegistry=ghcr.io \
             /p:ContainerRepository=nightbaker/${{ matrix.service.repo }} \
             /p:ContainerImageTag=${{ needs.setup.outputs.version }} \
-            /p:ContainerRuntimeIdentifiers="linux-x64;linux-arm64" \
+            /p:ContainerRuntimeIdentifiers=linux-x64%3Blinux-arm64 \
             --configuration Release
 
       - name: Tag :latest on stable releases
@@ -185,7 +185,10 @@ jobs:
           dotnet-version: '10.0.x'
 
       - name: Install Aspire CLI
-        run: dotnet workload install aspire
+        run: |
+          set -euo pipefail
+          dotnet tool install -g Aspire.Cli --prerelease
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
 
       - name: Restore
         run: dotnet restore
@@ -226,7 +229,10 @@ jobs:
           dotnet-version: '10.0.x'
 
       - name: Install Aspire CLI
-        run: dotnet workload install aspire
+        run: |
+          set -euo pipefail
+          dotnet tool install -g Aspire.Cli --prerelease
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
 
       - name: Setup Helm
         uses: azure/setup-helm@v4

--- a/tests/manual/42-release-pipeline/test-plan.md
+++ b/tests/manual/42-release-pipeline/test-plan.md
@@ -25,7 +25,7 @@ cd src/Fleans
 dotnet publish Fleans.Api/Fleans.Api.csproj \
   /t:PublishContainer \
   /p:Version=0.0.0-rc-test \
-  /p:ContainerRuntimeIdentifiers="linux-x64;linux-arm64"
+  /p:ContainerRuntimeIdentifiers=linux-x64%3Blinux-arm64
 docker buildx imagetools inspect fleans-api:0.0.0-rc-test
 ```
 
@@ -108,6 +108,13 @@ gh run watch
 **Expect:** the `helm-drift` job **fails** with a `::error::` message naming the exact resource path (e.g., `Drift: Deployment/fleans-api differs between Aspire and Helm`). The diff in the job log shows the env-var rename. Revert the rename, re-run, confirm the job passes again.
 
 This validates the deep-diff algorithm catches the failure mode that motivated the maintainer's "deep diff" decision.
+
+## Pitfalls
+
+Two issues hit the first dispatch (run #25436562303) and were fixed before any tag shipped — keep them in mind when editing `release.yml`:
+
+1. **Aspire CLI is a dotnet tool, not a workload.** Aspire 9+/13.x ships the CLI as the `Aspire.Cli` global tool; the .NET 8/Aspire 8 era `dotnet workload install aspire` is a no-op for CLI installation now. Use `dotnet tool install -g Aspire.Cli --prerelease` and prepend `$HOME/.dotnet/tools` to `$GITHUB_PATH`. Applies to both the `compose` and `helm-drift` jobs.
+2. **Semicolons in MSBuild property values must be `%3B`-escaped.** `dotnet publish /p:ContainerRuntimeIdentifiers="linux-x64;linux-arm64"` fails on Linux (`MSB1006: Property is not valid. Switch: linux-arm64`) because MSBuild's CLI parser splits on `;`. Use `/p:ContainerRuntimeIdentifiers=linux-x64%3Blinux-arm64` (URL-escaped) — works in bash, in `run: |` blocks, and in zsh.
 
 ## Verdict
 


### PR DESCRIPTION
## Summary

Two pre-existing `release.yml` bugs surfaced by the first ever `workflow_dispatch` dry-run (run [#25436562303](https://github.com/nightBaker/fleans/actions/runs/25436562303) against `main`, all 6 jobs failed). Neither was caught earlier because the cosign PR description noted the local dry-run wasn't run before merge.

- **Bug 1 — Aspire CLI install was wrong (compose + helm-drift jobs).** `dotnet workload install aspire` is the .NET 8 / Aspire 8 mechanism; Aspire 13.x ships the CLI as the `Aspire.Cli` global tool. Both jobs now run `dotnet tool install -g Aspire.Cli --prerelease` and prepend `$HOME/.dotnet/tools` to `$GITHUB_PATH`.
- **Bug 2 — `;` in `ContainerRuntimeIdentifiers` shell/MSBuild-splits.** `/p:ContainerRuntimeIdentifiers="linux-x64;linux-arm64"` fails on Linux with `MSB1006: Property is not valid. Switch: linux-arm64` because MSBuild's CLI parser splits property values on `;` even when bash preserves the quotes. Switch to URL-escaped `%3B` so the value reaches MSBuild as a single property.
- Sync the same `%3B` form in `tests/manual/42-release-pipeline/test-plan.md` (Scenario 1 local-pack smoke) and add a Pitfalls section documenting both root causes.

The cosign-signing changes from PR #499 are not touched — they sit in the `images` matrix after this fix and will run once the multi-arch publish step is unblocked.

## Test plan

- [ ] CI: this PR's `build` workflow (`.github/workflows/build.yml`) is green.
- [ ] Maintainer dispatches a fresh `workflow_dispatch` dry-run on this branch (`gh workflow run release.yml --ref fix/release-pipeline-aspire-cli -f version=0.0.0-rc-test`) and confirms:
  - all 4 `images` matrix legs reach `Sign container image (keyless)` and emit `tlog entry created with index:`,
  - `compose` job runs `aspire publish -t docker-compose` to completion and uploads the bundle,
  - `helm-drift` job runs `aspire publish -t kubernetes` + the deep-diff and emits the new `Sign helm chart tarball (keyless blob)` lines,
  - `release` job is skipped (dispatch dry-run gate),
  - run the cleanup loop in `tests/manual/website/cosign-signing/test-plan.md` to remove `0.0.0-rc-test` ghcr.io image versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)