### PR TITLE
fix(#520): clarify propagate-variables checkbox labels on CallActivity panel

### DIFF
--- a/src/Fleans/Fleans.Web/Components/Pages/ElementPropertiesPanel.razor
+++ b/src/Fleans/Fleans.Web/Components/Pages/ElementPropertiesPanel.razor
@@ -57,12 +57,12 @@
 
                 <div>
                     <FluentCheckbox Value="@propagateAllParentVariables" @onchange="OnPropagateParentChange"
-                                    Disabled="@ReadOnly" Label="Propagate all parent variables" />
+                                    Disabled="@ReadOnly" Label="Propagate all parent variables to child process" />
                 </div>
 
                 <div>
                     <FluentCheckbox Value="@propagateAllChildVariables" @onchange="OnPropagateChildChange"
-                                    Disabled="@ReadOnly" Label="Propagate all child variables" />
+                                    Disabled="@ReadOnly" Label="Propagate all child variables back to parent" />
                 </div>
 
                 <div>


### PR DESCRIPTION
## Summary

Closes #520

Clarifies the label text on the two propagate-variables checkboxes in the CallActivity properties panel.

**Before:**
- "Propagate all parent variables"
- "Propagate all child variables"

**After:**
- "Propagate all parent variables to child process"
- "Propagate all child variables back to parent"

The direction ("to child process" / "back to parent") makes the semantics immediately clear without needing to know the BPMN CallActivity data-flow model.

## Root cause

The DOM-walk audit flagged these as "unlabeled" because it cannot see into Fluent UI Blazor's shadow DOM (where `Label=` text is rendered). The labels were always present and wired correctly; only the text needed improvement.

## Changes

**`ElementPropertiesPanel.razor`** — two `Label=` string literals updated (lines 60, 65).

No changes to `bpmnEditor.js`, `BpmnElementData`, or any tests — property read/write logic was already correct.

## How to test

1. `dotnet run --project Fleans.Aspire`
2. Import `tests/manual/06-call-activity/parent-process.bpmn`
3. Click `callChild` — verify the two checkboxes between "Called Process Key" and "Input Mappings" display "Propagate all parent variables to child process" and "Propagate all child variables back to parent"
