### PR TITLE
feat(editor): surface isExecutable + documentation on Process panel (#508)

### DIFF
--- a/src/Fleans/Fleans.Web/Components/Pages/ElementPropertiesPanel.razor
+++ b/src/Fleans/Fleans.Web/Components/Pages/ElementPropertiesPanel.razor
@@ -32,6 +32,25 @@
                 <FluentTextField Value="@name" @oninput="OnNameInput" @onchange="OnNameChange" Disabled="@ReadOnly" Style="width: 100%;" />
             </div>
 
+            @if (Element.Type == "bpmn:Process")
+            {
+                <div>
+                    <FluentCheckbox Value="@isExecutable"
+                                    @onchange="OnIsExecutableChange"
+                                    Disabled="@ReadOnly"
+                                    Label="Executable" />
+                </div>
+                <div>
+                    <FluentLabel Typo="Typography.Body" Weight="FontWeight.Bold">Documentation</FluentLabel>
+                    <FluentTextArea Value="@documentation"
+                                    @oninput="OnDocumentationInput"
+                                    @onchange="OnDocumentationChange"
+                                    Disabled="@ReadOnly"
+                                    Style="width: 100%;" Rows="3"
+                                    Placeholder="Optional process description…" />
+                </div>
+            }
+
             @if (Element.Type == "bpmn:ScriptTask")
             {
                 <div>
@@ -382,6 +401,8 @@
     private string inputDataItem = "";
     private string outputCollection = "";
     private string outputDataItem = "";
+    private bool isExecutable = true;
+    private string documentation = "";
 
     // --- Custom-task plugin editor state (sub-issue C of #357) ---
     private List<CustomTaskCatalogEntry> catalogEntries = new();
@@ -447,6 +468,8 @@
         inputDataItem = Element.InputDataItem;
         outputCollection = Element.OutputCollection;
         outputDataItem = Element.OutputDataItem;
+        isExecutable = Element.IsExecutable;
+        documentation = Element.Documentation;
 
         // Custom-task plugin section: load catalog + current task type/parameters
         // when the selected element is a service task and the element id changed
@@ -756,6 +779,19 @@
         await JS.InvokeVoidAsync("bpmnEditor.updateExpectedOutputs", Element.Id, tags);
     }
 
+    private async Task OnIsExecutableChange(ChangeEventArgs e)
+    {
+        isExecutable = e.Value is bool b ? b : bool.TryParse(e.Value?.ToString(), out var v) && v;
+        await JS.InvokeVoidAsync("bpmnEditor.setIsExecutable", Element.Id, isExecutable);
+    }
+
+    private void OnDocumentationInput(ChangeEventArgs e) => documentation = e.Value?.ToString() ?? "";
+    private async Task OnDocumentationChange(ChangeEventArgs e)
+    {
+        documentation = e.Value?.ToString() ?? "";
+        await JS.InvokeVoidAsync("bpmnEditor.setDocumentation", Element.Id, documentation);
+    }
+
     private async Task AddMapping(string type)
     {
         await JS.InvokeVoidAsync("bpmnEditor.addMapping", Element.Id, type);
@@ -958,6 +994,8 @@
         public string InputDataItem { get; set; } = "";
         public string OutputCollection { get; set; } = "";
         public string OutputDataItem { get; set; } = "";
+        public bool IsExecutable { get; set; } = true;
+        public string Documentation { get; set; } = "";
     }
 
     public class MappingData

--- a/src/Fleans/Fleans.Web/wwwroot/js/bpmnEditor.js
+++ b/src/Fleans/Fleans.Web/wwwroot/js/bpmnEditor.js
@@ -88,7 +88,9 @@ window.bpmnEditor = {
             inputCollection: '',
             inputDataItem: '',
             outputCollection: '',
-            outputDataItem: ''
+            outputDataItem: '',
+            isExecutable: false,
+            documentation: ''
         };
 
         if (bo.$type === 'bpmn:ScriptTask') {
@@ -228,6 +230,11 @@ window.bpmnEditor = {
             data.inputDataItem    = readNs('elementVariable',  'elementVariable');
             data.outputCollection = readNs('outputCollection', 'outputCollection');
             data.outputDataItem   = readNs('outputElement',    'outputElement');
+        }
+
+        if (bo.$type === 'bpmn:Process') {
+            data.isExecutable = bo.isExecutable !== false;
+            data.documentation = (bo.documentation && bo.documentation[0] && bo.documentation[0].text) || '';
         }
 
         // Collect available variable names from ScriptTasks (only when a UserTask is selected)
@@ -625,6 +632,31 @@ window.bpmnEditor = {
                 modeling.updateModdleProperties(element, mi, attrUpdate);
                 break;
             }
+        }
+    },
+
+    setIsExecutable: function (elementId, value) {
+        if (!this._modeler) return;
+        var elementRegistry = this._modeler.get('elementRegistry');
+        var modeling = this._modeler.get('modeling');
+        var element = elementRegistry.get(elementId);
+        if (!element) return;
+        modeling.updateProperties(element, { isExecutable: !!value });
+    },
+
+    setDocumentation: function (elementId, text) {
+        if (!this._modeler) return;
+        var elementRegistry = this._modeler.get('elementRegistry');
+        var modeling = this._modeler.get('modeling');
+        var element = elementRegistry.get(elementId);
+        if (!element) return;
+        var bo = element.businessObject;
+        var moddle = this._modeler.get('moddle');
+        if (text) {
+            var docEl = moddle.create('bpmn:Documentation', { text: text });
+            modeling.updateModdleProperties(element, bo, { documentation: [docEl] });
+        } else {
+            modeling.updateModdleProperties(element, bo, { documentation: [] });
         }
     },
 


### PR DESCRIPTION
## Summary

- Surface `isExecutable` (checkbox, default true) on the Process panel in the BPMN editor
- Surface `documentation` (3-row textarea) on the Process panel
- Both fields read from and write back to the underlying bpmn-js model so they are included in exported BPMN XML

Closes #508

## What was implemented

**`bpmnEditor.js`**
- `_extractElementData`: reads `bo.isExecutable` and `bo.documentation[0].text` when the selected element is `bpmn:Process`; both default to safe values (`true` / `""`) so non-Process elements are unaffected
- `setIsExecutable(elementId, value)`: writes via `modeling.updateProperties` (plain XML attribute)
- `setDocumentation(elementId, text)`: writes via `modeling.updateModdleProperties` + `moddle.create('bpmn:Documentation', { text })` (child element, not attribute); clears the array when text is empty

**`ElementPropertiesPanel.razor`**
- `BpmnElementData` gains `IsExecutable` (bool, default `true`) and `Documentation` (string)
- `OnParametersSet` syncs local fields from incoming data
- New `@if (Element.Type == "bpmn:Process")` block renders a `FluentCheckbox` (Executable) and a `FluentTextArea` (Documentation, 3 rows)
- `OnIsExecutableChange` and `OnDocumentationChange` call the JS setters on commit; `OnDocumentationInput` keeps the local field live while typing

## How to test

1. Start `dotnet run --project Fleans.Aspire` from `src/Fleans/`
2. Open `/editor`, click the canvas background (selects the Process root)
3. Verify the panel shows "Executable" checkbox (checked) and "Documentation" textarea
4. Uncheck Executable → re-export BPMN XML → confirm `isExecutable="false"` appears on `<bpmn:process>`
5. Type text in Documentation → re-export → confirm `<bpmn:documentation>…</bpmn:documentation>` child element present
6. Load an existing BPMN with `isExecutable="false"` and documentation → confirm panel pre-populates correctly
