### PR TITLE
feat(#490): Phase C — Hazard cascade in nested TX cancel flow

### DIFF
--- a/src/Fleans/Fleans.Application/Grains/WorkflowInstance.Infrastructure.cs
+++ b/src/Fleans/Fleans.Application/Grains/WorkflowInstance.Infrastructure.cs
@@ -233,6 +233,9 @@ public partial class WorkflowInstance
             if (abortCount > 0)
                 LogAbortingDescendantWalks(abortCount, cancelledTx.TransactionInstanceId);
         }
+        foreach (var hazardTx in postCancelEvents.OfType<TransactionOutcomeSet>()
+            .Where(e => e.Outcome == TransactionOutcome.Hazard))
+            LogHazardCascadeToOuter(hazardTx.TransactionInstanceId, hazardTx.ErrorMessage);
         if (cancelEffects.Count > 0)
             await PerformEffects(cancelEffects);
 

--- a/src/Fleans/Fleans.Application/Grains/WorkflowInstance.Logging.cs
+++ b/src/Fleans/Fleans.Application/Grains/WorkflowInstance.Logging.cs
@@ -416,6 +416,10 @@ public partial class WorkflowInstance
         Message = "Transaction completed: transactionInstanceId={TransactionInstanceId} activityId={ActivityId}")]
     private partial void LogTransactionCompleted(Guid transactionInstanceId, string activityId);
 
+    [LoggerMessage(EventId = 1104, Level = LogLevel.Warning,
+        Message = "Outer transaction {OuterTxId} cancel aborted — Hazard propagated to outer TX; {ErrorMessage}")]
+    private partial void LogHazardCascadeToOuter(Guid outerTxId, string? errorMessage);
+
     [LoggerMessage(EventId = 3033, Level = LogLevel.Debug,
         Message = "Compensation log returned: {EntryCount} entries")]
     private partial void LogCompensationLogReturned(int entryCount);

