### PR TITLE
fix(release): trigger nuget-publish.yml on tag push

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -1,17 +1,24 @@
 name: nuget-publish
 
 # Publishes the three NuGet plugin packages — Fleans.Application.Abstractions,
-# Fleans.Worker, Fleans.Plugins.RestCaller — to nuget.org. Triggered when a
-# maintainer publishes a GitHub Release; can also be invoked manually
+# Fleans.Worker, Fleans.Plugins.RestCaller — to nuget.org. Triggered by the
+# same `v<SemVer>` tag push that triggers release.yml, then blocks on the
+# GitHub Release object existing before publishing (so a failed release.yml
+# never leaks orphan NuGet packages). Can also be invoked manually
 # (workflow_dispatch) with `version=0.0.0-ci-test` for a dry-run that exercises
 # pack + upload-artifact without ever calling `dotnet nuget push`.
+#
+# Why not `on.release.published`? Releases created by the default `GITHUB_TOKEN`
+# (which release.yml uses for `gh release create`) do NOT trigger downstream
+# workflows — a GitHub anti-recursion safeguard. Tag-trigger + wait-for-release
+# sidesteps it without requiring a PAT.
 #
 # See `tests/manual/41-nuget-publish/test-plan.md` and CLAUDE.md "NuGet package
 # publishing" for the full runbook.
 
 on:
-  release:
-    types: [published]
+  push:
+    tags: ['v*']
   workflow_dispatch:
     inputs:
       version:
@@ -54,10 +61,8 @@ jobs:
           set -euo pipefail
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.version }}" ]; then
             VERSION="${{ inputs.version }}"
-          elif [ "${{ github.event_name }}" = "release" ]; then
-            VERSION="${{ github.event.release.tag_name }}"
-            VERSION="${VERSION#v}"
           else
+            # push.tags trigger — derive from refs/tags/v<SemVer>
             TAG="${GITHUB_REF_NAME#v}"
             VERSION="${TAG}"
           fi
@@ -69,6 +74,31 @@ jobs:
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Resolved version: $VERSION"
+
+      # On tag-push, release.yml runs in parallel. Block here until the GitHub
+      # Release object exists so we never publish NuGet packages for a release
+      # that ultimately failed (e.g., image push or helm-package failure).
+      # workflow_dispatch (including the 0.0.0-ci-test dry-run) skips this step.
+      - name: Wait for GitHub Release to exist
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        working-directory: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          DEADLINE=$(( $(date +%s) + 1200 ))   # 20 min — release.yml ran ~9 min historically; doubled for safety
+          while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+            if gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" --silent 2>/dev/null; then
+              echo "::notice::GitHub Release ${TAG} confirmed — proceeding with NuGet publish."
+              exit 0
+            fi
+            echo "Release ${TAG} not yet present — sleeping 30s"
+            sleep 30
+          done
+          echo "::error::GitHub Release ${TAG} did not appear within 20 minutes — release.yml likely failed. Aborting NuGet publish."
+          exit 1
 
       - name: Restore
         run: dotnet restore

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ The release pipeline at `.github/workflows/release.yml` triggers on `git push or
 git tag v0.1.0-beta && git push origin v0.1.0-beta
 ```
 
