### PR TITLE
refactor(bpmn): extract CustomTaskRoutingResolver from BpmnConverter

### DIFF
--- a/src/Fleans/Fleans.Infrastructure.Tests/BpmnConverter/CustomTaskRoutingTests.cs
+++ b/src/Fleans/Fleans.Infrastructure.Tests/BpmnConverter/CustomTaskRoutingTests.cs
@@ -1,39 +1,25 @@
 using Fleans.Domain.Activities;
+using Fleans.Infrastructure.Bpmn;
 using System.Text;
+using System.Xml.Linq;
 
 namespace Fleans.Infrastructure.Tests.BpmnConverter;
 
 [TestClass]
 public class CustomTaskRoutingTests : BpmnConverterTestBase
 {
-    private const string ZeebeNs = "xmlns:zeebe=\"http://camunda.org/schema/zeebe/1.0\"";
-    private const string BpmnNs = "xmlns=\"http://www.omg.org/spec/BPMN/20100524/MODEL\"";
+    private static readonly XNamespace Bpmn  = BpmnNamespaces.Bpmn;
+    private static readonly XNamespace Zeebe = BpmnNamespaces.Zeebe;
 
-    private static string CreateBpmnWithCustomServiceTask(string taskType, string ioMappingXml = "")
+    private CustomTaskRoutingResolver _resolver = null!;
+
+    [TestInitialize]
+    public void SetupResolver()
     {
-        return $@"<?xml version=""1.0"" encoding=""UTF-8""?>
-<definitions {BpmnNs} {ZeebeNs}>
-  <process id=""wf"">
-    <startEvent id=""start"" />
-    <serviceTask id=""ct1"" type=""{taskType}"">
-      <extensionElements>
-        <zeebe:ioMapping>{ioMappingXml}</zeebe:ioMapping>
-      </extensionElements>
-    </serviceTask>
-    <endEvent id=""end"" />
-    <sequenceFlow id=""f1"" sourceRef=""start"" targetRef=""ct1"" />
-    <sequenceFlow id=""f2"" sourceRef=""ct1"" targetRef=""end"" />
-  </process>
-</definitions>";
+        _resolver = new CustomTaskRoutingResolver();
     }
 
-    private async Task<CustomTaskActivity> ParseSingleCustomTask(string taskType, string ioMappingXml)
-    {
-        var bpmn = CreateBpmnWithCustomServiceTask(taskType, ioMappingXml);
-        var workflow = await _converter.ConvertFromXmlAsync(new MemoryStream(Encoding.UTF8.GetBytes(bpmn)));
-        return workflow.Activities.OfType<CustomTaskActivity>().Single();
-    }
-
+    // Integration: verifies BpmnConverter creates TaskActivity when resolver returns null
     [TestMethod]
     public async Task ServiceTask_WithoutTypeAttribute_ParsesAsTaskActivity()
     {
@@ -44,49 +30,57 @@ public class CustomTaskRoutingTests : BpmnConverterTestBase
     }
 
     [TestMethod]
-    public async Task ServiceTask_WithTypeAttribute_ParsesAsCustomTaskActivity()
+    public void ResolveTaskType_WithTypeAttribute_ReturnsType()
     {
-        var ct = await ParseSingleCustomTask("rest-call", "");
-        Assert.AreEqual("rest-call", ct.TaskType);
-        Assert.AreEqual(0, ct.InputMappings.Count);
-        Assert.AreEqual(0, ct.OutputMappings.Count);
+        var el = new XElement(Bpmn + "serviceTask",
+            new XAttribute("id", "ct1"),
+            new XAttribute("type", "rest-call"));
+        Assert.AreEqual("rest-call", _resolver.ResolveTaskType(el));
     }
 
     [TestMethod]
-    public async Task ServiceTask_WithZeebeTaskDefinition_ParsesAsCustomTaskActivity()
+    public void ResolveTaskType_WithoutTypeAttribute_ReturnsNull()
     {
-        var bpmn = $@"<?xml version=""1.0"" encoding=""UTF-8""?>
-<definitions {BpmnNs} {ZeebeNs}>
-  <process id=""wf"">
-    <startEvent id=""start"" />
-    <serviceTask id=""ct1"">
-      <extensionElements>
-        <zeebe:taskDefinition type=""rest-call"" />
-      </extensionElements>
-    </serviceTask>
-    <endEvent id=""end"" />
-    <sequenceFlow id=""f1"" sourceRef=""start"" targetRef=""ct1"" />
-    <sequenceFlow id=""f2"" sourceRef=""ct1"" targetRef=""end"" />
-  </process>
-</definitions>";
-        var workflow = await _converter.ConvertFromXmlAsync(new MemoryStream(Encoding.UTF8.GetBytes(bpmn)));
-        var ct = workflow.Activities.OfType<CustomTaskActivity>().Single();
-        Assert.AreEqual("rest-call", ct.TaskType);
+        var el = new XElement(Bpmn + "serviceTask", new XAttribute("id", "ct1"));
+        Assert.IsNull(_resolver.ResolveTaskType(el));
     }
 
     [TestMethod]
-    public async Task ServiceTask_WithInputAndOutputMappings_ParsesBothLists()
+    public void ResolveTaskType_WithZeebeTaskDefinition_ReturnsType()
     {
-        var io = @"
-          <zeebe:input source=""=userId"" target=""user_id"" />
-          <zeebe:input source=""=&quot;literal&quot;"" target=""label"" />
-          <zeebe:output source=""=__response.body.id"" target=""created_id"" />";
-        var ct = await ParseSingleCustomTask("rest-call", io);
-        Assert.AreEqual(2, ct.InputMappings.Count);
-        Assert.AreEqual(1, ct.OutputMappings.Count);
-        Assert.AreEqual("user_id", ct.InputMappings[0].Target);
-        Assert.AreEqual("=userId", ct.InputMappings[0].Source);
-        Assert.AreEqual("created_id", ct.OutputMappings[0].Target);
+        var el = new XElement(Bpmn + "serviceTask",
+            new XAttribute("id", "ct1"),
+            new XElement(Bpmn + "extensionElements",
+                new XElement(Zeebe + "taskDefinition",
+                    new XAttribute("type", "rest-call"))));
+        Assert.AreEqual("rest-call", _resolver.ResolveTaskType(el));
+    }
+
+    [TestMethod]
+    public void ParseMappings_ParsesInputAndOutputLists()
+    {
+        var el = new XElement(Bpmn + "serviceTask",
+            new XAttribute("id", "ct1"),
+            new XElement(Bpmn + "extensionElements",
+                new XElement(Zeebe + "ioMapping",
+                    new XElement(Zeebe + "input",
+                        new XAttribute("source", "=userId"),
+                        new XAttribute("target", "user_id")),
+                    new XElement(Zeebe + "input",
+                        new XAttribute("source", "=\"literal\""),
+                        new XAttribute("target", "label")),
+                    new XElement(Zeebe + "output",
+                        new XAttribute("source", "=__response.body.id"),
+                        new XAttribute("target", "created_id")))));
+
+        var inputs = _resolver.ParseInputMappings(el);
+        var outputs = _resolver.ParseOutputMappings(el);
+
+        Assert.AreEqual(2, inputs.Count);
+        Assert.AreEqual(1, outputs.Count);
+        Assert.AreEqual("user_id", inputs[0].Target);
+        Assert.AreEqual("=userId", inputs[0].Source);
+        Assert.AreEqual("created_id", outputs[0].Target);
     }
 
     // ---- Output mapping deploy-time validation (9 scenarios) ----
@@ -101,12 +95,16 @@ public class CustomTaskRoutingTests : BpmnConverterTestBase
     [DataRow("=valid.path", "with-dash", DisplayName = "Output: hyphen in target")]
     [DataRow("=valid.path", "with space", DisplayName = "Output: space in target")]
     [DataRow("=valid.path", "__response", DisplayName = "Output: __response is reserved")]
-    public async Task DeployTime_RejectsMalformedOutputMapping(string source, string target)
+    public void DeployTime_RejectsMalformedOutputMapping(string source, string target)
     {
-        var io = $@"<zeebe:output source=""{System.Security.SecurityElement.Escape(source)}"" target=""{System.Security.SecurityElement.Escape(target)}"" />";
-        var bpmn = CreateBpmnWithCustomServiceTask("rest-call", io);
-        await Assert.ThrowsExactlyAsync<InvalidOperationException>(async () =>
-            await _converter.ConvertFromXmlAsync(new MemoryStream(Encoding.UTF8.GetBytes(bpmn))));
+        var el = new XElement(Bpmn + "serviceTask",
+            new XAttribute("id", "ct1"),
+            new XElement(Bpmn + "extensionElements",
+                new XElement(Zeebe + "ioMapping",
+                    new XElement(Zeebe + "output",
+                        new XAttribute("source", source),
+                        new XAttribute("target", target)))));
+        Assert.ThrowsExactly<InvalidOperationException>(() => _resolver.ParseOutputMappings(el));
     }
 
     // ---- Input mapping deploy-time validation (8 scenarios) ----
@@ -120,11 +118,15 @@ public class CustomTaskRoutingTests : BpmnConverterTestBase
     [DataRow("=valid.path", "", DisplayName = "Input: empty target")]
     [DataRow("=valid.path", "with-dash", DisplayName = "Input: hyphen in target")]
     [DataRow("=valid.path", "with space", DisplayName = "Input: space in target")]
-    public async Task DeployTime_RejectsMalformedInputMapping(string source, string target)
+    public void DeployTime_RejectsMalformedInputMapping(string source, string target)
     {
-        var io = $@"<zeebe:input source=""{System.Security.SecurityElement.Escape(source)}"" target=""{System.Security.SecurityElement.Escape(target)}"" />";
-        var bpmn = CreateBpmnWithCustomServiceTask("rest-call", io);
-        await Assert.ThrowsExactlyAsync<InvalidOperationException>(async () =>
-            await _converter.ConvertFromXmlAsync(new MemoryStream(Encoding.UTF8.GetBytes(bpmn))));
+        var el = new XElement(Bpmn + "serviceTask",
+            new XAttribute("id", "ct1"),
+            new XElement(Bpmn + "extensionElements",
+                new XElement(Zeebe + "ioMapping",
+                    new XElement(Zeebe + "input",
+                        new XAttribute("source", source),
+                        new XAttribute("target", target)))));
+        Assert.ThrowsExactly<InvalidOperationException>(() => _resolver.ParseInputMappings(el));
     }
 }

