### PR TITLE
fix: use matrix.service.name for correct job display name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
           echo "Resolved: VERSION=$VERSION IS_PRE=$IS_PRE IS_DRY=$IS_DRY"
 
   images:
-    name: Publish ${{ matrix.service }} image
+    name: Publish ${{ matrix.service.name }} image
     needs: setup
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
When the 'images' job runs with a matrix strategy, the job name should reference the 'name' property of the service object, not the entire object.

Changed from:
  name: Publish ${{ matrix.service }} image

To:
  name: Publish ${{ matrix.service.name }} image

This ensures the job displays as "Publish api image", "Publish web image", etc. instead of "Publish Object image".