### PR TITLE
feat: escalation event code editor panel

### DIFF
--- a/src/Fleans/Fleans.Web/Components/Pages/ElementPropertiesPanel.razor
+++ b/src/Fleans/Fleans.Web/Components/Pages/ElementPropertiesPanel.razor
@@ -232,6 +232,18 @@
                 </div>
             }
 
+            @if (HasEscalation)
+            {
+                <div>
+                    <FluentLabel Typo="Typography.Body" Weight="FontWeight.Bold">Escalation Code</FluentLabel>
+                    <FluentTextField Value="@escalationCode" @oninput="OnEscalationCodeInput" @onchange="OnEscalationCodeChange"
+                                     Disabled="@ReadOnly" Placeholder="e.g. ESC-001 (leave empty for catch-all)" Style="width: 100%;" />
+                    <FluentLabel Style="color: var(--neutral-foreground-hint); margin-top: 4px; font-size: 12px;">
+                        Specific escalation code to catch. Leave empty to catch all escalations.
+                    </FluentLabel>
+                </div>
+            }
+
             @if (Element.Type == "bpmn:UserTask")
             {
                 <div>
@@ -462,6 +474,7 @@
     private string correlationKey = "";
     private string signalName = "";
     private string errorCode = "";
+    private string escalationCode = "";
     private bool isInterrupting = true;
     private bool isEventSubProcess;
     private string assignee = "";
@@ -531,6 +544,7 @@
         correlationKey = Element.CorrelationKey;
         signalName = Element.SignalName;
         errorCode = Element.ErrorCode;
+        escalationCode = Element.EscalationCode;
         isInterrupting = Element.IsInterrupting;
         isEventSubProcess = Element.IsEventSubProcess;
         assignee = Element.Assignee;
@@ -748,6 +762,7 @@
     private bool HasError => Element.HasErrorDefinition;
     private bool HasCancel => Element.HasCancelDefinition;
     private bool HasConditional => Element.HasConditionalDefinition;
+    private bool HasEscalation => Element.HasEscalationDefinition;
     private bool IsBoundaryEvent => Element.Type == "bpmn:BoundaryEvent";
 
     private static readonly Dictionary<string, string> TimerTypesAll = new()
@@ -841,6 +856,13 @@
     {
         conditionExpression = e.Value?.ToString() ?? "";
         await JS.InvokeVoidAsync("bpmnEditor.updateConditionalDefinition", Element.Id, conditionExpression);
+    }
+
+    private void OnEscalationCodeInput(ChangeEventArgs e) => escalationCode = e.Value?.ToString() ?? "";
+    private async Task OnEscalationCodeChange(ChangeEventArgs e)
+    {
+        escalationCode = e.Value?.ToString() ?? "";
+        await JS.InvokeVoidAsync("bpmnEditor.updateEscalationDefinition", Element.Id, escalationCode);
     }
 
     private void OnAssigneeInput(ChangeEventArgs e) => assignee = e.Value?.ToString() ?? "";
@@ -1056,6 +1078,18 @@
                 _ => Element.Type.Replace("bpmn:", "")
             };
         }
