### PR TITLE
fix(streams): scope engine-internal events to per-event stream namespaces

### DIFF
--- a/src/Fleans/Fleans.Application.Abstractions/Events/WorkflowEventStreams.cs
+++ b/src/Fleans/Fleans.Application.Abstractions/Events/WorkflowEventStreams.cs
@@ -31,4 +31,13 @@ public static class WorkflowEventStreams
     /// subscriber for that stream. Dropping on the floor." on each cross-event delivery.
     /// </summary>
     public const string ExecuteCustomTaskStreamNamespace = "events.ExecuteCustomTaskEvent";
+
+    /// <summary>Dedicated namespace for <c>ExecuteScriptEvent</c>.</summary>
+    public const string ExecuteScriptStreamNamespace = "events.ExecuteScriptEvent";
+
+    /// <summary>Dedicated namespace for <c>EvaluateConditionEvent</c>.</summary>
+    public const string EvaluateConditionStreamNamespace = "events.EvaluateConditionEvent";
+
+    /// <summary>Dedicated namespace for <c>EvaluateActivationConditionEvent</c>.</summary>
+    public const string EvaluateActivationConditionStreamNamespace = "events.EvaluateActivationConditionEvent";
 }

--- a/src/Fleans/Fleans.Application.Tests/KafkaStreamProviderIntegrationTests.cs
+++ b/src/Fleans/Fleans.Application.Tests/KafkaStreamProviderIntegrationTests.cs
@@ -1,3 +1,4 @@
+using Fleans.Application.Abstractions.Events;
 using Fleans.Domain.Events;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
@@ -20,7 +21,7 @@ public class KafkaStreamProviderIntegrationTests
         string.Equals(Environment.GetEnvironmentVariable("FLEANS_KAFKA_TESTS"), "1", StringComparison.Ordinal);
 
     private const string ProviderName = "StreamProvider";
-    private const string Namespace = "events";
+    private const string Namespace = WorkflowEventStreams.ExecuteScriptStreamNamespace;
 
     [TestMethod]
     public async Task Smoke_publish_then_receive_round_trips_via_kafka()

--- a/src/Fleans/Fleans.Application/Events/Handlers/WorfklowEvaluateConditionEventHandler.cs
+++ b/src/Fleans/Fleans.Application/Events/Handlers/WorfklowEvaluateConditionEventHandler.cs
@@ -10,7 +10,7 @@ using Orleans.Streams;
 
 namespace Fleans.Application.Events.Handlers;
 
