### PR TITLE
fix(#497): wrap StartChildWorkflow/AddConditions/EvaluateActivation Process* calls in try/catch

### DIFF
--- a/src/Fleans/Fleans.Domain.Tests/WorkflowExecutionProcessCommandsTests.cs
+++ b/src/Fleans/Fleans.Domain.Tests/WorkflowExecutionProcessCommandsTests.cs
@@ -414,4 +414,46 @@ public class WorkflowExecutionProcessCommandsTests
         var spawned = events.OfType<ActivitySpawned>().Single();
         Assert.AreEqual(scopeId, spawned.ScopeId);
     }
+
+    // --- #497: Process* build-time throw paths ---
+    // All three cases below trigger the catch handler introduced in #497.
+    // A non-existent activityInstanceId causes GetActiveEntry to throw inside the
+    // Process* method; the catch uses FindEntry (nullable) which returns null, so
+    // FailActivity is skipped and no exception propagates to the caller.
+
+    [TestMethod]
+    public void ProcessCommands_StartChildWorkflowCommand_UnknownActivityInstanceId_DoesNotThrow()
+    {
+        // BuildChildInputVariables silently skips missing variables (TryGetValue).
+        // The realistic throw trigger is GetActiveEntry on a non-existent instance.
+        var callActivity = new CallActivity("call1", "childProcess", [], []);
+        var (execution, _, _) = CreateStartedExecution(extraActivities: [callActivity]);
+
+        var effects = execution.ProcessCommands(
+            [new StartChildWorkflowCommand(callActivity)], Guid.NewGuid());
+
+        Assert.AreEqual(0, effects.Count);
+    }
+
+    [TestMethod]
+    public void ProcessCommands_AddConditionsCommand_UnknownActivityInstanceId_DoesNotThrow()
+    {
+        var (execution, _, _) = CreateStartedExecution();
+
+        var effects = execution.ProcessCommands(
+            [new AddConditionsCommand(["seq1"], [])], Guid.NewGuid());
+
+        Assert.AreEqual(0, effects.Count);
+    }
+
+    [TestMethod]
+    public void ProcessCommands_EvaluateActivationConditionCommand_UnknownActivityInstanceId_DoesNotThrow()
+    {
+        var (execution, _, _) = CreateStartedExecution();
+
+        var effects = execution.ProcessCommands(
+            [new EvaluateActivationConditionCommand("= x > 0", 1)], Guid.NewGuid());
+
+        Assert.AreEqual(0, effects.Count);
+    }
 }

--- a/src/Fleans/Fleans.Domain/Aggregates/WorkflowExecution.cs
+++ b/src/Fleans/Fleans.Domain/Aggregates/WorkflowExecution.cs
@@ -492,10 +492,6 @@ public class WorkflowExecution
                     // targeting the same activity are naturally no-op'd by the aggregate's
                     // "Each activity instance executes at most once" invariant
                     // (FailActivity's IsCompleted stale-guard).
-                    // The other three Process*-call cases (StartChildWorkflowCommand,
-                    // AddConditionsCommand, EvaluateActivationConditionCommand) are tracked
-                    // by #497 — their command records lack a direct ActivityId field and need
-                    // a reverse-lookup helper or a schema change to support the same pattern.
                     try
                     {
                         effects.Add(ProcessRegisterMessage(msg, activityInstanceId));
@@ -513,15 +509,45 @@ public class WorkflowExecution
                     break;
 
                 case StartChildWorkflowCommand startChild:
-                    effects.Add(ProcessStartChildWorkflow(startChild, activityInstanceId));
+                    // Note: ProcessStartChildWorkflow emits ChildWorkflowLinked before
+                    // BuildChildInputVariables runs; a throw leaves a phantom link entry.
+                    // This is acceptable — the child grain never receives StartWorkflow.
+                    try
+                    {
+                        effects.Add(ProcessStartChildWorkflow(startChild, activityInstanceId));
+                    }
+                    catch (Exception ex)
+                    {
+                        var activityId = _state.FindEntry(activityInstanceId)?.ActivityId;
+                        if (activityId is not null)
+                            effects.AddRange(FailActivity(activityId, activityInstanceId, ex));
+                    }
                     break;
 
                 case AddConditionsCommand conditions:
-                    effects.AddRange(ProcessAddConditions(conditions, activityInstanceId));
+                    try
+                    {
+                        effects.AddRange(ProcessAddConditions(conditions, activityInstanceId));
+                    }
+                    catch (Exception ex)
+                    {
+                        var activityId = _state.FindEntry(activityInstanceId)?.ActivityId;
+                        if (activityId is not null)
+                            effects.AddRange(FailActivity(activityId, activityInstanceId, ex));
+                    }
                     break;
 
                 case EvaluateActivationConditionCommand evalActivation:
-                    effects.Add(ProcessEvaluateActivationCondition(evalActivation, activityInstanceId));
+                    try
+                    {
+                        effects.Add(ProcessEvaluateActivationCondition(evalActivation, activityInstanceId));
+                    }
+                    catch (Exception ex)
+                    {
+                        var activityId = _state.FindEntry(activityInstanceId)?.ActivityId;
+                        if (activityId is not null)
+                            effects.AddRange(FailActivity(activityId, activityInstanceId, ex));
+                    }
                     break;
 
                 case RegisterUserTaskCommand regUserTask:


### PR DESCRIPTION
Closes #497

## Summary

- Wraps three `PerformEffects` switch cases (`StartChildWorkflowCommand`, `AddConditionsCommand`, `EvaluateActivationConditionCommand`) in try/catch — matching the pattern established for `RegisterMessageCommand` in #425
- Catch handler uses `_state.FindEntry(activityInstanceId)?.ActivityId` (nullable, safe in catch) to call `FailActivity`; if the entry is already gone, the exception is swallowed without failing (the activity is no longer active)
- Removes the now-resolved `#497` TODO comment from the `RegisterMessageCommand` case

## Key decisions

- **`FindEntry` over `GetActiveEntry` in catch**: `GetActiveEntry` throws on missing entry — using it in a catch block would mask the original exception. `FindEntry` is the nullable variant.
- **`activityId is not null` guard**: In the (unlikely) case the entry has been removed from state before the catch runs, FailActivity is safely skipped.
- **`BuildChildInputVariables` does NOT throw on missing variables**: It uses `TryGetValue`, silently skipping unmapped variables. The realistic throw trigger for all three cases is `GetActiveEntry` on a non-existent instance (state/programming error). Defensive wrapping is still correct for future changes.
- **`StartChildWorkflowCommand` phantom `ChildWorkflowLinked`**: If `GetActiveEntry` succeeds but a later line throws, `ChildWorkflowLinked` would already be emitted. This pre-existing concern is out of scope for this fix (the child grain never receives `StartWorkflow` in this case).

## Tests

Three new tests in `WorkflowExecutionProcessCommandsTests`:
- `ProcessCommands_StartChildWorkflowCommand_UnknownActivityInstanceId_DoesNotThrow`
- `ProcessCommands_AddConditionsCommand_UnknownActivityInstanceId_DoesNotThrow`
- `ProcessCommands_EvaluateActivationConditionCommand_UnknownActivityInstanceId_DoesNotThrow`

Each passes a non-existent `activityInstanceId` which triggers `GetActiveEntry` to throw inside the Process* method. Verifies: no exception propagates, effects are empty (FailActivity skipped because FindEntry returns null).

Full domain test suite: 414/414 passing.
