### PR TITLE
feat(#489): Phase B — nested TX cancel-path semantics + CompensationWalkAborted

### DIFF
--- a/src/Fleans/Fleans.Application/Grains/WorkflowInstance.Infrastructure.cs
+++ b/src/Fleans/Fleans.Application/Grains/WorkflowInstance.Infrastructure.cs
@@ -222,14 +222,16 @@ public partial class WorkflowInstance
         // before CompleteFinishedSubProcessScopes can auto-complete the Transaction as Completed.
         var cancelEventCountBefore = _execution.GetUncommittedEvents().Count;
         var cancelEffects = _execution.InitiateTransactionCancelFlowIfNeeded();
-        // Log each transaction cancel that was just initiated
-        foreach (var cancelledTx in _execution.GetUncommittedEvents()
-            .Skip(cancelEventCountBefore)
-            .OfType<TransactionOutcomeSet>()
+        // Log each transaction cancel that was just initiated, including descendant walk aborts
+        var postCancelEvents = _execution.GetUncommittedEvents().Skip(cancelEventCountBefore).ToList();
+        foreach (var cancelledTx in postCancelEvents.OfType<TransactionOutcomeSet>()
             .Where(e => e.Outcome == TransactionOutcome.Cancelled))
         {
             var txEntry = State.FindEntry(cancelledTx.TransactionInstanceId);
             LogTransactionCancelInitiated(cancelledTx.TransactionInstanceId, txEntry?.ActivityId ?? "unknown");
+            var abortCount = postCancelEvents.OfType<CompensationWalkAborted>().Count();
+            if (abortCount > 0)
+                LogAbortingDescendantWalks(abortCount, cancelledTx.TransactionInstanceId);
         }
         if (cancelEffects.Count > 0)
             await PerformEffects(cancelEffects);
@@ -649,6 +651,9 @@ public partial class WorkflowInstance
                 break;
             case CompensationWalkFailed walkFailed:
                 LogCompensationHandlerFailed(walkFailed.HandlerInstanceId, walkFailed.ErrorCode, walkFailed.ErrorMessage);
+                break;
+            case CompensationWalkAborted walkAborted:
+                LogCompensationWalkAborted(walkAborted.ScopeId, walkAborted.Reason);
                 break;
             case WorkflowCancelled wfCancelled:
                 LogWorkflowCancelled(wfCancelled.Reason);

--- a/src/Fleans/Fleans.Application/Grains/WorkflowInstance.Logging.cs
+++ b/src/Fleans/Fleans.Application/Grains/WorkflowInstance.Logging.cs
@@ -334,6 +334,14 @@ public partial class WorkflowInstance
         Message = "Compensation handler failed: HandlerInstanceId={HandlerInstanceId}, ErrorCode={ErrorCode}, ErrorMessage={ErrorMessage}")]
     private partial void LogCompensationHandlerFailed(Guid handlerInstanceId, string errorCode, string errorMessage);
 
+    [LoggerMessage(EventId = 1117, Level = LogLevel.Warning,
+        Message = "Compensation walk for scope {ScopeId} aborted: {Reason}")]
+    private partial void LogCompensationWalkAborted(Guid? scopeId, string reason);
+
+    [LoggerMessage(EventId = 1118, Level = LogLevel.Information,
+        Message = "Aborting {Count} descendant compensation walk(s) for outer transaction {TxInstanceId}")]
+    private partial void LogAbortingDescendantWalks(int count, Guid txInstanceId);
+
     // Complex gateway lifecycle (EventId 1080-1089)
     [LoggerMessage(EventId = 1080, Level = LogLevel.Debug,
         Message = "Complex gateway activation condition late callback — join instance {ActivityInstanceId} has already fired or was removed")]