--- a/src/Fleans/Fleans.Domain.Tests/NestedTxPhaseCDomainTests.cs
+++ b/src/Fleans/Fleans.Domain.Tests/NestedTxPhaseCDomainTests.cs
@@ -1,0 +1,155 @@
+using Fleans.Domain.Activities;
+using Fleans.Domain.Aggregates;
+using Fleans.Domain.Events;
+using Fleans.Domain.Sequences;
+using Fleans.Domain.States;
+
+namespace Fleans.Domain.Tests;
+
+[TestClass]
+public class NestedTxPhaseCDomainTests
+{
+    private static (WorkflowExecution execution, WorkflowInstanceState state) CreateExecution()
+    {
+        var cancelOuter = new CancelEndEvent("cancel-outer");
+        var innerTx = new Transaction("inner-tx") { Activities = [new ScriptTask("inner-task", "return 1;")] };
+        var outerSiblingTask = new ScriptTask("outer-sibling", "return 1;");
+        var outerTx = new Transaction("outer-tx") { Activities = [cancelOuter, innerTx, outerSiblingTask] };
+        var start = new StartEvent("start");
+        var end = new EndEvent("end");
+
+        var definition = new WorkflowDefinition
+        {
+            WorkflowId = "nested-tx-c-test",
+            ProcessDefinitionId = "pd1",
+            Activities = [start, outerTx, end],
+            SequenceFlows = [new SequenceFlow("s1", start, outerTx), new SequenceFlow("s2", outerTx, end)]
+        };
+
+        var state = new WorkflowInstanceState();
+        var execution = new WorkflowExecution(state, definition);
+        execution.Start();
+        execution.ClearUncommittedEvents();
+        return (execution, state);
+    }
+
+    // Scenario F: Outer TX fires CancelEndEvent, but a descendant TX ended in Hazard.
+    // Expected: outer TX outcome is Hazard (not Cancelled), scope children are cancelled,
+    // and no compensation walk is started for the outer TX.
+    [TestMethod]
+    public void NestedTx_OuterCancels_AfterInnerHazard_ScenarioF()
+    {
+        var (execution, state) = CreateExecution();
+        var wfId = state.Id;
+        var outerTxId = Guid.NewGuid();
+        var innerTxId = Guid.NewGuid();
+        var outerSiblingId = Guid.NewGuid();
+        var cancelOuterId = Guid.NewGuid();
+
+        // Outer TX is active; it has an active sibling task and a completed CancelEndEvent
+        var outerTxEntry = new ActivityInstanceEntry(outerTxId, "outer-tx", wfId);
+        var outerSiblingEntry = new ActivityInstanceEntry(outerSiblingId, "outer-sibling", wfId, scopeId: outerTxId);
+        var cancelEntry = new ActivityInstanceEntry(cancelOuterId, "cancel-outer", wfId, scopeId: outerTxId);
+        // Inner TX was active inside outer TX scope and already ended — not in ActiveEntryIds
+        var innerTxEntry = new ActivityInstanceEntry(innerTxId, "inner-tx", wfId, scopeId: outerTxId);
+
+        state.AddEntries([outerTxEntry, outerSiblingEntry, cancelEntry, innerTxEntry]);
+        state.CompleteEntries([cancelEntry, innerTxEntry]); // inner TX is done (Hazard), cancel-outer fired
+
+        // Seed inner TX with Hazard outcome (inner TX ended in Hazard before outer cancel fires)
+        execution.SetTransactionOutcomeHazard(innerTxId, "500", "inner task escaped");
+        execution.ClearUncommittedEvents();
+
+        // Act
+        var effects = execution.InitiateTransactionCancelFlowIfNeeded();
+
+        var events = execution.GetUncommittedEvents();
+
+        // Outer TX outcome must be Hazard (cascaded from inner TX), not Cancelled
+        var outcomeSet = events.OfType<TransactionOutcomeSet>()
+            .FirstOrDefault(e => e.TransactionInstanceId == outerTxId);
+        Assert.IsNotNull(outcomeSet, "Outer TX outcome must be set");
+        Assert.AreEqual(TransactionOutcome.Hazard, outcomeSet.Outcome,
+            "Outer TX outcome must be Hazard (cascaded from inner)");
+        Assert.AreEqual(TransactionOutcome.Hazard, state.TransactionOutcomes[outerTxId].Outcome);
+
+        // CancelScopeChildren must have run — the outer sibling task is cancelled
+        var cancelledActivities = events.OfType<ActivityCancelled>()
+            .Select(e => e.ActivityInstanceId).ToList();
+        Assert.IsTrue(cancelledActivities.Contains(outerSiblingId),
+            "Outer sibling task must be cancelled by CancelScopeChildren");
+
+        // No compensation walk must be started for the outer TX (walk skipped)
+        Assert.IsFalse(events.OfType<CompensationWalkStarted>().Any(),
+            "No compensation walk must start for outer TX in Hazard cascade");
+
+        // No walk abort (inner TX had no active walk to abort)
+        Assert.IsFalse(events.OfType<CompensationWalkAborted>().Any(),
+            "No CompensationWalkAborted expected (inner TX had no active walk)");
+
+        // Effects list may be empty for plain tasks (no infrastructure cleanup needed);
+        // the cancellation is expressed via ActivityCancelled domain events above.
+    }
+
+    // Guard: if no descendant has Hazard, normal cancel flow still runs
+    [TestMethod]
+    public void NestedTx_OuterCancels_NoDescendantHazard_NormalCancelFlow()
+    {
+        var (execution, state) = CreateExecution();
+        var wfId = state.Id;
+        var outerTxId = Guid.NewGuid();
+        var cancelOuterId = Guid.NewGuid();
+
+        var outerTxEntry = new ActivityInstanceEntry(outerTxId, "outer-tx", wfId);
+        var cancelEntry = new ActivityInstanceEntry(cancelOuterId, "cancel-outer", wfId, scopeId: outerTxId);
+        state.AddEntries([outerTxEntry, cancelEntry]);
+        state.CompleteEntries([cancelEntry]);
+        execution.ClearUncommittedEvents();
+
+        execution.InitiateTransactionCancelFlowIfNeeded();
+
+        var events = execution.GetUncommittedEvents();
+
+        var outcomeSet = events.OfType<TransactionOutcomeSet>()
+            .FirstOrDefault(e => e.TransactionInstanceId == outerTxId);
+        Assert.IsNotNull(outcomeSet, "Outer TX outcome must be set");
+        Assert.AreEqual(TransactionOutcome.Cancelled, outcomeSet.Outcome,
+            "Without descendant Hazard, outcome is Cancelled");
+
+        // Walk starts
+        Assert.IsTrue(events.OfType<CompensationWalkStarted>().Any(),
+            "Normal cancel flow must start a compensation walk");
+    }
+
+    // Guard: idempotency — calling twice doesn't re-process a Hazard outer TX
+    [TestMethod]
+    public void NestedTx_OuterCancels_AfterInnerHazard_Idempotent()
+    {
+        var (execution, state) = CreateExecution();
+        var wfId = state.Id;
+        var outerTxId = Guid.NewGuid();
+        var innerTxId = Guid.NewGuid();
+        var cancelOuterId = Guid.NewGuid();
+
+        var outerTxEntry = new ActivityInstanceEntry(outerTxId, "outer-tx", wfId);
+        var cancelEntry = new ActivityInstanceEntry(cancelOuterId, "cancel-outer", wfId, scopeId: outerTxId);
+        var innerTxEntry = new ActivityInstanceEntry(innerTxId, "inner-tx", wfId, scopeId: outerTxId);
+        state.AddEntries([outerTxEntry, cancelEntry, innerTxEntry]);
+        state.CompleteEntries([cancelEntry, innerTxEntry]);
+
+        execution.SetTransactionOutcomeHazard(innerTxId, "500", "inner error");
+        execution.ClearUncommittedEvents();
+
+        // First call
+        execution.InitiateTransactionCancelFlowIfNeeded();
+        execution.ClearUncommittedEvents();
+
+        // Second call — idempotency check (Hazard already set on outer TX) must skip
+        execution.InitiateTransactionCancelFlowIfNeeded();
+        var events = execution.GetUncommittedEvents();
+
+        Assert.IsFalse(events.OfType<TransactionOutcomeSet>()
+            .Any(e => e.TransactionInstanceId == outerTxId),
+            "Second call must not re-emit outcome for already-Hazard outer TX");
+    }
+}

