### PR TITLE
fix(release): bump Aspire.AppHost.Sdk + per-RID multi-arch publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,17 +131,36 @@ jobs:
       - name: Restore
         run: dotnet restore
 
-      - name: Publish multi-arch container
+      # SDK Container Support's `ContainerRuntimeIdentifiers` (plural) injects the
+      # multi-RID list into `$(OutputPath)` and breaks scalar-only MSBuild targets
+      # (HasTrailingSlash → MSB4115). Canonical fix: publish each RID separately
+      # at a per-RID image tag, then assemble the manifest list with
+      # `docker buildx imagetools create`. The per-RID tags stay in the registry
+      # as harmless garbage; cosign signs the manifest-list digest.
+      - name: Publish per-RID containers
         run: |
           set -euo pipefail
-          dotnet publish ${{ matrix.service.project }}/${{ matrix.service.project }}.csproj \
-            /t:PublishContainer \
-            /p:Version=${{ needs.setup.outputs.version }} \
-            /p:ContainerRegistry=ghcr.io \
-            /p:ContainerRepository=nightbaker/${{ matrix.service.repo }} \
-            /p:ContainerImageTag=${{ needs.setup.outputs.version }} \
-            /p:ContainerRuntimeIdentifiers=linux-x64%3Blinux-arm64 \
-            --configuration Release
+          for RID in linux-x64 linux-arm64; do
+            ARCH=${RID#linux-}
+            dotnet publish ${{ matrix.service.project }}/${{ matrix.service.project }}.csproj \
+              /t:PublishContainer \
+              /p:Version=${{ needs.setup.outputs.version }} \
+              /p:ContainerRegistry=ghcr.io \
+              /p:ContainerRepository=nightbaker/${{ matrix.service.repo }} \
+              /p:ContainerImageTag=${{ needs.setup.outputs.version }}-$ARCH \
+              /p:RuntimeIdentifier=$RID \
+              --configuration Release
+          done
+
+      - name: Assemble multi-arch manifest list
+        run: |
+          set -euo pipefail
+          REPO=ghcr.io/nightbaker/${{ matrix.service.repo }}
+          VERSION=${{ needs.setup.outputs.version }}
+          docker buildx imagetools create \
+            --tag $REPO:$VERSION \
+            $REPO:$VERSION-x64 \
+            $REPO:$VERSION-arm64
 
       - name: Tag :latest on stable releases
         if: needs.setup.outputs.is_prerelease == 'false'

--- a/src/Fleans/Fleans.Aspire/Fleans.Aspire.csproj
+++ b/src/Fleans/Fleans.Aspire/Fleans.Aspire.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<Sdk Name="Aspire.AppHost.Sdk" Version="9.0.0" />
+	<Sdk Name="Aspire.AppHost.Sdk" Version="13.2.3" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>

--- a/tests/manual/42-release-pipeline/test-plan.md
+++ b/tests/manual/42-release-pipeline/test-plan.md
@@ -18,18 +18,18 @@ End-to-end validation that a `git push origin v<SemVer>` produces:
 
 ### 1. Local pack smoke (developer-box, no GitHub Actions)
 
-For each of the 4 services (api/web/worker/mcp):
+For each of the 4 services (api/web/worker/mcp), run a single-arch publish to the local Docker daemon:
 
 ```bash
 cd src/Fleans
 dotnet publish Fleans.Api/Fleans.Api.csproj \
   /t:PublishContainer \
   /p:Version=0.0.0-rc-test \
-  /p:ContainerRuntimeIdentifiers=linux-x64%3Blinux-arm64
-docker buildx imagetools inspect fleans-api:0.0.0-rc-test
+  /p:RuntimeIdentifier=linux-x64
+docker image inspect fleans-api:0.0.0-rc-test
 ```
 
-**Expect:** the manifest list shows both `linux/amd64` and `linux/arm64` digests.
+**Expect:** `dotnet publish` exits 0 and `docker image inspect` returns a non-empty result. Multi-arch manifest assembly is exercised in CI only (Scenario 2) — locally that requires QEMU + buildx and isn't worth the per-machine setup for a smoke test.
 
 Repeat for `Fleans.Web`, `Fleans.WorkerHost`, `Fleans.Mcp`.
 
@@ -111,10 +111,12 @@ This validates the deep-diff algorithm catches the failure mode that motivated t
 
 ## Pitfalls
 
-Two issues hit the first dispatch (run #25436562303) and were fixed before any tag shipped — keep them in mind when editing `release.yml`:
+Four issues hit early dispatches and were fixed before any tag shipped — keep them in mind when editing `release.yml`:
 
 1. **Aspire CLI is a dotnet tool, not a workload.** Aspire 9+/13.x ships the CLI as the `Aspire.Cli` global tool; the .NET 8/Aspire 8 era `dotnet workload install aspire` is a no-op for CLI installation now. Use `dotnet tool install -g Aspire.Cli --prerelease` and prepend `$HOME/.dotnet/tools` to `$GITHUB_PATH`. Applies to both the `compose` and `helm-drift` jobs.
-2. **Semicolons in MSBuild property values must be `%3B`-escaped.** `dotnet publish /p:ContainerRuntimeIdentifiers="linux-x64;linux-arm64"` fails on Linux (`MSB1006: Property is not valid. Switch: linux-arm64`) because MSBuild's CLI parser splits on `;`. Use `/p:ContainerRuntimeIdentifiers=linux-x64%3Blinux-arm64` (URL-escaped) — works in bash, in `run: |` blocks, and in zsh.
+2. **`Aspire.AppHost.Sdk` must match the Aspire.Hosting.* package version.** Aspire CLI 13.x rejects an apphost whose `<Sdk Name="Aspire.AppHost.Sdk" Version="…">` does not match the host packages (`The app host is not compatible. Aspire.Hosting version: 9.0.0`, exit code 9). Bump the SDK pin in `Fleans.Aspire.csproj` whenever the `Aspire.Hosting.*` packages move; today both should be `13.2.3`. The dev-mode `dotnet run --project Fleans.Aspire` does NOT surface this — only `aspire publish` validates the SDK pin.
+3. **Semicolons in MSBuild property values must be `%3B`-escaped.** `dotnet publish /p:ContainerRuntimeIdentifiers="linux-x64;linux-arm64"` fails on Linux (`MSB1006: Property is not valid. Switch: linux-arm64`) because MSBuild's CLI parser splits on `;`. Use `/p:ContainerRuntimeIdentifiers=linux-x64%3Blinux-arm64` (URL-escaped) — works in bash, in `run: |` blocks, and in zsh.
+4. **`ContainerRuntimeIdentifiers` (plural) breaks scalar `OutputPath` targets.** Even with the `%3B` escape, .NET 10 SDK 10.0.203 expands the multi-RID list into `$(OutputPath)` so a downstream MSBuild target (`HasTrailingSlash`) trips with `MSB4115: only accepts a scalar value`. Use the canonical multi-arch pattern instead: publish each RID separately at a per-RID image tag (`/p:RuntimeIdentifier=linux-x64 /p:ContainerImageTag=$VERSION-x64`) and assemble the manifest list with `docker buildx imagetools create --tag $REPO:$VERSION $REPO:$VERSION-x64 $REPO:$VERSION-arm64`. Cosign signs the manifest-list digest.
 
 ## Verdict
 

--- a/tests/manual/website/cosign-signing/test-plan.md
+++ b/tests/manual/website/cosign-signing/test-plan.md
@@ -67,14 +67,16 @@ Manual verification that the release pipeline (`.github/workflows/release.yml`) 
 
 ## Cleanup after dry-run
 
-Each `0.0.0-rc-test` invocation publishes 4 images tagged `0.0.0-rc-test` to ghcr.io and emits 4 immutable Rekor entries. Use the `## Cutting a Release` rollback loop to clean up ghcr.io after each dry-run iteration:
+Each `0.0.0-rc-test` invocation publishes 12 image versions per dispatch (4 services × { manifest list `0.0.0-rc-test`, per-RID `0.0.0-rc-test-x64`, per-RID `0.0.0-rc-test-arm64` }) and emits 4 immutable Rekor entries (manifest-list digests are what cosign signs). Use the `## Cutting a Release` rollback loop to clean up ghcr.io after each dry-run iteration:
 
 ```bash
 for IMG in fleans-api fleans-web fleans-worker fleans-mcp; do
-  VID=$(gh api "/user/packages/container/$IMG/versions" \
-    --jq '.[] | select(.metadata.container.tags | index("0.0.0-rc-test")) | .id' \
-    | head -1)
-  [ -n "$VID" ] && gh api -X DELETE "/user/packages/container/$IMG/versions/$VID"
+  for TAG in 0.0.0-rc-test 0.0.0-rc-test-x64 0.0.0-rc-test-arm64; do
+    VID=$(gh api "/user/packages/container/$IMG/versions" \
+      --jq '.[] | select(.metadata.container.tags | index("'"$TAG"'")) | .id' \
+      | head -1)
+    [ -n "$VID" ] && gh api -X DELETE "/user/packages/container/$IMG/versions/$VID"
+  done
 done
 ```
 
@@ -84,9 +86,9 @@ Rekor entries cannot be deleted — that's by design (transparency-log invariant
 
 These line-pinned references back the CLAUDE.md regression entry. If any pin no longer resolves to the named symbol at the current branch SHA, update the test-plan and the regression entry together.
 
-- `release.yml:154-166` — `Resolve image digest` → `Install cosign` → `Sign container image (keyless)` block inside the `images` matrix job.
-- `release.yml:356-374` — `Install cosign` + `Sign helm chart tarball (keyless blob)` block in the `helm-drift` job, plus the `actions/upload-artifact` `path:` glob that picks up `*.tgz.sig` / `*.tgz.crt`.
-- `release.yml:420-421` — `gh release create` asset list inside the `release` job (`./artifacts/*.sig` and `./artifacts/*.crt`).
+- `release.yml:173-185` — `Resolve image digest` → `Install cosign` → `Sign container image (keyless)` block inside the `images` matrix job, sitting after `Assemble multi-arch manifest list` so the digest captured is the manifest-list digest.
+- `release.yml:381-400` — `Install cosign` + `Sign helm chart tarball (keyless blob)` block in the `helm-drift` job, plus the `actions/upload-artifact` `path:` glob that picks up `*.tgz.sig` / `*.tgz.crt`.
+- `release.yml:445-446` — `gh release create` asset list inside the `release` job (`./artifacts/*.sig` and `./artifacts/*.crt`).
 
 ## Reporting
 


### PR DESCRIPTION
## Summary

Two next-layer release-pipeline blockers exposed by dispatch run [#25449883121](https://github.com/nightBaker/fleans/actions/runs/25449883121) on `main`, once the trivial PR #501 fixes (`aspire` CLI install + `%3B` escape) had cleared the way:

- **`Aspire.AppHost.Sdk` was pinned at 9.0.0** while the actual `Aspire.Hosting.*` packages and the 13.x `Aspire.Cli` global tool we install in CI are 13.2.3. `aspire publish` exits 9 with `The Aspire.Hosting package version 9.0.0 is not supported`. Bumping the `<Sdk Name="…" Version="…" />` pin in `Fleans.Aspire.csproj` to 13.2.3 fixes both `compose` and `helm-drift` jobs. `dotnet run --project Fleans.Aspire` does NOT validate this pin (only `aspire publish` does), which is why the lag went undetected.
- **`/p:ContainerRuntimeIdentifiers=linux-x64%3Blinux-arm64` corrupts `$(OutputPath)`.** Even with the URL-escape from PR #501, .NET 10 SDK 10.0.203's Container Support leaks the multi-RID list into `$(OutputPath)` and trips `MSB4115: HasTrailingSlash only accepts a scalar value` in a downstream Common targets step. Switch to the canonical multi-arch pattern: two single-RID `dotnet publish /p:RuntimeIdentifier=$RID /p:ContainerImageTag=$VERSION-$ARCH` runs, then `docker buildx imagetools create --tag $REPO:$VERSION $REPO:$VERSION-x64 $REPO:$VERSION-arm64`. Cosign signs the manifest-list digest unchanged.

## Side effects

- Each dispatch now publishes 12 image versions per dry-run (4 services × {manifest-list `$VERSION`, per-RID `-x64`, per-RID `-arm64`}). The `cosign-signing` test-plan's cleanup loop is extended to delete all three tag forms.
- The per-RID tags (`$VERSION-x64`, `$VERSION-arm64`) are intentionally left in the registry as garbage after manifest-list assembly. They cost ~nothing and avoid extra REST roundtrips during the build. Cleanup is via the rollback loop on dry-runs.

## Test plan

- [x] Local `dotnet build -c Release` from `src/Fleans/` succeeds with the bumped Aspire SDK pin (warnings only, all pre-existing).
- [ ] Maintainer dispatches `gh workflow run release.yml --ref fix/release-pipeline-multiarch-and-aspire-sdk -f version=0.0.0-rc-test` and confirms:
  - `compose` job: `aspire publish -t docker-compose` runs to completion and uploads the bundle.
  - `helm-drift` job: `aspire publish -t kubernetes` + deep-diff pass; chart-blob signing emits Rekor lines.
  - All 4 `images` matrix legs: per-RID publish loop produces `:$VERSION-x64` and `:$VERSION-arm64`; `Assemble multi-arch manifest list` step succeeds; `Resolve image digest` returns a valid sha256; `Sign container image (keyless)` emits `tlog entry created with index:`.
  - `release` job is skipped (dispatch dry-run gate).
  - Run the extended cleanup loop in `tests/manual/website/cosign-signing/test-plan.md` to remove all 12 ghcr.io image versions per service per dry-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)