--- a/src/Fleans/Fleans.Infrastructure/Bpmn/BpmnConverter.cs
+++ b/src/Fleans/Fleans.Infrastructure/Bpmn/BpmnConverter.cs
@@ -10,22 +10,19 @@ namespace Fleans.Infrastructure.Bpmn;
 public partial class BpmnConverter : IBpmnConverter
 {
     private const int MaxConversionDepth = 10;
-    private const string BpmnNamespace = "http://www.omg.org/spec/BPMN/20100524/MODEL";
-    private const string BpmndiNamespace = "http://www.omg.org/spec/BPMN/20100524/DI";
-    private const string ZeebeNamespace = "http://camunda.org/schema/zeebe/1.0";
-    private const string FleansNamespace = "http://fleans.io/schema/bpmn/fleans";
-    private const string CamundaNamespace = "http://camunda.org/schema/1.0/bpmn";
-    private static readonly XNamespace Bpmn = BpmnNamespace;
-    private static readonly XNamespace Bpmndi = BpmndiNamespace;
-    private static readonly XNamespace Zeebe = ZeebeNamespace;
-    private static readonly XNamespace Fleans = FleansNamespace;
-    private static readonly XNamespace Camunda = CamundaNamespace;
+    private static readonly XNamespace Bpmn    = BpmnNamespaces.Bpmn;
+    private static readonly XNamespace Bpmndi  = BpmnNamespaces.Bpmndi;
+    private static readonly XNamespace Zeebe   = BpmnNamespaces.Zeebe;
+    private static readonly XNamespace Fleans  = BpmnNamespaces.Fleans;
+    private static readonly XNamespace Camunda = BpmnNamespaces.Camunda;
 
     private readonly ILogger<BpmnConverter> _logger;
+    private readonly CustomTaskRoutingResolver _resolver;
 
     public BpmnConverter(ILogger<BpmnConverter> logger)
     {
         _logger = logger;
+        _resolver = new CustomTaskRoutingResolver();
     }
 
     public async Task<WorkflowDefinition> ConvertFromXmlAsync(Stream bpmnXmlStream)
@@ -333,12 +330,12 @@ public partial class BpmnConverter : IBpmnConverter
         foreach (var serviceTask in scopeElement.Elements(Bpmn + "serviceTask"))
         {
             var id = GetId(serviceTask);
-            var taskType = ResolveServiceTaskType(serviceTask);
+            var taskType = _resolver.ResolveTaskType(serviceTask);
             Activity activity;
             if (!string.IsNullOrEmpty(taskType))
             {
-                var inputMappings = ParseInputMappings(serviceTask);
-                var outputMappings = ParseOutputMappings(serviceTask);
+                var inputMappings = _resolver.ParseInputMappings(serviceTask);
+                var outputMappings = _resolver.ParseOutputMappings(serviceTask);
                 activity = new CustomTaskActivity(id, taskType, inputMappings, outputMappings);
             }
             else
@@ -1241,118 +1238,4 @@ public partial class BpmnConverter : IBpmnConverter
         Message = "Complex gateway '{GatewayId}' has activationCondition but is detected as a fork — activationCondition is ignored on fork gateways")]
     private partial void LogActivationConditionIgnoredOnFork(string gatewayId);
 