--- a/src/Fleans/Fleans.Domain/Aggregates/WorkflowExecution.cs
+++ b/src/Fleans/Fleans.Domain/Aggregates/WorkflowExecution.cs
@@ -223,9 +223,10 @@ public class WorkflowExecution
             var activity = scopeDef.GetActivity(txEntry.ActivityId);
             if (activity is not Activities.Transaction) continue;
 
-            // Idempotent: if already Cancelled, skip
+            // Idempotent: if already Cancelled or Hazard, skip
             if (_state.TransactionOutcomes.TryGetValue(txEntry.ActivityInstanceId, out var existing)
-                && existing.Outcome == TransactionOutcome.Cancelled) continue;
+                && (existing.Outcome == TransactionOutcome.Cancelled
+                    || existing.Outcome == TransactionOutcome.Hazard)) continue;
 
             // Look for a completed CancelEndEvent among this Transaction's scope entries
             var cancelEntry = _state.GetEntriesInScope(txEntry.ActivityInstanceId)
@@ -233,6 +234,17 @@ public class WorkflowExecution
                     && _definition.GetActivityAcrossScopes(e.ActivityId) is Activities.CancelEndEvent);
 
             if (cancelEntry is null) continue;
+
+            // Phase C: if any descendant TX ended in Hazard, propagate Hazard upward and skip the walk
+            var hazardDescendantId = FindDescendantHazardTx(txEntry.ActivityInstanceId);
+            if (hazardDescendantId.HasValue)
+            {
+                SetTransactionOutcomeHazard(txEntry.ActivityInstanceId, "503",
+                    $"Cancellation aborted: descendant transaction {hazardDescendantId.Value} ended in Hazard");
+                // CancelScopeChildren still runs so CompleteFinishedSubProcessScopes can fire
+                effects.AddRange(CancelScopeChildren(txEntry.ActivityInstanceId, "HazardCascade"));
+                continue; // skip compensation walk
+            }
 
             // 1. Mark outcome as Cancelled
             SetTransactionOutcomeCancelled(txEntry.ActivityInstanceId);
@@ -2611,6 +2623,17 @@ public class WorkflowExecution
         }
 
         return effects.AsReadOnly();
+    }
+
+    private Guid? FindDescendantHazardTx(Guid outerTxScopeId)
+    {
+        foreach (var (txId, outcome) in _state.TransactionOutcomes)
+        {
+            if (outcome.Outcome != TransactionOutcome.Hazard) continue;
+            if (IsDescendantOfScope(txId, outerTxScopeId))
+                return txId;
+        }
+        return null;
     }
 
     private IEnumerable<Guid> DescendantScopesWithActiveWalk(Guid rootScopeId)