+        if (HasEscalation)
+        {
+            return Element.Type switch
+            {
+                "bpmn:StartEvent" => "Escalation Start Event",
+                "bpmn:EndEvent" => "Escalation End Event",
+                "bpmn:BoundaryEvent" => "Escalation Boundary Event",
+                "bpmn:IntermediateThrowEvent" => "Escalation Intermediate Throw Event",
+                "bpmn:IntermediateCatchEvent" => "Escalation Intermediate Catch Event",
+                _ => Element.Type.Replace("bpmn:", "")
+            };
+        }
         return Element.Type switch
         {
             "bpmn:StartEvent" => "Start Event",
@@ -1102,6 +1136,8 @@
         public string ErrorCode { get; set; } = "";
         public bool HasCancelDefinition { get; set; }
         public bool HasConditionalDefinition { get; set; }
+        public bool HasEscalationDefinition { get; set; }
+        public string EscalationCode { get; set; } = "";
         public bool IsInterrupting { get; set; } = true;
         public bool IsEventSubProcess { get; set; }
         public string Assignee { get; set; } = "";

--- a/src/Fleans/Fleans.Web/wwwroot/js/bpmnEditor.js
+++ b/src/Fleans/Fleans.Web/wwwroot/js/bpmnEditor.js
@@ -112,7 +112,9 @@ window.bpmnEditor = {
             documentation: '',
             isEventSubProcess: false,
             hasConditionalDefinition: false,
-            completionCondition: ''
+            completionCondition: '',
+            hasEscalationDefinition: false,
+            escalationCode: ''
         };
 
         if (bo.$type === 'bpmn:ScriptTask') {
@@ -233,6 +235,14 @@ window.bpmnEditor = {
                     data.hasConditionalDefinition = true;
                     var condDef = bo.eventDefinitions[i];
                     data.conditionExpression = (condDef.condition && condDef.condition.body) || '';
+                    break;
+                }
+                if (bo.eventDefinitions[i].$type === 'bpmn:EscalationEventDefinition') {
+                    data.hasEscalationDefinition = true;
+                    var escDef = bo.eventDefinitions[i];
+                    if (escDef.escalationRef) {
+                        data.escalationCode = escDef.escalationRef.escalationCode || '';
+                    }
                     break;
                 }
             }
@@ -625,6 +635,51 @@ window.bpmnEditor = {
             modeling.updateModdleProperties(element, errDef, { errorRef: errorEl });
         } else {
             modeling.updateModdleProperties(element, errDef, { errorRef: undefined });
+        }
+    },
+
+    updateEscalationDefinition: function (elementId, escalationCode) {
+        if (!this._modeler) return;
+        var elementRegistry = this._modeler.get('elementRegistry');
+        var modeling = this._modeler.get('modeling');
+        var moddle = this._modeler.get('moddle');
+        var element = elementRegistry.get(elementId);
+        if (!element) return;
+
+        var bo = element.businessObject;
+        if (!bo.eventDefinitions || bo.eventDefinitions.length === 0) return;
+
+        var escDef = null;
+        for (var i = 0; i < bo.eventDefinitions.length; i++) {
+            if (bo.eventDefinitions[i].$type === 'bpmn:EscalationEventDefinition') {
+                escDef = bo.eventDefinitions[i];
+                break;
+            }
+        }
+        if (!escDef) return;
+
+        var canvas = this._modeler.get('canvas');
+        var definitions = canvas.getRootElement().businessObject.$parent;
+
+        if (escalationCode) {
+            var escEl = escDef.escalationRef;
+
+            if (!escEl) {
+                var escId = 'Escalation_' + elementId;
+                escEl = moddle.create('bpmn:Escalation', { id: escId, escalationCode: escalationCode });
+                escEl.$parent = definitions;
+
+                var rootElements = definitions.get('rootElements');
+                rootElements.push(escEl);
+
+                moddle.ids.claim(escId, escEl);
+            } else {
+                escEl.escalationCode = escalationCode;
+            }
+
+            modeling.updateModdleProperties(element, escDef, { escalationRef: escEl });
+        } else {
+            modeling.updateModdleProperties(element, escDef, { escalationRef: undefined });
         }
     },
 


### PR DESCRIPTION
Closes #510

## Summary
- Added `hasEscalationDefinition` / `escalationCode` fields to the `bpmnEditor.js` element data extraction, with `EscalationEventDefinition` detection in the event-definitions loop
- Added `updateEscalationDefinition(elementId, escalationCode)` JS function (mirrors `updateErrorDefinition`) that creates/updates a `bpmn:Escalation` root element and links it via `escalationRef`
- Added `HasEscalationDefinition` / `EscalationCode` to `BpmnElementData`, private `escalationCode` field, `HasEscalation` computed property, and `@if (HasEscalation)` panel section in `ElementPropertiesPanel.razor`
- Added escalation-specific type labels in `GetTypeLabel()` (Start/End/Boundary/Throw/Catch variants)

## How to test
1. Open the BPMN editor and place an Escalation Boundary Event or Escalation End Event
2. Select it — the properties panel should show an "Escalation Code" text field
3. Enter a code (e.g. `ESC-001`) and blur — the BPMN XML should contain a `bpmn:Escalation` root element with `escalationCode="ESC-001"` linked to the event definition
4. Clear the field — `escalationRef` should be removed from the definition