-The release workflow runs setup → images → compose → helm-package → release in a single CI run. The `release.published` event then triggers `nuget-publish.yml` automatically.
+The release workflow runs setup → images → compose → helm-package → release in a single CI run. The same `v<SemVer>` tag push triggers `nuget-publish.yml` in parallel; that workflow waits for the GitHub Release object to exist before publishing to nuget.org, so a failed `release.yml` never produces orphan NuGet packages. (We can't use `on.release.published` here: releases created by the default `GITHUB_TOKEN` do not trigger downstream workflows — GitHub anti-recursion safeguard.)
 
 ### Post-tag verification
 
@@ -152,7 +152,7 @@ The release workflow runs setup → images → compose → helm-package → rele
 2. **All 4 images pullable, multi-arch** — `docker buildx imagetools inspect ghcr.io/nightbaker/fleans-{api,web,worker,mcp}:0.1.0-beta` should resolve `linux/amd64` + `linux/arm64`.
 3. **Release assets attached** — `gh release view v0.1.0-beta --json assets` should list `docker-compose-v0.1.0-beta.zip` + `fleans-0.1.0-beta.tgz`.
 4. **Notes look right** — auto-generated notes group commits per `.github/release.yml` categories.
-5. **NuGet publish triggered + green** — the `release.published` event triggers `nuget-publish.yml`. Verify via `gh run list --workflow=nuget-publish.yml --limit 1`. Verify each of the 3 packages on nuget.org: `Fleans.Application.Abstractions`, `Fleans.Worker`, `Fleans.Plugins.RestCaller`.
+5. **NuGet publish triggered + green** — pushing the tag fires `nuget-publish.yml` in parallel with `release.yml`. It blocks on the GitHub Release existing (max 20 min wait) before pushing to nuget.org. Verify via `gh run list --workflow=nuget-publish.yml --limit 1`. Verify each of the 3 packages on nuget.org: `Fleans.Application.Abstractions`, `Fleans.Worker`, `Fleans.Plugins.RestCaller`.
 6. **Cosign verify smoke test** — pick one of the published images and verify the signature against Sigstore. The output should include a `Bundle` block with a `tlogEntries[0].logIndex` proving the signature was logged to the public Rekor transparency log.
 
    ```bash


### PR DESCRIPTION
## Summary

Surfaced by the **v0.1.0-rc.1** pre-release: `release.yml` succeeded end-to-end, but `nuget-publish.yml` had **zero** runs in its history. The chain CLAUDE.md described (\"the \`release.published\` event then triggers \`nuget-publish.yml\` automatically\") has been silently broken since day one.

### Root cause

GitHub Actions anti-recursion rule: **releases created by the default \`GITHUB_TOKEN\` do not start downstream workflows**. Since \`release.yml\` calls \`gh release create\` with \`secrets.GITHUB_TOKEN\`, the resulting \`release.published\` event is suppressed for workflow trigger purposes.

### Fix

- Drop the dead \`on.release.published\` trigger.
- Add \`on.push.tags: ['v*']\` — same trigger that runs \`release.yml\`, so both workflows run in parallel on every \`v<SemVer>\` tag push.
- **Add a wait-for-release step** that polls \`gh api repos/{owner}/{repo}/releases/tags/{tag}\` for up to 20 min. \`nuget-publish.yml\` blocks until \`release.yml\` has actually created the GitHub Release before calling \`dotnet nuget push\`. If \`release.yml\` fails, the NuGet push is skipped — no orphan packages on nuget.org (which cannot be deleted, only unlisted).
- Collapse the now-dead \`github.event_name == 'release'\` branch in the version-resolution step.
- \`workflow_dispatch\` path unchanged (still supports \`version=0.0.0-ci-test\` dry-run).
- CLAUDE.md updated to describe the new chain and explain why \`release.published\` was abandoned.

### Why not use a PAT?

A PAT would let \`gh release create\` trigger downstream workflows directly, matching CLAUDE.md's original intent. But PATs expire and need rotation; the tag-trigger + wait-for-release approach has no secret to manage and gives the same race-safety.

## Test plan

- [ ] Workflow YAML still parses (verified locally with Ruby YAML loader).
- [ ] After merge: push **v0.1.0-rc.2** to validate the full chain end-to-end (\`release.yml\` and \`nuget-publish.yml\` both run; NuGet publish waits, then pushes rc.2 packages to nuget.org).
- [ ] Then push **v0.1.0** for the real release.
- [ ] Spot-check: \`workflow_dispatch -f version=0.0.0-ci-test\` still produces packed-but-not-pushed artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)