### PR TITLE
refactor(state): per-scope CompensationWalkState dict (#488)

### DIFF
--- a/src/Fleans/Fleans.Domain/Aggregates/WorkflowExecution.cs
+++ b/src/Fleans/Fleans.Domain/Aggregates/WorkflowExecution.cs
@@ -18,6 +18,8 @@ public record CompletedActivityTransitions(
 
 public class WorkflowExecution
 {
+    private static Guid ScopeKey(Guid? scopeId) => scopeId ?? Guid.Empty;
+
     private readonly WorkflowInstanceState _state;
     private readonly IWorkflowDefinition _definition;
     private readonly List<IDomainEvent> _uncommittedEvents = [];
@@ -663,7 +665,7 @@ public class WorkflowExecution
     private void AdvanceCompensationWalk(Guid? scopeId, IWorkflowDefinition scopeDef,
         List<CompletedActivitySnapshot> orderedSnapshots)
     {
-        var walk = _state.ActiveCompensationWalk;
+        var walk = _state.GetCompensationWalk(scopeId);
         if (walk is null) return;
 
         // Find the next uncompensated snapshot that has a compensation handler
@@ -740,8 +742,8 @@ public class WorkflowExecution
     /// </summary>
     public Guid? AdvanceCompensationWalkIfHandlerCompleted()
     {
-        var walk = _state.ActiveCompensationWalk;
-        if (walk is null || walk.CurrentHandlerInstanceId is null) return null;
+        var walk = _state.GetActiveWalkWithHandler();
+        if (walk is null) return null;
 
         var handlerEntry = _state.FindEntry(walk.CurrentHandlerInstanceId.Value);
         if (handlerEntry is null || !handlerEntry.IsCompleted) return null;
@@ -795,7 +797,7 @@ public class WorkflowExecution
 
         // If the walk completed (no more handlers), the thrower was completed inside AdvanceCompensationWalk.
         // Return its instance ID so the caller can compute transitions for it.
-        if (_state.ActiveCompensationWalk is null)
+        if (_state.GetCompensationWalk(scopeId) is null)
             return walk.ThrowerActivityInstanceId;
 
         return null;
@@ -2957,17 +2959,17 @@ public class WorkflowExecution
                 break;
             case CompensationWalkStarted e:
                 if (e.HandlerCount > 0)
-                    _state.StartCompensationWalk(new CompensationWalkState(e.ScopeId, e.TargetActivityRef, e.ThrowerActivityInstanceId));
+                    _state.StartCompensationWalk(e.ScopeId, new CompensationWalkState(e.ScopeId, e.TargetActivityRef, e.ThrowerActivityInstanceId));
                 break;
             case CompensationHandlerSpawned e:
-                _state.SetCompensationHandlerInstanceId(e.HandlerInstanceId);
+                _state.SetCompensationHandlerInstanceId(e.ScopeId, e.HandlerInstanceId);
                 _state.MarkCurrentHandlerEntry(e.HandlerInstanceId);
                 break;
             case CompensationEntryMarkedCompensated e:
                 _state.MarkSnapshotCompensated(e.ActivityDefinitionId, e.ScopeId);
                 break;
-            case CompensationWalkCompleted:
-                _state.ClearCompensationWalk();
+            case CompensationWalkCompleted e:
+                _state.ClearCompensationWalk(e.ScopeId);
                 break;
             case CompensationWalkFailed:
                 // Walk state intentionally NOT cleared — preserved for observability

--- a/src/Fleans/Fleans.Domain/States/WorkflowInstanceState.cs
+++ b/src/Fleans/Fleans.Domain/States/WorkflowInstanceState.cs
@@ -146,9 +146,13 @@ public class WorkflowInstanceState
     [Id(21)]
     public int NextCompensationSequence { get; private set; }
 
-    /// <summary>Non-null while a compensation walk is in progress. At most one walk at a time.</summary>
-    [Id(22)]
-    public CompensationWalkState? ActiveCompensationWalk { get; private set; }
+    /// <summary>
+    /// Active compensation walks keyed by scope id. <see cref="Guid.Empty"/> is the root-scope sentinel.
+    /// Rebuilt from <c>CompensationWalkStarted</c> / <c>CompensationWalkCompleted</c> events on replay.
+    /// Preserved (not removed) on <c>CompensationWalkFailed</c> for observability.
+    /// </summary>
+    [Id(25)]
+    public Dictionary<Guid, CompensationWalkState> ActiveCompensationWalks { get; private set; } = new();
 
     internal int GetDirtyFlags() => _dirtyFlags;
 
@@ -590,21 +594,31 @@ public class WorkflowInstanceState
         _dirtyFlags |= DirtyCompensationLog;
     }
 
-    public void StartCompensationWalk(CompensationWalkState walk)
+    public void StartCompensationWalk(Guid? scopeId, CompensationWalkState walk)
     {
-        ActiveCompensationWalk = walk;
+        ActiveCompensationWalks[scopeId ?? Guid.Empty] = walk;
         _dirtyFlags |= DirtyCompensationLog;
     }
 
-    public void ClearCompensationWalk()
+    public void ClearCompensationWalk(Guid? scopeId)
     {
-        ActiveCompensationWalk = null;
+        ActiveCompensationWalks.Remove(scopeId ?? Guid.Empty);
         _dirtyFlags |= DirtyCompensationLog;
     }
 
-    public void SetCompensationHandlerInstanceId(Guid handlerInstanceId)
+    public CompensationWalkState? GetCompensationWalk(Guid? scopeId)
+        => ActiveCompensationWalks.TryGetValue(scopeId ?? Guid.Empty, out var w) ? w : null;
+
+    /// <summary>
+    /// Returns the walk that has an active handler, or null if none.
+    /// At most one walk has a non-null <c>CurrentHandlerInstanceId</c> at any time.
+    /// </summary>
+    public CompensationWalkState? GetActiveWalkWithHandler()
+        => ActiveCompensationWalks.Values.FirstOrDefault(w => w.CurrentHandlerInstanceId != null);
+
+    public void SetCompensationHandlerInstanceId(Guid? scopeId, Guid handlerInstanceId)
     {
-        ActiveCompensationWalk?.SetCurrentHandler(handlerInstanceId);
+        GetCompensationWalk(scopeId)?.SetCurrentHandler(handlerInstanceId);
         _dirtyFlags |= DirtyCompensationLog;
     }
 

--- a/src/Fleans/Fleans.Persistence/FleanModelConfiguration.cs
+++ b/src/Fleans/Fleans.Persistence/FleanModelConfiguration.cs
@@ -48,10 +48,10 @@ internal static class FleanModelConfiguration
             // UserTasks is an in-memory dictionary rehydrated from the UserTasks table on activation.
             entity.Ignore(e => e.UserTasks);
 
-            // CompensationLog and ActiveCompensationWalk are event-sourced state: they are rebuilt
+            // CompensationLog and ActiveCompensationWalks are event-sourced state: they are rebuilt
             // from domain events on grain activation and are NOT projected to the relational store.
             entity.Ignore(e => e.CompensationLog);
-            entity.Ignore(e => e.ActiveCompensationWalk);
+            entity.Ignore(e => e.ActiveCompensationWalks);
             entity.Ignore(e => e.NextCompensationSequence);
 
             // TransactionOutcomes is rebuilt from TransactionOutcomeSet events on grain activation.


### PR DESCRIPTION
## Summary

- Replace `[Id(22)] CompensationWalkState? ActiveCompensationWalk` with `[Id(25)] Dictionary<Guid, CompensationWalkState> ActiveCompensationWalks` keyed by scope id (`Guid.Empty` = root-scope sentinel)
- Enables Phase B–D (nested cancel/hazard semantics) to track concurrent compensation walks across nested Transaction Sub-Processes

Closes #488

## Key decisions

- **Slot `[Id(25)]`**: `[Id(24)]` was already taken by `ScopeHostExecutionScopes` added after the v5 design was written; `[Id(25)]` is the next free slot
- **`CompensationWalkFailed` is a no-op**: Walk entry preserved in dict for observability (matching existing behavior — `CompensationWalkFailed` is always immediately followed by `WorkflowCompleted`)
- **No migration**: Field is EF-ignored and rebuilt from events on activation; retiring `[Id(22)]` needs no deserialization shim
- **`HandlerCount > 0` guard preserved**: Only adds walk to dict when there are handlers (matching existing Apply behavior)

## Files changed

| File | Change |
|---|---|
| `Fleans.Domain/States/WorkflowInstanceState.cs` | Remove `[Id(22)]` field; add `[Id(25)]` dict + `StartCompensationWalk`, `ClearCompensationWalk`, `GetCompensationWalk`, `SetCompensationHandlerInstanceId`, `GetActiveWalkWithHandler` |
| `Fleans.Domain/Aggregates/WorkflowExecution.cs` | Add `ScopeKey` helper; update all 6 `ActiveCompensationWalk` call-sites; bind `e` in `CompensationWalkCompleted` Apply |
| `Fleans.Persistence/FleanModelConfiguration.cs` | Rename `Ignore(e.ActiveCompensationWalk)` → `Ignore(e.ActiveCompensationWalks)` |

## How to test

All 411 Domain.Tests pass (`dotnet test Fleans.Domain.Tests`). Existing compensation tests verify single-walk behavior is unchanged. Nested-walk correctness will be exercised by Phase B tests.