-[ImplicitStreamSubscription(WorkflowEventsPublisher.StreamNameSpace)]
+[ImplicitStreamSubscription(WorkflowEventsPublisher.EvaluateConditionStreamNamespace)]
 [CorePlacement]
 public partial class WorfklowEvaluateConditionEventHandler : Grain, IWorfklowEvaluateConditionEventHandler, IAsyncObserver<EvaluateConditionEvent>
 {
@@ -27,7 +27,7 @@ public partial class WorfklowEvaluateConditionEventHandler : Grain, IWorfklowEva
     public override async Task OnActivateAsync(CancellationToken cancellationToken)
     {
         var streamProvider = this.GetStreamProvider(WorkflowEventsPublisher.StreamProvider);
-        var streamId = StreamId.Create(WorkflowEventsPublisher.StreamNameSpace, nameof(EvaluateConditionEvent));
+        var streamId = StreamId.Create(WorkflowEventsPublisher.EvaluateConditionStreamNamespace, nameof(EvaluateConditionEvent));
         var stream = streamProvider.GetStream<EvaluateConditionEvent>(streamId);
 
         var handles = await stream.GetAllSubscriptionHandles();

--- a/src/Fleans/Fleans.Application/Events/Handlers/WorkflowEvaluateActivationConditionEventHandler.cs
+++ b/src/Fleans/Fleans.Application/Events/Handlers/WorkflowEvaluateActivationConditionEventHandler.cs
@@ -11,7 +11,7 @@ using Orleans.Streams;
 
 namespace Fleans.Application.Events.Handlers;
 
-[ImplicitStreamSubscription(WorkflowEventsPublisher.StreamNameSpace)]
+[ImplicitStreamSubscription(WorkflowEventsPublisher.EvaluateActivationConditionStreamNamespace)]
 [CorePlacement]
 public partial class WorkflowEvaluateActivationConditionEventHandler : Grain, IWorkflowEvaluateActivationConditionEventHandler, IAsyncObserver<EvaluateActivationConditionEvent>
 {
@@ -29,7 +29,7 @@ public partial class WorkflowEvaluateActivationConditionEventHandler : Grain, IW
     public override async Task OnActivateAsync(CancellationToken cancellationToken)
     {
         var streamProvider = this.GetStreamProvider(WorkflowEventsPublisher.StreamProvider);
-        var streamId = StreamId.Create(WorkflowEventsPublisher.StreamNameSpace, nameof(EvaluateActivationConditionEvent));
+        var streamId = StreamId.Create(WorkflowEventsPublisher.EvaluateActivationConditionStreamNamespace, nameof(EvaluateActivationConditionEvent));
         var stream = streamProvider.GetStream<EvaluateActivationConditionEvent>(streamId);
 
         var handles = await stream.GetAllSubscriptionHandles();

--- a/src/Fleans/Fleans.Application/Events/Handlers/WorkflowExecuteScriptEventHandler.cs
+++ b/src/Fleans/Fleans.Application/Events/Handlers/WorkflowExecuteScriptEventHandler.cs
@@ -8,7 +8,7 @@ using Orleans.Streams;
 
 namespace Fleans.Application.Events.Handlers;
 
-[ImplicitStreamSubscription(WorkflowEventsPublisher.StreamNameSpace)]
+[ImplicitStreamSubscription(WorkflowEventsPublisher.ExecuteScriptStreamNamespace)]
 [CorePlacement]
 public partial class WorkflowExecuteScriptEventHandler : Grain, IWorkflowExecuteScriptEventHandler, IAsyncObserver<ExecuteScriptEvent>
 {
@@ -24,7 +24,7 @@ public partial class WorkflowExecuteScriptEventHandler : Grain, IWorkflowExecute
     public override async Task OnActivateAsync(CancellationToken cancellationToken)
     {
         var streamProvider = this.GetStreamProvider(WorkflowEventsPublisher.StreamProvider);
-        var streamId = StreamId.Create(WorkflowEventsPublisher.StreamNameSpace, nameof(ExecuteScriptEvent));
+        var streamId = StreamId.Create(WorkflowEventsPublisher.ExecuteScriptStreamNamespace, nameof(ExecuteScriptEvent));
         var stream = streamProvider.GetStream<ExecuteScriptEvent>(streamId);
 
         var handles = await stream.GetAllSubscriptionHandles();

--- a/src/Fleans/Fleans.Application/Events/WorkflowEventsPublisher.cs
+++ b/src/Fleans/Fleans.Application/Events/WorkflowEventsPublisher.cs
@@ -21,6 +21,9 @@ public partial class WorkflowEventsPublisher : Grain, IEventPublisher
     public const string StreamProvider = WorkflowEventStreams.StreamProvider;
     public const string StreamNameSpace = WorkflowEventStreams.StreamNameSpace;
     public const string ExecuteCustomTaskStreamNamespace = WorkflowEventStreams.ExecuteCustomTaskStreamNamespace;
+    public const string ExecuteScriptStreamNamespace = WorkflowEventStreams.ExecuteScriptStreamNamespace;
+    public const string EvaluateConditionStreamNamespace = WorkflowEventStreams.EvaluateConditionStreamNamespace;
+    public const string EvaluateActivationConditionStreamNamespace = WorkflowEventStreams.EvaluateActivationConditionStreamNamespace;
 
     public WorkflowEventsPublisher(ILogger<WorkflowEventsPublisher> logger)
     {
@@ -42,18 +45,18 @@ public partial class WorkflowEventsPublisher : Grain, IEventPublisher
         {
             case EvaluateConditionEvent evaluateConditionEvent:
 
-                var streamId = StreamId.Create(WorkflowEventStreams.StreamNameSpace, nameof(EvaluateConditionEvent));
+                var streamId = StreamId.Create(WorkflowEventStreams.EvaluateConditionStreamNamespace, nameof(EvaluateConditionEvent));
                 var stream = _streamProvider.GetStream<EvaluateConditionEvent>(streamId);
                 await stream.OnNextAsync(evaluateConditionEvent);
                 break;
             case EvaluateActivationConditionEvent evaluateActivationConditionEvent:
-                var activationStreamId = StreamId.Create(WorkflowEventStreams.StreamNameSpace, nameof(EvaluateActivationConditionEvent));
+                var activationStreamId = StreamId.Create(WorkflowEventStreams.EvaluateActivationConditionStreamNamespace, nameof(EvaluateActivationConditionEvent));
                 var activationStream = _streamProvider.GetStream<EvaluateActivationConditionEvent>(activationStreamId);
                 await activationStream.OnNextAsync(evaluateActivationConditionEvent);
                 break;
             case ExecuteScriptEvent executeScriptEvent:
 
-                var scriptStreamId = StreamId.Create(WorkflowEventStreams.StreamNameSpace, nameof(ExecuteScriptEvent));
+                var scriptStreamId = StreamId.Create(WorkflowEventStreams.ExecuteScriptStreamNamespace, nameof(ExecuteScriptEvent));
                 var scriptStream = _streamProvider.GetStream<ExecuteScriptEvent>(scriptStreamId);
                 await scriptStream.OnNextAsync(executeScriptEvent);
                 break;


### PR DESCRIPTION
## Summary

Scopes the three engine-internal stream handlers to per-event namespaces, eliminating the "Dropping on the floor" log warnings that fire on every workflow execution.

- Add `ExecuteScriptStreamNamespace`, `EvaluateConditionStreamNamespace`, and `EvaluateActivationConditionStreamNamespace` constants to `WorkflowEventStreams` (in `Fleans.Application.Abstractions`) — single source of truth, same pattern as `ExecuteCustomTaskStreamNamespace` added in #441
- Add corresponding aliases to `WorkflowEventsPublisher` for existing call sites
- Update 3 publisher `case` arms to publish to the per-event namespaces
- Update `[ImplicitStreamSubscription]` + `StreamId.Create` in all 3 handlers to match

No behavior change at runtime — events are still delivered to the correct handlers. Orleans no longer activates all three handler grains on each event publication.

Closes #442

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `dotnet test` (Fleans.Application.Tests) — all passing
- [ ] Run Aspire stack with a script task + conditional gateway workflow and confirm `grep "Dropping on the floor"` returns nothing in the silo log

🤖 Generated with [Claude Code](https://claude.com/claude-code)
