### PR TITLE
feat(editor): surface condition expression on Conditional events (#509)

### DIFF
--- a/src/Fleans/Fleans.Web/Components/Pages/ElementPropertiesPanel.razor
+++ b/src/Fleans/Fleans.Web/Components/Pages/ElementPropertiesPanel.razor
@@ -222,6 +222,16 @@
                 </div>
             }
 
+            @if (HasConditional)
+            {
+                <div>
+                    <FluentLabel Typo="Typography.Body" Weight="FontWeight.Bold">Condition Expression</FluentLabel>
+                    <FluentTextArea Value="@conditionExpression" @oninput="OnConditionInput" @onchange="OnConditionalDefinitionChange"
+                                    Disabled="@ReadOnly" Rows="3" Resize="TextAreaResize.Vertical"
+                                    Placeholder="e.g. $context.amount > 100" Style="width: 100%;" />
+                </div>
+            }
+
             @if (Element.Type == "bpmn:UserTask")
             {
                 <div>
@@ -680,6 +690,7 @@
     private bool HasSignal => Element.HasSignalDefinition;
     private bool HasError => Element.HasErrorDefinition;
     private bool HasCancel => Element.HasCancelDefinition;
+    private bool HasConditional => Element.HasConditionalDefinition;
     private bool IsBoundaryEvent => Element.Type == "bpmn:BoundaryEvent";
 
     private static readonly Dictionary<string, string> TimerTypesAll = new()
@@ -767,6 +778,12 @@
     {
         errorCode = e.Value?.ToString() ?? "";
         await JS.InvokeVoidAsync("bpmnEditor.updateErrorDefinition", Element.Id, errorCode);
+    }
+
+    private async Task OnConditionalDefinitionChange(ChangeEventArgs e)
+    {
+        conditionExpression = e.Value?.ToString() ?? "";
+        await JS.InvokeVoidAsync("bpmnEditor.updateConditionalDefinition", Element.Id, conditionExpression);
     }
 
     private void OnAssigneeInput(ChangeEventArgs e) => assignee = e.Value?.ToString() ?? "";
@@ -964,6 +981,16 @@
                 _ => Element.Type.Replace("bpmn:", "")
             };
         }