--- a/src/Fleans/Fleans.Domain.Tests/NestedTxPhaseBDomainTests.cs
+++ b/src/Fleans/Fleans.Domain.Tests/NestedTxPhaseBDomainTests.cs
@@ -1,0 +1,179 @@
+using Fleans.Domain.Activities;
+using Fleans.Domain.Aggregates;
+using Fleans.Domain.Events;
+using Fleans.Domain.Sequences;
+using Fleans.Domain.States;
+
+namespace Fleans.Domain.Tests;
+
+[TestClass]
+public class NestedTxPhaseBDomainTests
+{
+    private static (WorkflowExecution execution, WorkflowInstanceState state) CreateExecution(
+        bool withInnerTx = false)
+    {
+        var cancelOuter = new CancelEndEvent("cancel-outer");
+        var outerTxActivities = withInnerTx
+            ? new List<Activity> { cancelOuter, new Transaction("inner-tx") { Activities = [new CancelEndEvent("cancel-inner"), new ScriptTask("handler-act", "return 1;")] } }
+            : new List<Activity> { cancelOuter };
+        var outerTx = new Transaction("outer-tx") { Activities = outerTxActivities };
+        var start = new StartEvent("start");
+        var end = new EndEvent("end");
+
+        var definition = new WorkflowDefinition
+        {
+            WorkflowId = "nested-tx-b-test",
+            ProcessDefinitionId = "pd1",
+            Activities = [start, outerTx, end],
+            SequenceFlows = [new SequenceFlow("s1", start, outerTx), new SequenceFlow("s2", outerTx, end)]
+        };
+
+        var state = new WorkflowInstanceState();
+        var execution = new WorkflowExecution(state, definition);
+        execution.Start();
+        execution.ClearUncommittedEvents();
+        return (execution, state);
+    }
+
+    // Scenario B: Inner TX fires CancelEndEvent; outer continues with no CompensationWalkAborted
+    [TestMethod]
+    public void NestedTx_InnerCancels_OuterContinues_ScenarioB()
+    {
+        var (execution, state) = CreateExecution(withInnerTx: true);
+        var wfId = state.Id;
+        var outerTxId = Guid.NewGuid();
+        var innerTxId = Guid.NewGuid();
+        var cancelInnerId = Guid.NewGuid();
+
+        // Outer TX active; inner TX has a completed CancelEndEvent (inner TX cancelling itself)
+        var outerTxEntry = new ActivityInstanceEntry(outerTxId, "outer-tx", wfId);
+        var innerTxEntry = new ActivityInstanceEntry(innerTxId, "inner-tx", wfId, scopeId: outerTxId);
+        var cancelInnerEntry = new ActivityInstanceEntry(cancelInnerId, "cancel-inner", wfId, scopeId: innerTxId);
+        state.AddEntries([outerTxEntry, innerTxEntry, cancelInnerEntry]);
+        state.CompleteEntries([cancelInnerEntry]);
+
+        // Act: outer TX has NO CancelEndEvent — loop skips the outer TX
+        execution.InitiateTransactionCancelFlowIfNeeded();
+
+        var events = execution.GetUncommittedEvents();
+
+        // The inner TX cancel is handled separately; this loop only triggers on outer TX CancelEndEvent
+        // Since outer TX has no completed CancelEndEvent, nothing fires for the outer TX
+        Assert.IsFalse(events.OfType<CompensationWalkAborted>().Any(), "No walk to abort");
+        Assert.IsFalse(events.OfType<TransactionOutcomeSet>()
+            .Any(e => e.TransactionInstanceId == outerTxId), "Outer TX outcome not set");
+    }
+
+    // Scenario C: Outer TX fires CancelEndEvent; inner TX completed (no active walk)
+    [TestMethod]
+    public void NestedTx_OuterCancels_NoInnerWalk_ScenarioC()
+    {
+        var (execution, state) = CreateExecution();
+        var wfId = state.Id;
+        var outerTxId = Guid.NewGuid();
+        var cancelOuterId = Guid.NewGuid();
+
+        var outerTxEntry = new ActivityInstanceEntry(outerTxId, "outer-tx", wfId);
+        var cancelEntry = new ActivityInstanceEntry(cancelOuterId, "cancel-outer", wfId, scopeId: outerTxId);
+        state.AddEntries([outerTxEntry, cancelEntry]);
+        state.CompleteEntries([cancelEntry]);
+
+        // Act
+        execution.InitiateTransactionCancelFlowIfNeeded();
+
+        var events = execution.GetUncommittedEvents();
+
+        Assert.IsFalse(events.OfType<CompensationWalkAborted>().Any(), "No walk to abort");
+        Assert.IsTrue(events.OfType<TransactionOutcomeSet>().Any(e =>
+            e.TransactionInstanceId == outerTxId && e.Outcome == TransactionOutcome.Cancelled),
+            "Outer TX outcome set to Cancelled");
+        Assert.IsTrue(events.OfType<CompensationWalkStarted>().Any(),
+            "Outer compensation walk started");
+    }
+
+    // Scenario D: Outer TX fires CancelEndEvent; inner TX completed + inner walk completed
+    [TestMethod]
+    public void NestedTx_OuterCancels_InnerWalkCompleted_ScenarioD()
+    {
+        var (execution, state) = CreateExecution(withInnerTx: true);
+        var wfId = state.Id;
+        var outerTxId = Guid.NewGuid();
+        var innerTxId = Guid.NewGuid();
+        var cancelOuterId = Guid.NewGuid();
+
+        var outerTxEntry = new ActivityInstanceEntry(outerTxId, "outer-tx", wfId);
+        var innerTxEntry = new ActivityInstanceEntry(innerTxId, "inner-tx", wfId, scopeId: outerTxId);
+        var cancelEntry = new ActivityInstanceEntry(cancelOuterId, "cancel-outer", wfId, scopeId: outerTxId);
+        state.AddEntries([outerTxEntry, innerTxEntry, cancelEntry]);
+        state.CompleteEntries([cancelEntry, innerTxEntry]);
+        // No ActiveCompensationWalks entry for inner TX — its walk already completed
+
+        // Act
+        execution.InitiateTransactionCancelFlowIfNeeded();
+
+        var events = execution.GetUncommittedEvents();
+
+        Assert.IsFalse(events.OfType<CompensationWalkAborted>().Any(),
+            "No walk to abort — inner walk already done");
+        Assert.IsTrue(events.OfType<TransactionOutcomeSet>().Any(e =>
+            e.TransactionInstanceId == outerTxId && e.Outcome == TransactionOutcome.Cancelled),
+            "Outer TX outcome set to Cancelled");
+        Assert.IsTrue(events.OfType<CompensationWalkStarted>().Any(),
+            "Outer compensation walk started");
+    }
+
+    // Scenario E: Outer TX fires CancelEndEvent; inner TX mid-walk (handler running)
+    [TestMethod]
+    public void NestedTx_OuterCancels_InnerWalkMidFlight_ScenarioE()
+    {
+        var (execution, state) = CreateExecution(withInnerTx: true);
+        var wfId = state.Id;
+        var outerTxId = Guid.NewGuid();
+        var innerTxId = Guid.NewGuid();
+        var cancelOuterId = Guid.NewGuid();
+        var handlerId = Guid.NewGuid();
+
+        var outerTxEntry = new ActivityInstanceEntry(outerTxId, "outer-tx", wfId);
+        var innerTxEntry = new ActivityInstanceEntry(innerTxId, "inner-tx", wfId, scopeId: outerTxId);
+        var cancelEntry = new ActivityInstanceEntry(cancelOuterId, "cancel-outer", wfId, scopeId: outerTxId);
+        // Handler entry is active (mid-flight), scoped to inner TX
+        var handlerEntry = new ActivityInstanceEntry(handlerId, "handler-act", wfId, scopeId: innerTxId);
+
+        state.AddEntries([outerTxEntry, innerTxEntry, cancelEntry, handlerEntry]);
+        state.CompleteEntries([cancelEntry, innerTxEntry]);
+
+        // Set up inner TX compensation walk mid-flight with handler running
+        var thrower = Guid.NewGuid();
+        state.StartCompensationWalk(innerTxId, new CompensationWalkState(innerTxId, null, thrower));
+        state.SetCompensationHandlerInstanceId(innerTxId, handlerId);
+
+        // Act
+        execution.InitiateTransactionCancelFlowIfNeeded();
+
+        var events = execution.GetUncommittedEvents();
+
+        // CompensationWalkAborted emitted for inner TX scope
+        var aborted = events.OfType<CompensationWalkAborted>().ToList();
+        Assert.AreEqual(1, aborted.Count, "Exactly one walk aborted");
+        Assert.AreEqual(innerTxId, aborted[0].ScopeId, "Inner TX walk aborted");
+        Assert.AreEqual("OuterTransactionCancellation", aborted[0].Reason);
+
+        // In-flight handler activity entry is cancelled
+        Assert.IsTrue(events.OfType<ActivityCancelled>()
+            .Any(e => e.ActivityInstanceId == handlerId),
+            "In-flight handler cancelled");
+
+        // Outer TX outcome set to Cancelled
+        Assert.IsTrue(events.OfType<TransactionOutcomeSet>().Any(e =>
+            e.TransactionInstanceId == outerTxId && e.Outcome == TransactionOutcome.Cancelled),
+            "Outer TX outcome set to Cancelled");
+
+        // Outer compensation walk started
+        Assert.IsTrue(events.OfType<CompensationWalkStarted>().Any(),
+            "Outer compensation walk started");
+
+        // Inner TX walk cleared from state (ClearCompensationWalk was applied)
+        Assert.IsFalse(state.ActiveCompensationWalks.ContainsKey(innerTxId),
+            "Inner TX walk no longer active");
+    }
+}

