### PR TITLE
feat(#518): completionCondition field in Multi-Instance editor panel

### DIFF
--- a/src/Fleans/Fleans.Web/Components/Pages/ElementPropertiesPanel.razor
+++ b/src/Fleans/Fleans.Web/Components/Pages/ElementPropertiesPanel.razor
@@ -376,6 +376,12 @@
                                          Disabled="@ReadOnly" Placeholder="e.g. result" Style="width: 100%;" />
                     </div>
 
+                    <div>
+                        <FluentLabel Typo="Typography.Body" Weight="FontWeight.Bold">Completion Condition</FluentLabel>
+                        <FluentTextField Value="@completionCondition" @oninput="OnCompletionConditionInput" @onchange="OnCompletionConditionChange"
+                                         Disabled="@ReadOnly" Placeholder="e.g. _context.nrOfCompletedInstances >= 1" Style="width: 100%;" />
+                    </div>
+
                     @if (string.IsNullOrWhiteSpace(loopCardinality) && string.IsNullOrWhiteSpace(inputCollection))
                     {
                         <FluentLabel Style="color: var(--warning); margin-top: 4px; font-size: 12px;">
@@ -422,6 +428,7 @@
     private string outputDataItem = "";
     private bool isExecutable = true;
     private string documentation = "";
+    private string completionCondition = "";
 
     // --- Custom-task plugin editor state (sub-issue C of #357) ---
     private List<CustomTaskCatalogEntry> catalogEntries = new();
@@ -490,6 +497,7 @@
         outputDataItem = Element.OutputDataItem;
         isExecutable = Element.IsExecutable;
         documentation = Element.Documentation;
+        completionCondition = Element.CompletionCondition;
 
         // Custom-task plugin section: load catalog + current task type/parameters
         // when the selected element is a service task and the element id changed
@@ -882,6 +890,7 @@
             inputDataItem = "";
             outputCollection = "";
             outputDataItem = "";
+            completionCondition = "";
             await JS.InvokeVoidAsync("bpmnEditor.enableMultiInstance", Element.Id);
         }
         else
@@ -929,6 +938,13 @@
     {
         outputDataItem = e.Value?.ToString() ?? "";
         await JS.InvokeVoidAsync("bpmnEditor.updateMultiInstanceProperty", Element.Id, "outputDataItem", outputDataItem);
+    }
+
+    private void OnCompletionConditionInput(ChangeEventArgs e) => completionCondition = e.Value?.ToString() ?? "";
+    private async Task OnCompletionConditionChange(ChangeEventArgs e)
+    {
+        completionCondition = e.Value?.ToString() ?? "";
+        await JS.InvokeVoidAsync("bpmnEditor.updateMultiInstanceProperty", Element.Id, "completionCondition", completionCondition);
     }
 
     private string GetTypeLabel()
@@ -1053,6 +1069,7 @@
         public string OutputDataItem { get; set; } = "";
         public bool IsExecutable { get; set; } = true;
         public string Documentation { get; set; } = "";
+        public string CompletionCondition { get; set; } = "";
     }
 
     public class MappingData

