### PR TITLE
docs: use Starlight Tabs for interchangeable approaches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,12 @@ The public docs site lives in `website/` — an Astro + Starlight project deploy
 
 When deciding where a new doc belongs, ask: *does it require working in the source checkout, or does it only require a released artifact?* Source-checkout docs → repo `README.md` / `CLAUDE.md` / `docs/plans/`. Released-artifact docs → website. Quick Start on the website MUST use a released artifact (container pull, Helm install) — not `git clone && dotnet run`, which is a source-tree workflow.
 
+**Tabs for interchangeable approaches.** When a page documents two or more **interchangeable** tools or commands that produce the same outcome (e.g. `gh release download` vs `curl -LO`, `docker compose up` vs `helm install`, `apt` vs `brew`), use Starlight's [`<Tabs>`](https://starlight.astro.build/components/tabs/) component instead of stacking *"Or, without X:"* sections — keeps the page compact and lets the reader focus on the path they actually use. Convention:
+
+- Pages that import components must use the `.mdx` extension. Add `import { Tabs, TabItem } from '@astrojs/starlight/components';` after the frontmatter.
+- Set a `syncKey` so the tool choice persists across pages (e.g. `<Tabs syncKey="release-download-tool">` on every gh-vs-curl block, `syncKey="package-manager"` on every npm-vs-yarn block).
+- **Don't use tabs for non-interchangeable content** — dev vs prod configs, SQLite vs PostgreSQL, compose vs Helm are *different workflows* the reader needs to see both of, not a one-of-two choice.
+
 For website-build infrastructure (Hero BPMN diagram regeneration, 3D landing background, load-test publishing rule), see [`website/README.md`](website/README.md).
 
 ## How to Add a New BPMN Activity

--- a/website/src/content/docs/guides/quick-start.mdx
+++ b/website/src/content/docs/guides/quick-start.mdx
@@ -3,6 +3,8 @@ title: Quick Start
 description: Run Fleans locally from the released Docker Compose bundle in under 5 minutes.
 ---
 
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
 This walkthrough brings up the full Fleans stack from a published release, deploys a
 sample workflow through the admin UI, and starts an instance via the REST API.
 
@@ -19,21 +21,24 @@ No .NET SDK, no source checkout — the bundle pulls signed container images fro
 The release pipeline attaches `docker-compose-v<VER>.zip` to every GitHub Release.
 Grab the latest:
 
-```bash
-gh release download v0.3.0 --repo nightBaker/fleans -p 'docker-compose-*.zip'
-unzip docker-compose-v0.3.0.zip -d fleans
-cd fleans
-docker compose up -d
-```
-
-Or, without the `gh` CLI:
-
-```bash
-curl -LO https://github.com/nightBaker/fleans/releases/download/v0.3.0/docker-compose-v0.3.0.zip
-unzip docker-compose-v0.3.0.zip -d fleans
-cd fleans
-docker compose up -d
-```
+<Tabs syncKey="release-download-tool">
+  <TabItem label="gh CLI">
+    ```bash
+    gh release download v0.3.0 --repo nightBaker/fleans -p 'docker-compose-*.zip'
+    unzip docker-compose-v0.3.0.zip -d fleans
+    cd fleans
+    docker compose up -d
+    ```
+  </TabItem>
+  <TabItem label="curl">
+    ```bash
+    curl -LO https://github.com/nightBaker/fleans/releases/download/v0.3.0/docker-compose-v0.3.0.zip
+    unzip docker-compose-v0.3.0.zip -d fleans
+    cd fleans
+    docker compose up -d
+    ```
+  </TabItem>
+</Tabs>
 
 :::tip[Pick the latest tag]
 Substitute the current release tag (see


### PR DESCRIPTION
## Summary
- Convert the **gh CLI** vs **curl** download options on Quick Start into a `<Tabs syncKey="release-download-tool">` block. Rename `quick-start.md` → `quick-start.mdx` so it can import Starlight components.
- Add a CLAUDE.md convention: use `<Tabs>` only for **interchangeable** tools producing the same outcome (download, package manager, install command). Don't use them for content where the reader needs to see both sides (dev vs prod, SQLite vs PostgreSQL, Compose vs Helm).
- `syncKey` makes the reader's tool choice persist across pages.

## Test plan
- [x] `npm run build` passes (31 pages)
- [x] Local `npm run dev` preview reviewed — tab switching works, syncKey carries forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)