--- a/src/Fleans/Fleans.Domain/Aggregates/WorkflowExecution.cs
+++ b/src/Fleans/Fleans.Domain/Aggregates/WorkflowExecution.cs
@@ -18,8 +18,6 @@ public record CompletedActivityTransitions(
 
 public class WorkflowExecution
 {
-    private static Guid ScopeKey(Guid? scopeId) => scopeId ?? Guid.Empty;
-
     private readonly WorkflowInstanceState _state;
     private readonly IWorkflowDefinition _definition;
     private readonly List<IDomainEvent> _uncommittedEvents = [];
@@ -242,6 +240,10 @@ public class WorkflowExecution
             // 2. Cancel all remaining active activities in the transaction scope
             //    (the CancelEndEvent is already completed, so it is not in GetActiveActivities)
             effects.AddRange(CancelScopeChildren(txEntry.ActivityInstanceId, "CancelledByTransaction"));
+
+            // 3b. Abort any descendant TX compensation walks that are mid-flight (Scenario E)
+            foreach (var descendantScope in DescendantScopesWithActiveWalk(txEntry.ActivityInstanceId))
+                AbortCompensationWalk(descendantScope, "OuterTransactionCancellation");
 
             // 3. Initiate compensation walk — CancelEndEvent is the thrower, broadcast (null target)
             PerformCompensationWalk(cancelEntry.ActivityInstanceId, targetActivityRef: null);
@@ -2546,6 +2548,40 @@ public class WorkflowExecution
         return effects.AsReadOnly();
     }
 
+    private IEnumerable<Guid> DescendantScopesWithActiveWalk(Guid rootScopeId)
+    {
+        foreach (var scopeKey in _state.ActiveCompensationWalks.Keys)
+        {
+            if (scopeKey == Guid.Empty) continue;
+            if (IsDescendantOfScope(scopeKey, rootScopeId))
+                yield return scopeKey;
+        }
+    }
+
+    private bool IsDescendantOfScope(Guid childScopeId, Guid ancestorScopeId)
+    {
+        var entry = _state.FindEntry(childScopeId);
+        if (entry is null) return false;
+        if (entry.ScopeId == ancestorScopeId) return true;
+        if (!entry.ScopeId.HasValue) return false;
+        return IsDescendantOfScope(entry.ScopeId.Value, ancestorScopeId);
+    }
+
+    private void AbortCompensationWalk(Guid? scopeId, string reason)
+    {
+        var walk = _state.GetCompensationWalk(scopeId);
+        if (walk is null) return;
+
+        if (walk.CurrentHandlerInstanceId.HasValue)
+        {
+            var handlerEntry = _state.FindEntry(walk.CurrentHandlerInstanceId.Value);
+            if (handlerEntry is not null && !handlerEntry.IsCompleted && !handlerEntry.IsCancelled)
+                Emit(new ActivityCancelled(walk.CurrentHandlerInstanceId.Value, "CompensationHandlerAborted"));
+        }
+
+        Emit(new CompensationWalkAborted(scopeId, reason));
+    }
+
     /// <summary>
     /// Recursively cancels all active entries within a scope (and their nested scope children).
     /// </summary>
@@ -2999,6 +3035,9 @@ public class WorkflowExecution
                 break;
             case CompensationWalkFailed:
                 // Walk state intentionally NOT cleared — preserved for observability
+                break;
+            case CompensationWalkAborted e:
+                _state.ClearCompensationWalk(e.ScopeId);
                 break;
             case TransactionOutcomeSet e:
                 _state.TransactionOutcomes[e.TransactionInstanceId] =

--- a/src/Fleans/Fleans.Domain/Events/WorkflowDomainEvents.cs
+++ b/src/Fleans/Fleans.Domain/Events/WorkflowDomainEvents.cs
@@ -112,6 +112,10 @@ public record CompensationWalkFailed(
     string ErrorCode,
     string ErrorMessage) : IDomainEvent;
 
+public record CompensationWalkAborted(
+    Guid? ScopeId,
+    string Reason) : IDomainEvent;
+
 // Transaction Sub-Process outcome
 // Plain record — no [GenerateSerializer] — stored via Newtonsoft.Json in EfCoreEventStore,
 // consistent with all other JournaledGrain events in this file.


### PR DESCRIPTION
Closes #489

## Summary

- Adds `CompensationWalkAborted(Guid? ScopeId, string Reason)` domain event. Apply: `ClearCompensationWalk(e.ScopeId)` — unlike `CompensationWalkFailed` which preserves for observability, an aborted walk is deliberately terminated and removed
- Adds `DescendantScopesWithActiveWalk` + `IsDescendantOfScope` helpers to find inner TX scopes with active compensation walks
- Adds `AbortCompensationWalk` helper: cancels the in-flight handler entry via `ActivityCancelled(handlerInstanceId, "CompensationHandlerAborted")` (2-param — matches `WorkflowDomainEvents.cs:22`), then emits `CompensationWalkAborted`
- Updates `InitiateTransactionCancelFlowIfNeeded` with step 3b: abort descendant walks before starting the outer walk (handles Scenario E)
- Removes unused `ScopeKey` static helper from Phase A.2 (#488)
- Adds `[LoggerMessage]` partials EventId 1117 (`LogCompensationWalkAborted`) and 1118 (`LogAbortingDescendantWalks`) in the compensation block (1110–1119)
- Adds `CompensationWalkAborted` case to the grain event-processing switch in `WorkflowInstance.Infrastructure.cs`
- Domain tests: Scenarios B (inner cancels, outer continues), C (outer cancels, no inner walk), D (outer cancels, inner walk completed), E (outer cancels, inner walk mid-flight — primary new scenario)

## Key decisions

- **`ClearCompensationWalk` on Abort vs Fail**: `CompensationWalkFailed` preserves state for observability (intentional from Phase A.2). `CompensationWalkAborted` clears it — an abort is an engine-driven termination, not an error requiring post-mortem.
- **`ActivityCancelled` 2-param**: `new ActivityCancelled(handlerInstanceId, "CompensationHandlerAborted")` — matches the actual record definition (2 params, confirmed in review).
- **`IsDescendantOfScope` uses `FindEntry` (nullable)**: `FindEntry` works on the full `EntriesById` cache including completed entries — correct for nested TX entries that completed before the outer cancel.
- **`ScopeKey` removal**: Phase A.2 added it for potential future use; unused after Phase B; removed here to avoid confusion.

## Test plan

418/418 domain tests green. New tests:
- `NestedTx_InnerCancels_OuterContinues_ScenarioB` — outer TX skipped when it has no CancelEndEvent
- `NestedTx_OuterCancels_NoInnerWalk_ScenarioC` — walk starts normally when no inner walk active
- `NestedTx_OuterCancels_InnerWalkCompleted_ScenarioD` — same as C (inner walk already done)
- `NestedTx_OuterCancels_InnerWalkMidFlight_ScenarioE` — `CompensationWalkAborted` emitted, handler cancelled, outer walk starts