-    private static readonly System.Text.RegularExpressions.Regex IdentifierRegex =
-        new("^[a-zA-Z_][a-zA-Z0-9_]*$", System.Text.RegularExpressions.RegexOptions.Compiled);
-
-    private static string? ResolveServiceTaskType(XElement serviceTask)
-    {
-        var attr = serviceTask.Attribute("type")?.Value;
-        if (!string.IsNullOrWhiteSpace(attr))
-            return attr;
-
-        var taskDef = serviceTask.Element(Bpmn + "extensionElements")?.Element(Zeebe + "taskDefinition");
-        var zType = taskDef?.Attribute("type")?.Value;
-        if (!string.IsNullOrWhiteSpace(zType))
-            return zType;
-
-        return null;
-    }
-
-    private static List<InputMapping> ParseInputMappings(XElement serviceTask)
-    {
-        var mappings = new List<InputMapping>();
-        var ioMapping = serviceTask.Element(Bpmn + "extensionElements")?.Element(Zeebe + "ioMapping");
-        if (ioMapping is null) return mappings;
-
-        foreach (var input in ioMapping.Elements(Zeebe + "input"))
-            mappings.Add(ParseInputMapping(input));
-
-        return mappings;
-    }
-
-    private static List<OutputMapping> ParseOutputMappings(XElement serviceTask)
-    {
-        var mappings = new List<OutputMapping>();
-        var ioMapping = serviceTask.Element(Bpmn + "extensionElements")?.Element(Zeebe + "ioMapping");
-        if (ioMapping is null) return mappings;
-
-        foreach (var output in ioMapping.Elements(Zeebe + "output"))
-            mappings.Add(ParseOutputMapping(output));
-
-        return mappings;
-    }
-
-    private static InputMapping ParseInputMapping(XElement input)
-    {
-        var source = input.Attribute("source")?.Value
-            ?? throw new InvalidOperationException("<zeebe:input> missing required 'source' attribute");
-        var target = input.Attribute("target")?.Value
-            ?? throw new InvalidOperationException("<zeebe:input> missing required 'target' attribute");
-
-        if (string.IsNullOrWhiteSpace(target))
-            throw new InvalidOperationException("<zeebe:input> 'target' is empty or whitespace-only");
-
-        if (!IdentifierRegex.IsMatch(target))
-            throw new InvalidOperationException(
-                $"<zeebe:input target=\"{target}\"> target must be a valid identifier (^[a-zA-Z_][a-zA-Z0-9_]*$)");
-
-        ValidateMappingSource(source, $"<zeebe:input target=\"{target}\">");
-
-        return new InputMapping(source, target);
-    }
-
-    private static OutputMapping ParseOutputMapping(XElement output)
-    {
-        var source = output.Attribute("source")?.Value
-            ?? throw new InvalidOperationException("<zeebe:output> missing required 'source' attribute");
-        var target = output.Attribute("target")?.Value
-            ?? throw new InvalidOperationException("<zeebe:output> missing required 'target' attribute");
-
-        if (string.IsNullOrWhiteSpace(target))
-            throw new InvalidOperationException("<zeebe:output> 'target' is empty or whitespace-only");
-
-        if (!IdentifierRegex.IsMatch(target))
-            throw new InvalidOperationException(
-                $"<zeebe:output target=\"{target}\"> target must be a valid identifier (^[a-zA-Z_][a-zA-Z0-9_]*$)");
-
-        if (target == "__response")
-            throw new InvalidOperationException(
-                "<zeebe:output target=\"__response\"> is reserved — providers populate it during execution; output mapping cannot target it directly");
-
-        ValidateMappingSource(source, $"<zeebe:output target=\"{target}\">");
-
-        return new OutputMapping(source, target);
-    }
-
-    private static void ValidateMappingSource(string source, string errorPrefix)
-    {
-        if (string.IsNullOrEmpty(source))
-            throw new InvalidOperationException($"{errorPrefix} has empty 'source' attribute");
-
-        if (source[0] != '=')
-            return;
-
-        var expr = source.Substring(1);
-        if (expr.Length == 0)
-            throw new InvalidOperationException($"{errorPrefix} 'source' is bare '=' with no expression");
-
-        if (expr[0] == '"')
-        {
-            if (expr.Length < 2 || expr[expr.Length - 1] != '"')
-                throw new InvalidOperationException($"{errorPrefix} has unmatched quote in source: '{source}'");
-            return;
-        }
-
-        if (expr == "true" || expr == "false" || expr == "null") return;
-        if (long.TryParse(expr, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out _)) return;
-        if (double.TryParse(expr, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out _)) return;
-
-        var segments = expr.Split('.');
-        foreach (var seg in segments)
-        {
-            if (!IdentifierRegex.IsMatch(seg))
-                throw new InvalidOperationException(
-                    $"{errorPrefix} has invalid path segment '{seg}' in source: '{source}'");
-        }
-    }
 }

