### PR TITLE
chore: relicense from PolyForm Noncommercial to PolyForm Internal Use 1.0.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-# PolyForm Noncommercial License 1.0.0
+# PolyForm Internal Use License 1.0.0
 
-<https://polyformproject.org/licenses/noncommercial/1.0.0>
+<https://polyformproject.org/licenses/internal-use/1.0.0>
 
 ## Acceptance
 
@@ -8,17 +8,7 @@ In order to get any license under these terms, you must agree to them as both st
 
 ## Copyright License
 
-The licensor grants you a copyright license for the software to do everything you might do with the software that would otherwise infringe the licensor's copyright in it for any permitted purpose.  However, you may only distribute the software according to [Distribution License](#distribution-license) and make changes or new works based on the software according to [Changes and New Works License](#changes-and-new-works-license).
-
-## Distribution License
-
-The licensor grants you an additional copyright license to distribute copies of the software.  Your license to distribute covers distributing the software with changes and new works permitted by [Changes and New Works License](#changes-and-new-works-license).
-
-## Notices
-
-You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these terms or the URL for them above, as well as copies of any plain-text lines beginning with `Required Notice:` that the licensor provided with the software.  For example:
-
-> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+The licensor grants you a copyright license for the software to do everything you might do with the software that would otherwise infringe the licensor's copyright in it for any permitted purpose.  However, you may only make changes or new works based on the software according to [Changes and New Works License](#changes-and-new-works-license), and you may not distribute the software.
 
 ## Changes and New Works License
 
@@ -28,21 +18,13 @@ The licensor grants you an additional copyright license to make changes and new 
 
 The licensor grants you a patent license for the software that covers patent claims the licensor can license, or becomes able to license, that you would infringe by using the software.
 
-## Noncommercial Purposes
-
-Any noncommercial purpose is a permitted purpose.
-
-## Personal Uses
-
-Personal use for research, experiment, and testing for the benefit of public knowledge, personal study, private entertainment, hobby projects, amateur pursuits, or religious observance, without any anticipated commercial application, is use for a permitted purpose.
-
-## Noncommercial Organizations
-
-Use by any charitable organization, educational institution, public research organization, public safety or health organization, environmental protection organization, or government institution is use for a permitted purpose regardless of the source of funding or obligations resulting from the funding.
-
 ## Fair Use
 
 You may have "fair use" rights for the software under the law. These terms do not limit them.
+
+## Internal Business Use
+
+Use of the software for the internal business operations of you and your company is use for a permitted purpose.
 
 ## No Other Rights
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="https://github.com/nightBaker/fleans/actions/workflows/dotnet.yml"><img src="https://github.com/nightBaker/fleans/actions/workflows/dotnet.yml/badge.svg?branch=main" alt="Build"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-PolyForm--NC--1.0-blue.svg" alt="License: PolyForm Noncommercial 1.0"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-PolyForm--IU--1.0-blue.svg" alt="License: PolyForm Internal Use 1.0"></a>
   <img src="https://img.shields.io/badge/.NET-10-512BD4" alt=".NET 10">
   <a href="https://www.nuget.org/packages/Fleans.Worker"><img src="https://img.shields.io/nuget/v/Fleans.Worker?label=nuget" alt="NuGet"></a>
   <a href="https://github.com/nightBaker/fleans/stargazers"><img src="https://img.shields.io/github/stars/nightBaker/fleans?style=social" alt="GitHub stars"></a>
@@ -117,6 +117,8 @@ For larger changes, open an issue first to align on the design. Design docs live
 
 ## License
 
-Fleans is licensed under **[PolyForm Noncommercial 1.0.0](LICENSE)** — source-available, free for non-commercial use (personal, research, evaluation, internal at non-profits). For commercial deployment, contact the maintainer for a commercial license.
+Fleans is licensed under **[PolyForm Internal Use 1.0.0](LICENSE)** — source-available, free for the internal business operations of any organisation (companies, non-profits, individuals alike). Use it, modify it for your own needs, run it on your own infrastructure, integrate it with your internal systems — all free, no licence fee, no user count cap, no contact required.
 
-PolyForm Noncommercial is a tech-industry-lawyer-drafted source-available licence — see [polyformproject.org](https://polyformproject.org/licenses/noncommercial/1.0.0/). It keeps the source open for inspection, learning, and contribution while reserving commercial revenue to fund sustained development.
+What's **not** permitted under this licence: distributing fleans (modified or unmodified) to anyone outside your organisation, hosting it as a managed service for third-party customers, or embedding it in a product you ship to others. For those use cases, contact the maintainer for a commercial licence.
+
+PolyForm Internal Use is a tech-industry-lawyer-drafted source-available licence — canonical text at [polyformproject.org/licenses/internal-use/1.0.0](https://polyformproject.org/licenses/internal-use/1.0.0/). It keeps the source open for inspection, learning, and internal modification while reserving distribution rights to fund sustained development.


### PR DESCRIPTION
## Summary

Switches the project licence from **PolyForm Noncommercial 1.0.0** to **PolyForm Internal Use 1.0.0** so any organisation — commercial, non-profit, or individual — can use fleans for free for internal business operations.

> Originally bundled into #557 as a second commit, but that commit was lost during the merge (push race / branch deletion). This PR re-applies it as a clean standalone change against current `main`.

### What changes for users

- ✅ **Internal commercial use is now free** (previously forbidden under NC).
- ✅ Internal modifications remain allowed.
- ❌ Distribution of the software (modified or unmodified) to third parties is forbidden under the new licence (previously also restricted under NC).
- ❌ Hosting fleans as a managed service or embedding it in a product shipped to customers still requires a commercial licence.

### Files touched

- `LICENSE` — replaced with canonical PolyForm Internal Use 1.0.0 text from `github.com/polyformproject/polyform-licenses@1.0.0`.
- `README.md` — badge label updated to `PolyForm--IU--1.0`; License section paragraph rewritten.

Existing copies distributed under PolyForm NC remain governed by NC terms forever — this is normal for any licence change.

## Test plan

- [ ] License badge on README shows "PolyForm IU 1.0".
- [ ] Clicking the License badge opens `LICENSE` with PolyForm Internal Use text.
- [ ] No other doc / config files reference "Noncommercial" (verified via `grep -ri polyform` — only README.md and LICENSE matched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)