+        if (HasConditional)
+        {
+            return Element.Type switch
+            {
+                "bpmn:StartEvent" => "Conditional Start Event",
+                "bpmn:IntermediateCatchEvent" => "Conditional Intermediate Catch Event",
+                "bpmn:BoundaryEvent" => "Conditional Boundary Event",
+                _ => Element.Type.Replace("bpmn:", "")
+            };
+        }
         return Element.Type switch
         {
             "bpmn:StartEvent" => "Start Event",
@@ -1009,6 +1036,7 @@
         public bool HasErrorDefinition { get; set; }
         public string ErrorCode { get; set; } = "";
         public bool HasCancelDefinition { get; set; }
+        public bool HasConditionalDefinition { get; set; }
         public bool IsInterrupting { get; set; } = true;
         public bool IsEventSubProcess { get; set; }
         public string Assignee { get; set; } = "";

--- a/src/Fleans/Fleans.Web/wwwroot/js/bpmnEditor.js
+++ b/src/Fleans/Fleans.Web/wwwroot/js/bpmnEditor.js
@@ -92,7 +92,8 @@ window.bpmnEditor = {
             outputDataItem: '',
             isExecutable: false,
             documentation: '',
-            isEventSubProcess: false
+            isEventSubProcess: false,
+            hasConditionalDefinition: false
         };
 
         if (bo.$type === 'bpmn:ScriptTask') {
@@ -202,6 +203,12 @@ window.bpmnEditor = {
                 }
                 if (bo.eventDefinitions[i].$type === 'bpmn:CancelEventDefinition') {
                     data.hasCancelDefinition = true;
+                    break;
+                }
+                if (bo.eventDefinitions[i].$type === 'bpmn:ConditionalEventDefinition') {
+                    data.hasConditionalDefinition = true;
+                    var condDef = bo.eventDefinitions[i];
+                    data.conditionExpression = (condDef.condition && condDef.condition.body) || '';
                     break;
                 }
             }
@@ -406,6 +413,31 @@ window.bpmnEditor = {
         }
 
         modeling.updateModdleProperties(element, timerDef, newProps);
+    },
+
+    updateConditionalDefinition: function (elementId, expression) {
+        if (!this._modeler) return;
+        var elementRegistry = this._modeler.get('elementRegistry');
+        var modeling = this._modeler.get('modeling');
+        var moddle = this._modeler.get('moddle');
+        var element = elementRegistry.get(elementId);
+        if (!element) return;
+        var bo = element.businessObject;
+        if (!bo.eventDefinitions || bo.eventDefinitions.length === 0) return;
+        var condDef = null;
+        for (var i = 0; i < bo.eventDefinitions.length; i++) {
+            if (bo.eventDefinitions[i].$type === 'bpmn:ConditionalEventDefinition') {
+                condDef = bo.eventDefinitions[i]; break;
+            }
+        }
+        if (!condDef) return;
+        if (expression && expression.trim() !== '') {
+            var formalExpr = moddle.create('bpmn:FormalExpression', { body: expression });
+            formalExpr.$parent = condDef;
+            modeling.updateModdleProperties(element, condDef, { condition: formalExpr });
+        } else {
+            modeling.updateModdleProperties(element, condDef, { condition: undefined });
+        }
     },
 
     updateMessageDefinition: function (elementId, messageName, correlationKey) {


### PR DESCRIPTION
## Summary

- Surface the condition expression for `bpmn:ConditionalEventDefinition` in the BPMN editor Properties Panel
- Affects: Conditional Start Event, Conditional Intermediate Catch Event, Conditional Boundary Event
- Previously the condition was invisible and stuck at its XML value with no way to edit it

Closes #509

## What was implemented

**`bpmnEditor.js`**
- `_extractElementData`: detects `bpmn:ConditionalEventDefinition` in the `eventDefinitions` loop, sets `hasConditionalDefinition=true` and reads `condDef.condition.body` into the shared `conditionExpression` field. SequenceFlow and ConditionalEvent are mutually exclusive element types, so sharing the field is safe.
- `updateConditionalDefinition(elementId, expression)`: writes via `moddle.create('bpmn:FormalExpression', { body })` + `modeling.updateModdleProperties(element, condDef, { condition })`. Mirrors `updateTimerDefinition` exactly (child element write path, not attribute).

**`ElementPropertiesPanel.razor`**
- `BpmnElementData` gains `HasConditionalDefinition` (bool)
- `HasConditional` computed property added alongside `HasTimer`/`HasMessage`/`HasSignal`/`HasError`
- `@if (HasConditional)` section renders a `FluentTextArea` (3 rows, resizable) placed after the Error section; shares `conditionExpression` local field and `OnConditionInput` (input handler); separate `OnConditionalDefinitionChange` (change handler) calls `updateConditionalDefinition`
- `GetTypeLabel()` adds "Conditional Start Event", "Conditional Intermediate Catch Event", "Conditional Boundary Event" labels

## Key decisions

- **Reuse `conditionExpression` field**: SequenceFlow's `conditionExpression` attribute and ConditionalEvent's `condition` child are both exposed via the same `conditionExpression` backing field. They are mutually exclusive, so no collision is possible.
- **`condition` property name**: BPMN 2.0 spec / bpmn-js moddle uses `condition` (type `bpmn:FormalExpression`) on `ConditionalEventDefinition`, not `conditionExpression` (that's SequenceFlow only).

## How to test

1. Start `dotnet run --project Fleans.Aspire` from `src/Fleans/`
2. Open `/editor`, draw a Conditional Intermediate Catch Event (or load a BPMN with one)
3. Click the Conditional event — panel header should read "Conditional Intermediate Catch Event"
4. Verify a "Condition Expression" textarea appears
5. Type an expression, export XML — confirm `<bpmn:condition>…</bpmn:condition>` child appears inside the `<bpmn:conditionalEventDefinition>` element
6. Repeat for Conditional Start Event and Conditional Boundary Event