--- a/src/Fleans/Fleans.Infrastructure/Bpmn/BpmnNamespaces.cs
+++ b/src/Fleans/Fleans.Infrastructure/Bpmn/BpmnNamespaces.cs
@@ -1,0 +1,12 @@
+using System.Xml.Linq;
+
+namespace Fleans.Infrastructure.Bpmn;
+
+internal static class BpmnNamespaces
+{
+    public static readonly XNamespace Bpmn    = "http://www.omg.org/spec/BPMN/20100524/MODEL";
+    public static readonly XNamespace Bpmndi  = "http://www.omg.org/spec/BPMN/20100524/DI";
+    public static readonly XNamespace Zeebe   = "http://camunda.org/schema/zeebe/1.0";
+    public static readonly XNamespace Fleans  = "http://fleans.io/schema/bpmn/fleans";
+    public static readonly XNamespace Camunda = "http://camunda.org/schema/1.0/bpmn";
+}

--- a/src/Fleans/Fleans.Infrastructure/Bpmn/CustomTaskRoutingResolver.cs
+++ b/src/Fleans/Fleans.Infrastructure/Bpmn/CustomTaskRoutingResolver.cs
@@ -1,0 +1,128 @@
+using System.Xml.Linq;
+using Fleans.Domain.Activities;
+
+namespace Fleans.Infrastructure.Bpmn;
+
+internal sealed class CustomTaskRoutingResolver
+{
+    private static readonly System.Text.RegularExpressions.Regex IdentifierRegex =
+        new("^[a-zA-Z_][a-zA-Z0-9_]*$", System.Text.RegularExpressions.RegexOptions.Compiled);
+
+    public string? ResolveTaskType(XElement serviceTask)
+    {
+        var attr = serviceTask.Attribute("type")?.Value;
+        if (!string.IsNullOrWhiteSpace(attr))
+            return attr;
+
+        var taskDef = serviceTask
+            .Element(BpmnNamespaces.Bpmn + "extensionElements")?
+            .Element(BpmnNamespaces.Zeebe + "taskDefinition");
+        var zType = taskDef?.Attribute("type")?.Value;
+        if (!string.IsNullOrWhiteSpace(zType))
+            return zType;
+
+        return null;
+    }
+
+    public List<InputMapping> ParseInputMappings(XElement serviceTask)
+    {
+        var mappings = new List<InputMapping>();
+        var ioMapping = serviceTask
+            .Element(BpmnNamespaces.Bpmn + "extensionElements")?
+            .Element(BpmnNamespaces.Zeebe + "ioMapping");
+        if (ioMapping is null) return mappings;
+
+        foreach (var input in ioMapping.Elements(BpmnNamespaces.Zeebe + "input"))
+            mappings.Add(ParseInputMapping(input));
+
+        return mappings;
+    }
+
+    public List<OutputMapping> ParseOutputMappings(XElement serviceTask)
+    {
+        var mappings = new List<OutputMapping>();
+        var ioMapping = serviceTask
+            .Element(BpmnNamespaces.Bpmn + "extensionElements")?
+            .Element(BpmnNamespaces.Zeebe + "ioMapping");
+        if (ioMapping is null) return mappings;
+
+        foreach (var output in ioMapping.Elements(BpmnNamespaces.Zeebe + "output"))
+            mappings.Add(ParseOutputMapping(output));
+
+        return mappings;
+    }
+
+    private static InputMapping ParseInputMapping(XElement input)
+    {
+        var source = input.Attribute("source")?.Value
+            ?? throw new InvalidOperationException("<zeebe:input> missing required 'source' attribute");
+        var target = input.Attribute("target")?.Value
+            ?? throw new InvalidOperationException("<zeebe:input> missing required 'target' attribute");
+
+        if (string.IsNullOrWhiteSpace(target))
+            throw new InvalidOperationException("<zeebe:input> 'target' is empty or whitespace-only");
+
+        if (!IdentifierRegex.IsMatch(target))
+            throw new InvalidOperationException(
+                $"<zeebe:input target=\"{target}\"> target must be a valid identifier (^[a-zA-Z_][a-zA-Z0-9_]*$)");
+
+        ValidateMappingSource(source, $"<zeebe:input target=\"{target}\">");
+
+        return new InputMapping(source, target);
+    }
+
+    private static OutputMapping ParseOutputMapping(XElement output)
+    {
+        var source = output.Attribute("source")?.Value
+            ?? throw new InvalidOperationException("<zeebe:output> missing required 'source' attribute");
+        var target = output.Attribute("target")?.Value
+            ?? throw new InvalidOperationException("<zeebe:output> missing required 'target' attribute");
+
+        if (string.IsNullOrWhiteSpace(target))
+            throw new InvalidOperationException("<zeebe:output> 'target' is empty or whitespace-only");
+
+        if (!IdentifierRegex.IsMatch(target))
+            throw new InvalidOperationException(
+                $"<zeebe:output target=\"{target}\"> target must be a valid identifier (^[a-zA-Z_][a-zA-Z0-9_]*$)");
+
+        if (target == "__response")
+            throw new InvalidOperationException(
+                "<zeebe:output target=\"__response\"> is reserved — providers populate it during execution; output mapping cannot target it directly");
+
+        ValidateMappingSource(source, $"<zeebe:output target=\"{target}\">");
+
+        return new OutputMapping(source, target);
+    }
+
+    private static void ValidateMappingSource(string source, string errorPrefix)
+    {
+        if (string.IsNullOrEmpty(source))
+            throw new InvalidOperationException($"{errorPrefix} has empty 'source' attribute");
+
+        if (source[0] != '=')
+            return;
+
+        var expr = source.Substring(1);
+        if (expr.Length == 0)
+            throw new InvalidOperationException($"{errorPrefix} 'source' is bare '=' with no expression");
+
+        if (expr[0] == '"')
+        {
+            if (expr.Length < 2 || expr[expr.Length - 1] != '"')
+                throw new InvalidOperationException($"{errorPrefix} has unmatched quote in source: '{source}'");
+            return;
+        }
+
+        if (expr == "true" || expr == "false" || expr == "null") return;
+        if (long.TryParse(expr, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out _)) return;
+        if (double.TryParse(expr, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out _)) return;
+
+        var segments = expr.Split('.');
+        foreach (var seg in segments)
+        {
+            if (!IdentifierRegex.IsMatch(seg))
+                throw new InvalidOperationException(
+                    $"{errorPrefix} has invalid path segment '{seg}' in source: '{source}'");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Extract `ResolveTaskType`, `ParseInputMappings`, `ParseOutputMappings` (+ private helpers `ParseInputMapping`, `ParseOutputMapping`, `ValidateMappingSource`) from `BpmnConverter` into a new `internal sealed class CustomTaskRoutingResolver`
- Add `internal static class BpmnNamespaces` as single source of truth for all five BPMN/Zeebe/Fleans/Camunda namespace URI constants; `BpmnConverter` local aliases now initialize from it
- `BpmnConverter` gains a `private readonly CustomTaskRoutingResolver _resolver` field initialized in the constructor; service-task branch in `ParseActivities` delegates to it
- `CustomTaskRoutingTests` migrated to instantiate `CustomTaskRoutingResolver` directly — 22 tests, all passing

Closes #429

## Test plan

- [x] `dotnet test --filter FullyQualifiedName~CustomTaskRouting` — 22 passed, 0 failed
- [ ] Full `dotnet test` in `src/Fleans/` — run to confirm no regressions
- [ ] Build clean: `dotnet build` in `src/Fleans/` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
