### PR TITLE
audit: refresh infra rules 2026-05-11

### DIFF
--- a/docs/audits/audit-infra-rules.md
+++ b/docs/audits/audit-infra-rules.md
@@ -16,9 +16,9 @@
 - **dimension:** scalability
 - **severity:** important
 - **signal:** `EfCoreEventStore.ReadEventsAsync` in `src/Fleans/Fleans.Persistence/Events/EfCoreEventStore.cs` calls `.ToListAsync()` on a `WorkflowEvents` query with no `Take(limit)` — search for the absence of `Take(` between the `.Where(e => e.GrainId ==` filter and the `.ToListAsync()` call in that method.
-- **remediation:** (1) Short-term: add a configurable `MaxEventsPerLoad` guard and throw when exceeded. (2) Medium-term: implement `JournaledGrain` snapshotting so `ReadEventsAsync` is called with `afterVersion = snapshotVersion` instead of 0 on cold activation. The `ICustomStorageInterface` hook in `WorkflowInstance.cs` is the natural snapshot persistence point. See issue #414.
+- **remediation:** (1) Short-term: add a configurable `MaxEventsPerLoad` guard and throw when exceeded. (2) Periodic snapshotting (every 100 events + on graceful deactivation) is now implemented in `WorkflowInstance.cs` — ensure snapshot write errors surface loudly rather than leaving `_lastSnapshotVersion` stale. See issue #414.
 - **first seen:** 2026-04-28
-- **last matched:** 2026-04-28
+- **last matched:** 2026-05-11
 
 ## scalability/user-task-full-table-materialize
 - **dimension:** scalability
@@ -26,7 +26,7 @@
 - **signal:** `WorkflowQueryService.GetPendingUserTasks` (the paged overload) in `src/Fleans/Fleans.Persistence/WorkflowQueryService.cs` calls `sievedQuery.ToListAsync()` before the `ApplyUserTaskFilters` call — the assignee/candidateGroup WHERE clause is applied in memory after the full non-completed user-task table is loaded. Look for `ToListAsync()` followed by `ApplyUserTaskFilters(` with no intervening DB-level WHERE on assignee or candidateGroup.
 - **remediation:** Add provider-specific EF Core expressions for `CandidateUsers`/`CandidateGroups` JSON array containment (`@>` / `?` on PostgreSQL via Npgsql's `EF.Functions`) so the filter executes server-side on the Postgres provider. The SQLite path can retain the in-memory fallback. Follow the `RelationalModelCustomizer` subclass pattern in `Fleans.Persistence.Sqlite` and `Fleans.Persistence.PostgreSql`. See issue #415.
 - **first seen:** 2026-04-28
-- **last matched:** 2026-04-28
+- **last matched:** 2026-05-11
 
 ## pluggability/role-env-aspire-chart-parity
 - **dimension:** pluggability
@@ -35,3 +35,19 @@
 - **remediation:** Add `WithEnvironment("Fleans__Role", builder.Configuration["FLEANS_ROLE"] ?? "Combined")` when wiring the `fleans-core` project in Aspire. Document the `FLEANS_ROLE` local-dev override in CLAUDE.md under the Core/Worker role split section. See issue #416.
 - **first seen:** 2026-04-28
 - **last matched:** 2026-04-28
+
+## pluggability/streaming-azurequeue-chart-gap
+- **dimension:** pluggability
+- **severity:** important
+- **signal:** `charts/fleans/templates/_helpers.tpl` `fleans.commonEnv` has a branch for `kafka` but no branch for `azurequeue`, while `FleanStreamingExtensions.cs` and `Fleans.Aspire/Program.cs` both support `AzureQueue` as a third streaming provider — search for the absence of `azurequeue` or `AzureQueue` in `_helpers.tpl` and `values.yaml`.
+- **remediation:** Add an `{{- if eq (lower .Values.streaming.provider) "azurequeue" }}` branch to `_helpers.tpl` setting `Fleans__Streaming__Provider=AzureQueue` and `Fleans__Streaming__AzureQueue__ConnectionString`. Add `streaming.azureQueue.connectionString` to `values.yaml` (empty default). Update `values.yaml` comment to `# Memory | Kafka | AzureQueue`. See issue #551.
+- **first seen:** 2026-05-11
+- **last matched:** 2026-05-11
+
+## reliability/orphaned-grain-interface
+- **dimension:** reliability
+- **severity:** minor
+- **signal:** `src/Fleans/Fleans.Application/Events/Handlers/IWorkflowEventsHandler.cs` declares an Orleans grain interface (`IGrainWithStringKey`) with zero implementing classes and zero callers anywhere in the codebase — grep for `IWorkflowEventsHandler` outside the declaration file to confirm absence.
+- **remediation:** Delete `IWorkflowEventsHandler.cs`. If a handler is planned, add an inline comment with the tracking issue number so the interface is not mistaken for dead code. See issue #552.
+- **first seen:** 2026-05-11
+- **last matched:** 2026-05-11


### PR DESCRIPTION
Generated by `audit-infra` on 2026-05-11.

- rules refreshed: 2
- rules added: 2
- issues opened: 2
- issues updated: 2

## Rules refreshed

- `scalability/event-store-unbounded-read` — remediation note updated to reflect that periodic snapshotting (every 100 events + graceful deactivation) is now implemented; safety-valve `Take()` guard still absent. Issue #414 body refreshed.
- `scalability/user-task-full-table-materialize` — no code change; still fires. Issue #415 body refreshed.

## Rules added

- `pluggability/streaming-azurequeue-chart-gap` — AzureQueue streaming is supported by `FleanStreamingExtensions` and Aspire but has no branch in `charts/fleans/templates/_helpers.tpl` or entry in `values.yaml`. Issue #551 opened.
- `reliability/orphaned-grain-interface` — `IWorkflowEventsHandler` has zero implementations and zero callers. Issue #552 opened.

## Fixed rules confirmed (issues CLOSED by maintainer)

- `pluggability/persistence-unknown-provider-silent-fallback` — explicit `throw` added (#413 closed).
- `pluggability/role-env-aspire-chart-parity` — `Fleans__Role` is now stamped in Aspire (#416 closed).

## Touched issues

#414 #415 #551 #552

https://claude.ai/code/session_01T9t4gftJJGgJVGnd8PpCLL

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9t4gftJJGgJVGnd8PpCLL)_