### PR TITLE
feat: default outgoing-flow dropdown for gateway types

### DIFF
--- a/src/Fleans/Fleans.Web/Components/Pages/ElementPropertiesPanel.razor
+++ b/src/Fleans/Fleans.Web/Components/Pages/ElementPropertiesPanel.razor
@@ -157,6 +157,26 @@
                 </div>
             }
 
+            @if (HasDefaultFlowSelector)
+            {
+                <div>
+                    <FluentLabel Typo="Typography.Body" Weight="FontWeight.Bold">Default Flow</FluentLabel>
+                    <FluentSelect TOption="string" Value="@defaultFlow" @onchange="OnDefaultFlowChange"
+                                  Disabled="@ReadOnly" Style="width: 100%;">
+                        <FluentOption TOption="string" Value="">(none)</FluentOption>
+                        @foreach (var flow in Element.OutgoingFlows)
+                        {
+                            <FluentOption TOption="string" Value="@flow.Id" Selected="@(flow.Id == defaultFlow)">
+                                @(string.IsNullOrEmpty(flow.Name) ? flow.Id : flow.Name)
+                            </FluentOption>
+                        }
+                    </FluentSelect>
+                    <FluentLabel Style="color: var(--neutral-foreground-hint); margin-top: 4px; font-size: 12px;">
+                        Outgoing flow taken when no condition matches.
+                    </FluentLabel>
+                </div>
+            }
+
             @if (IsBoundaryEvent)
             {
                 <div>
@@ -490,6 +510,7 @@
     private string errorCode = "";
     private string escalationCode = "";
     private string activationCondition = "";
+    private string defaultFlow = "";
     private bool isInterrupting = true;
     private bool isEventSubProcess;
     private string assignee = "";
@@ -561,6 +582,7 @@
         errorCode = Element.ErrorCode;
         escalationCode = Element.EscalationCode;
         activationCondition = Element.ActivationCondition;
+        defaultFlow = Element.DefaultFlow;
         isInterrupting = Element.IsInterrupting;
         isEventSubProcess = Element.IsEventSubProcess;
         assignee = Element.Assignee;
@@ -780,6 +802,8 @@
     private bool HasConditional => Element.HasConditionalDefinition;
     private bool HasEscalation => Element.HasEscalationDefinition;
     private bool HasActivationCondition => Element.Type == "bpmn:ComplexGateway";
+    private bool HasDefaultFlowSelector =>
+        Element.Type is "bpmn:ExclusiveGateway" or "bpmn:InclusiveGateway" or "bpmn:ComplexGateway";
     private bool IsBoundaryEvent => Element.Type == "bpmn:BoundaryEvent";
 
     private static readonly Dictionary<string, string> TimerTypesAll = new()
@@ -887,6 +911,12 @@
     {
         activationCondition = e.Value?.ToString() ?? "";
         await JS.InvokeVoidAsync("bpmnEditor.updateActivationCondition", Element.Id, activationCondition);
+    }
+
+    private async Task OnDefaultFlowChange(ChangeEventArgs e)
+    {
+        defaultFlow = e.Value?.ToString() ?? "";
+        await JS.InvokeVoidAsync("bpmnEditor.updateDefaultFlow", Element.Id, defaultFlow);
     }
 
     private void OnAssigneeInput(ChangeEventArgs e) => assignee = e.Value?.ToString() ?? "";
@@ -1180,6 +1210,14 @@
         public string Documentation { get; set; } = "";
         public string CompletionCondition { get; set; } = "";
         public string ActivationCondition { get; set; } = "";
+        public string DefaultFlow { get; set; } = "";
+        public List<FlowReferenceOption> OutgoingFlows { get; set; } = [];
+    }
+
+    public class FlowReferenceOption
+    {
+        public string Id { get; set; } = "";
+        public string Name { get; set; } = "";
     }
 
     public class MappingData