--- a/src/Fleans/Fleans.Web/wwwroot/js/bpmnEditor.js
+++ b/src/Fleans/Fleans.Web/wwwroot/js/bpmnEditor.js
@@ -93,7 +93,8 @@ window.bpmnEditor = {
             isExecutable: false,
             documentation: '',
             isEventSubProcess: false,
-            hasConditionalDefinition: false
+            hasConditionalDefinition: false,
+            completionCondition: ''
         };
 
         if (bo.$type === 'bpmn:ScriptTask') {
@@ -247,6 +248,10 @@ window.bpmnEditor = {
             data.inputDataItem    = readNs('elementVariable',  'elementVariable');
             data.outputCollection = readNs('outputCollection', 'outputCollection');
             data.outputDataItem   = readNs('outputElement',    'outputElement');
+
+            if (miElement.completionCondition && miElement.completionCondition.body) {
+                data.completionCondition = miElement.completionCondition.body;
+            }
         }
 
         if (bo.$type === 'bpmn:Process') {
@@ -653,6 +658,17 @@ window.bpmnEditor = {
                     modeling.updateModdleProperties(element, mi, { loopCardinality: undefined });
                 }
                 break;
+
+            case 'completionCondition': {
+                if (value && value.trim() !== '') {
+                    var ccExpr = moddle.create('bpmn:FormalExpression', { body: value });
+                    ccExpr.$parent = mi;
+                    modeling.updateModdleProperties(element, mi, { completionCondition: ccExpr });
+                } else {
+                    modeling.updateModdleProperties(element, mi, { completionCondition: undefined });
+                }
+                break;
+            }
 
             case 'inputCollection':
             case 'inputDataItem':

--- a/tests/manual/13-multi-instance/test-plan.md
+++ b/tests/manual/13-multi-instance/test-plan.md
@@ -98,3 +98,30 @@ Deploy `completion-condition-1-of-N.bpmn`:
 - [ ] Only 1 approval appears in the output — the remaining 2 iterations are cancelled before they start or are cancelled mid-flight
 - [ ] Workflow proceeds to the end event
 - [ ] `_context.nrOfCompletedInstances` referenced in the condition resolves to `1` when the condition fires
+
+---
+
+## Scenario 13f: Editor displays completionCondition field
+
+Tests that the BPMN editor property panel shows the Completion Condition field and round-trips the value correctly.
+
+### Prerequisites
+
+Aspire stack running: `dotnet run --project Fleans.Aspire` from `src/Fleans/`
+
+### Steps
+
+1. Open `http://localhost:5104/editor`
+2. Import `completion-condition-1-of-N.bpmn`
+3. Click the ScriptTask node (`processApproval`)
+4. Verify the Multi-Instance section shows a **Completion Condition** field containing `_context.nrOfCompletedInstances >= 1`
+5. Clear the field and type `_context.nrOfCompletedInstances >= 2`, then click elsewhere to commit
+6. Export the BPMN (Download button)
+7. Open the downloaded XML and verify `<completionCondition>_context.nrOfCompletedInstances &gt;= 2</completionCondition>` is present
+
+### Expected
+
+- [ ] "Completion Condition" field is visible in the Multi-Instance section
+- [ ] Field initially shows `_context.nrOfCompletedInstances >= 1`
+- [ ] After editing, the exported BPMN contains the new value
+- [ ] No "Correlation Key" field appears (not applicable to multi-instance activities)

--- a/website/src/content/docs/guides/multi-instance-activities.md
+++ b/website/src/content/docs/guides/multi-instance-activities.md
@@ -156,6 +156,8 @@ Event sub-processes also do not support multi-instance — by BPMN spec, not a F
 
 **Output collection:** only outputs from *completed* iterations are included in `outputCollection`. Cancelled iterations contribute nothing.
 
+**Editor:** the BPMN editor exposes a **Completion Condition** field in the Multi-Instance section of the properties panel, so you can view and edit the expression without touching the XML directly.
+
 ## Limitations
 
 - **Transactions reject multi-instance at parse time.** `<transaction>` elements cannot carry `<multiInstanceLoopCharacteristics>` — the converter throws an explicit error. Wrap individual transactions in an outer multi-instance subprocess instead.


### PR DESCRIPTION
## Summary

Closes #518

Adds a **Completion Condition** field to the Multi-Instance section of the BPMN editor property panel, allowing users to view and edit `bpmn:completionCondition` expressions without editing XML directly.

## Changes

### `bpmnEditor.js`
- `completionCondition: ''` added to data literal
- Extraction from `miElement.completionCondition.body` in the loopCharacteristics block
- `case 'completionCondition'` in `updateMultiInstanceProperty` — creates/clears a `bpmn:FormalExpression` (same pattern as `loopCardinality`)

### `ElementPropertiesPanel.razor`
- `CompletionCondition` property on `BpmnElementData`
- `completionCondition` state field + populate from element + clear on multi-instance disable
- `FluentTextField` in Multi-Instance UI section (after Output Data Item)
- `OnCompletionConditionInput` / `OnCompletionConditionChange` handlers

### `tests/manual/13-multi-instance/test-plan.md`
- Scenario 13f: editor display + round-trip verification for `completionCondition`

### `website/src/content/docs/guides/multi-instance-activities.md`
- Added note that the editor exposes the Completion Condition field in the property panel

## Notes

The engine now fully evaluates `completionCondition` (merged in #529 / feat(#470)). The field is displayed without any "engine limitation" warning.

## How to test

1. Start the Aspire stack
2. Open `/editor`, import `tests/manual/13-multi-instance/completion-condition-1-of-N.bpmn`
3. Click the `processApproval` ScriptTask
4. Verify **Completion Condition** field shows `_context.nrOfCompletedInstances >= 1`
5. Edit the value and export — confirm the new value appears in the XML