--- a/tests/manual/26-transaction-subprocess/nested-tx-hazard.bpmn
+++ b/tests/manual/26-transaction-subprocess/nested-tx-hazard.bpmn
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+             xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+             xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+             id="Definitions_nested_tx_hazard"
+             targetNamespace="http://bpmn.io/schema/bpmn">
+
+  <!-- Scenario F test fixture: outer TX fires CancelEndEvent after inner TX ended in Hazard.
+       Expected: outer TX outcome is Hazard (not Cancelled), no compensation walk runs. -->
+  <process id="nested-tx-hazard" isExecutable="true">
+
+    <startEvent id="start" name="Start" />
+
+    <!-- Outer Transaction -->
+    <transaction id="outer-tx" name="Outer TX">
+
+      <!-- Inner Transaction — has no error boundary, so errors escape to Hazard -->
+      <transaction id="inner-tx" name="Inner TX">
+        <startEvent id="inner-start" />
+
+        <!-- Script that throws when shouldFail variable is set -->
+        <scriptTask id="inner-task" name="Inner Task (may fail)" scriptFormat="csharp">
+          <script>
+if (_context.shouldFail == true)
+    throw new Fleans.Domain.Errors.CustomTaskFailedActivityException("500", "Inner task failed — Hazard path");
+          </script>
+        </scriptTask>
+
+        <endEvent id="inner-end" />
+
+        <sequenceFlow id="isf1" sourceRef="inner-start" targetRef="inner-task" />
+        <sequenceFlow id="isf2" sourceRef="inner-task" targetRef="inner-end" />
+      </transaction>
+
+      <!-- After inner TX completes (normally), wait for cancel signal -->
+      <intermediateCatchEvent id="wait-for-cancel" name="Wait for Cancel">
+        <messageEventDefinition messageRef="triggerOuterCancel" />
+      </intermediateCatchEvent>
+
+      <cancelEndEvent id="cancel-end" name="Cancel End" />
+
+      <startEvent id="outer-start" />
+      <endEvent id="outer-end" />
+
+      <sequenceFlow id="osf1" sourceRef="outer-start" targetRef="inner-tx" />
+      <sequenceFlow id="osf2" sourceRef="inner-tx" targetRef="wait-for-cancel" />
+      <sequenceFlow id="osf3" sourceRef="wait-for-cancel" targetRef="cancel-end" />
+    </transaction>
+
+    <!-- Cancel boundary on outer TX — fires on normal TX cancellation -->
+    <boundaryEvent id="cancel-boundary" attachedToRef="outer-tx" cancelActivity="true">
+      <cancelEventDefinition />
+    </boundaryEvent>
+
+    <!-- Error boundary on outer TX — fires on Hazard (error code 503) -->
+    <boundaryEvent id="error-boundary" attachedToRef="outer-tx" cancelActivity="true">
+      <errorEventDefinition errorRef="hazardError" />
+    </boundaryEvent>
+
+    <endEvent id="cancel-path-end" name="Cancelled End" />
+    <endEvent id="hazard-path-end" name="Hazard End">
+      <errorEventDefinition />
+    </endEvent>
+    <endEvent id="process-end" name="Process End" />
+
+    <sequenceFlow id="sf1" sourceRef="start" targetRef="outer-tx" />
+    <sequenceFlow id="sf-cancel-boundary" sourceRef="cancel-boundary" targetRef="cancel-path-end" />
+    <sequenceFlow id="sf-error-boundary" sourceRef="error-boundary" targetRef="hazard-path-end" />
+    <sequenceFlow id="sf-normal" sourceRef="outer-tx" targetRef="process-end" />
+  </process>
+
+  <message id="triggerOuterCancel" name="trigger-outer-cancel" />
+  <error id="hazardError" name="HazardError" errorCode="503" />
+
+</definitions>