--- a/src/Fleans/Fleans.Web/wwwroot/js/bpmnEditor.js
+++ b/src/Fleans/Fleans.Web/wwwroot/js/bpmnEditor.js
@@ -115,7 +115,9 @@ window.bpmnEditor = {
             completionCondition: '',
             hasEscalationDefinition: false,
             escalationCode: '',
-            activationCondition: ''
+            activationCondition: '',
+            defaultFlow: '',
+            outgoingFlows: []
         };
 
         if (bo.$type === 'bpmn:ScriptTask') {
@@ -311,6 +313,17 @@ window.bpmnEditor = {
 
         if (bo.$type === 'bpmn:ComplexGateway' && bo.activationCondition) {
             data.activationCondition = bo.activationCondition.body || '';
+        }
+
+        if (bo.$type === 'bpmn:ExclusiveGateway' ||
+            bo.$type === 'bpmn:InclusiveGateway' ||
+            bo.$type === 'bpmn:ComplexGateway') {
+            data.defaultFlow = bo.default ? bo.default.id : '';
+            if (bo.outgoing) {
+                bo.outgoing.forEach(function (flow) {
+                    data.outgoingFlows.push({ id: flow.id, name: flow.name || '' });
+                });
+            }
         }
 
         return data;
@@ -702,6 +715,20 @@ window.bpmnEditor = {
             modeling.updateProperties(element, { activationCondition: expr });
         } else {
             modeling.updateProperties(element, { activationCondition: undefined });
+        }
+    },
+
+    updateDefaultFlow: function (elementId, flowId) {
+        if (!this._modeler) return;
+        var elementRegistry = this._modeler.get('elementRegistry');
+        var modeling = this._modeler.get('modeling');
+        var element = elementRegistry.get(elementId);
+        if (!element) return;
+        if (flowId) {
+            var flowEl = elementRegistry.get(flowId);
+            modeling.updateProperties(element, { default: flowEl ? flowEl.businessObject : undefined });
+        } else {
+            modeling.updateProperties(element, { default: undefined });
         }
     },
 

--- a/tests/manual/50-gateway-default-flow/test-plan.md
+++ b/tests/manual/50-gateway-default-flow/test-plan.md
@@ -1,0 +1,49 @@
+# Test Plan — #512: Gateway Default Flow Editor
+
+## Prerequisite
+
+Aspire stack running: `dotnet run --project Fleans.Aspire` (from `src/Fleans/`).
+Navigate to `http://localhost:5104/editor`.
+
+## Fixtures
+
+Reuse existing fixtures (no new BPMN required):
+- `tests/manual/03-exclusive-gateway/conditional-branching.bpmn` — has `<bpmn:exclusiveGateway id="gateway" default="defaultFlow">`
+- `tests/manual/14-inclusive-gateway/default-flow.bpmn` — has an inclusive gateway with a default flow
+
+## Steps
+
+### 1. Import exclusive-gateway fixture
+
+- [ ] Import `03-exclusive-gateway/conditional-branching.bpmn`.
+- [ ] Click the exclusive gateway element.
+- [ ] **Verify**: panel shows "Default Flow" dropdown.
+- [ ] **Verify**: dropdown pre-selects the flow whose ID matches `default="defaultFlow"` in the XML (shows the flow ID or its name label).
+
+### 2. Change the default flow
+
+- [ ] With the gateway selected, change the "Default Flow" dropdown to a different outgoing sequence flow.
+- [ ] **Verify**: the XML `default=` attribute on the gateway updates to the selected flow's ID.
+
+### 3. Clear the default flow
+
+- [ ] Change the dropdown to "(none)".
+- [ ] **Verify**: the `default` attribute is removed from the gateway element in the XML.
+
+### 4. Sequence flow panel is unaffected
+
+- [ ] Click one of the outgoing sequence flows.
+- [ ] **Verify**: sequence flow panel shows ID, Name, Condition Expression — no "Default Flow" field appears on the flow itself.
+
+### 5. Inclusive gateway fixture
+
+- [ ] Import `14-inclusive-gateway/default-flow.bpmn`.
+- [ ] Click the inclusive gateway.
+- [ ] **Verify**: "Default Flow" dropdown appears and pre-populates correctly.
+- [ ] Change and clear as in steps 2–3 — same behavior expected.
+
+### 6. Parallel gateway has no Default Flow field
+
+- [ ] Place a `bpmn:ParallelGateway` on the canvas.
+- [ ] Click it.
+- [ ] **Verify**: no "Default Flow" dropdown appears (parallel gateways do not support the `default` attribute).

--- a/tests/manual/README.md
+++ b/tests/manual/README.md
@@ -72,6 +72,7 @@ Each numbered entry below is one regression "step". For each one, follow the lin
 47. **Event Sub-Process editor toggle** — `47-event-subprocess-editor/test-plan.md`. Editor panel for `bpmn:SubProcess` shows "Triggered by event (Event Sub-Process)" checkbox; checking it sets `triggeredByEvent="true"` and redraws the element with a dashed border; unchecking reverts; panel header label updates to "Event Sub-Process" / "Sub-Process" accordingly.
 48. **IO Mapping editor** — `48-io-mapping-editor/test-plan.md`. CallActivity shows Input/Output Mappings from imported BPMNs (including `zeebe:ioMapping` nested format); ServiceTask with unregistered plugin type shows raw IO mapping table with existing entries visible; adding/removing rows works correctly.
 49. **Complex Gateway Activation Condition Editor** — `49-complex-gateway-activation-condition/test-plan.md`. Activation Condition text area on ComplexGateway; reuses `20-complex-gateway/join-activation-condition.bpmn`. Verifies pre-population, editing, clearing, and that other gateway types have no field.
+50. **Gateway Default Flow Editor** — `50-gateway-default-flow/test-plan.md`. Default outgoing-flow dropdown on ExclusiveGateway / InclusiveGateway / ComplexGateway; reuses `03-exclusive-gateway/conditional-branching.bpmn` and `14-inclusive-gateway/default-flow.bpmn`. Verifies pre-population from XML, editing, clearing, and that ParallelGateway has no field.
 
 ## Website regression suite
 


### PR DESCRIPTION
Closes #512

## Summary
- Added `defaultFlow` and `outgoingFlows` fields to `bpmnEditor.js` data extraction; extraction block reads `bo.default.id` and walks `bo.outgoing` for `ExclusiveGateway`, `InclusiveGateway`, and `ComplexGateway`
- Added `updateDefaultFlow(elementId, flowId)` JS function using `modeling.updateProperties` (direct gateway attribute, not a nested element) — sets `default` to the target flow's businessObject or clears to `undefined`
- Added `DefaultFlow` + `OutgoingFlows` to `BpmnElementData`; new standalone `FlowReferenceOption` class
- Added `HasDefaultFlowSelector` computed property and `@if (HasDefaultFlowSelector)` panel section with a `FluentSelect` dropdown populated from outgoing flows; "(none)" sentinel clears the attribute
- Added `OnDefaultFlowChange` handler
- Added `tests/manual/48-gateway-default-flow/test-plan.md` (reuses existing fixtures); updated `tests/manual/README.md` entry #48

## How to test
See `tests/manual/48-gateway-default-flow/test-plan.md` — import `03-exclusive-gateway/conditional-branching.bpmn` and verify the Default Flow dropdown pre-populates, edits, and clears correctly.
