### PR TITLE
fix(website): remove H2 bottom accent rule

### DIFF
--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -67,33 +67,6 @@
    D (scanline overlay on <main>, dark only)
    ============================================================ */
 
-/* --- A. H2 accent rule ---
-   2px gradient bar beneath each <h2> — reads as a printer
-   registration mark / CLI prompt bar.
-   Selector: .sl-markdown-content h2::after
-   Stability: STABLE — .sl-markdown-content is Starlight's documented
-   content override point (unchanged since v0.15). */
-.sl-markdown-content h2 {
-  position: relative;
-  padding-bottom: 0.45em;
-}
-
-.sl-markdown-content h2::after {
-  content: '';
-  display: block;
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  height: 2px;
-  background: linear-gradient(
-    to right,
-    var(--sl-color-accent) 0,
-    var(--sl-color-accent) 3.5rem,
-    transparent 3.5rem
-  );
-}
-
 /* --- B. Dot-matrix noise (dark theme only) ---
    Applied via body::before fixed pseudo-element in dark theme only.
    z-index: -1 keeps it behind all page content without requiring
@@ -363,23 +336,6 @@ h2#starlight__on-this-page,
       transform-origin: top;
     }
 
-    .sl-markdown-content h2 {
-      position: relative;
-    }
-
-    .sl-markdown-content h2::after {
-      content: '';
-      position: absolute;
-      bottom: -2px;
-      left: 0;
-      width: 100%;
-      height: 2px;
-      background: var(--fleans-accent-2);
-      transform-origin: left;
-      animation: underline-draw linear both;
-      animation-timeline: view();
-      animation-range: entry 0% entry 40%;
-    }
   }
 }
 
@@ -559,13 +515,6 @@ h2#starlight__on-this-page,
 }
 .card {
   border-left-color: var(--sl-color-accent) !important;
-}
-@supports (animation-timeline: view()) {
-  @media (prefers-reduced-motion: no-preference) {
-    .sl-markdown-content h2::after {
-      background: var(--sl-color-accent);
-    }
-  }
 }
 @media (hover: hover) {
   .card:hover {


### PR DESCRIPTION
## Summary
- Drops the 2px gradient bar that rendered under every `<h2>` in `.sl-markdown-content` (the static "A. H2 accent rule" block).
- Removes the scroll-driven `underline-draw` variant inside `@supports (animation-timeline: view())`.
- Removes the now-orphaned landing-page accent override that recolored the H2 `::after`.

## Test plan
- [ ] `cd website && npm run build` passes
- [ ] Visual: run `npm run dev` and confirm no bottom line under H2 headings in light + dark themes on any docs page

🤖 Generated with [Claude Code](https://claude.com/claude-code)