--- a/tests/manual/26-transaction-subprocess/test-plan-hazard.md
+++ b/tests/manual/26-transaction-subprocess/test-plan-hazard.md
@@ -1,0 +1,87 @@
+# 26 — Transaction Sub-Process: Hazard Path (Scenario F)
+
+Tests the Phase C behavior: when an outer Transaction fires a CancelEndEvent but a descendant Transaction already ended in Hazard, the outer TX outcome must be Hazard (not Cancelled) and no compensation walk must run for the outer TX.
+
+## Universal prerequisite
+
+Aspire stack running: `dotnet run --project src/Fleans/Fleans.Aspire` (from `src/Fleans/`).
+
+---
+
+## Test A — Scenario F: Outer cancel aborted by inner Hazard
+
+Uses `nested-tx-hazard.bpmn`.
+
+### Setup
+
+1. Deploy the workflow:
+   ```
+   POST /api/workflow/deploy  { "bpmnXml": "<contents of nested-tx-hazard.bpmn>" }
+   ```
+2. Start an instance:
+   ```
+   POST /api/workflow/start  { "workflowId": "nested-tx-hazard" }
+   ```
+   Note the `instanceId`.
+
+### Steps
+
+3. **Trigger the inner TX Hazard** — send a message named `trigger-inner-fail`:
+   ```
+   POST /api/workflow/message  { "messageName": "trigger-inner-fail", "correlationKey": "" }
+   ```
+   This causes the inner TX's script task to throw an error that is NOT caught by any boundary event on the inner TX (it escapes the inner TX scope → Hazard).
+
+4. **Trigger the outer TX cancel** — send a message named `trigger-outer-cancel`:
+   ```
+   POST /api/workflow/message  { "messageName": "trigger-outer-cancel", "correlationKey": "" }
+   ```
+   This fires the outer TX's CancelEndEvent.
+
+5. **Verify state**:
+   ```
+   GET /api/workflow/instances/{instanceId}/state
+   ```
+
+### Expected results
+
+- The workflow instance is **in error state** — the outer TX ended in Hazard and the outer Error/Hazard boundary event activated.
+- The error code on the workflow state is `503` (propagated from Phase C).
+- No compensation activities ran (no compensating service tasks in the state history).
+- The outer TX's Cancel boundary event did **not** fire.
+
+---
+
+## Test B — Baseline: Normal cancel (no inner Hazard)
+
+Uses `nested-tx-hazard.bpmn`, same workflow.
+
+### Steps
+
+1. Start a fresh instance (step 2 above).
+2. **Trigger the outer TX cancel directly** (skip triggering inner fail):
+   ```
+   POST /api/workflow/message  { "messageName": "trigger-outer-cancel", "correlationKey": "" }
+   ```
+3. **Verify state**: the workflow should route via the Cancel boundary event (NOT the Error boundary event), and the outer TX's compensation walk should run (compensating service tasks in state history).
+
+### Expected results
+
+- Workflow continues via the **Cancel Boundary Event** path (not the Error/Hazard boundary).
+- Compensation walk runs — compensating tasks are recorded in state history.
+- No error state on the workflow instance.
+
+---
+
+## BPMN fixture description (`nested-tx-hazard.bpmn`)
+
+The fixture contains:
+- **Outer TX** with:
+  - A CancelEndEvent (triggered by `trigger-outer-cancel` message catch event)
+  - A CancelBoundaryEvent (attached to outer TX)
+  - An ErrorBoundaryEvent (attached to outer TX, catches error code `503`)
+  - An inner TX (nested inside outer TX)
+- **Inner TX** with:
+  - A ScriptTask that throws when `trigger-inner-fail` message is received
+  - No boundary events catching the error → error escapes inner TX → inner TX ends in Hazard
+- Sequence flows routing Cancel boundary → end, Error boundary → error end


### PR DESCRIPTION
## Summary

- Add `FindDescendantHazardTx(Guid outerTxScopeId)` helper using `IsDescendantOfScope` from Phase B
- Extend idempotency check in `InitiateTransactionCancelFlowIfNeeded` to skip both `Cancelled` and `Hazard` outcomes
- Add Phase C Hazard pre-scan: if any descendant TX has `Hazard` outcome, propagate Hazard to the outer TX and skip the compensation walk (`CancelScopeChildren` still runs so `CompleteFinishedSubProcessScopes` can fire)
- Add `[LoggerMessage]` EventId 1104 for the Hazard cascade event
- 3 new domain tests (Scenario F + guard tests); 421/421 domain tests pass

## Key decisions

- `CancelScopeChildren` **must still run** in the Hazard path: without it, the outer TX's active scope children are orphaned and `CompleteFinishedSubProcessScopes` never fires (outer TX stuck indefinitely)
- `ActivateCancelBoundaryEvent` does **not** fire for Hazard: gated on `outcome?.Outcome == TransactionOutcome.Cancelled` at `WorkflowInstance.Infrastructure.cs:277`. The outer TX routes via `GetNextActivities` → Error/Hazard boundary instead
- `continue` (not `return`) in the per-TX `foreach` loop — correct generalization for multi-TX scenarios
- `FindDescendantHazardTx` returns the first Hazard descendant found; any single descendant Hazard is sufficient to cascade Hazard upward

## How to test

Manual test plan: `tests/manual/26-transaction-subprocess/test-plan-hazard.md` (Scenario F).

Quick test sequence:
1. Deploy a nested-TX workflow where inner TX has an Error Boundary Event that routes outside the TX scope (causing a Hazard)
2. Trigger the inner TX to fire the hazard path
3. Trigger the outer TX's CancelEndEvent
4. Verify: outer TX outcome is Hazard (not Cancelled), no compensation walk runs for outer TX, workflow routes via outer Error/Hazard boundary

Closes #490
