### PR TITLE
docs(website): rewrite load-testing image-pull around released artifacts (#581)

### DIFF
--- a/website/src/content/docs/reference/load-testing.md
+++ b/website/src/content/docs/reference/load-testing.md
@@ -174,8 +174,20 @@ For the Azure run specifically, you'll need:
   (auto-register on first use).
 - Either local `az` CLI (Python 3.13 may have a `pyexpat` issue depending on platform; if so,
   use `mcr.microsoft.com/azure-cli` from Docker), or just the Azure portal.
-- The `fleans-api` container image (built locally with
-  `dotnet publish Fleans.Api/Fleans.Api.csproj /t:PublishContainer …`) pushed to ACR.
+- The released `fleans-api` container image, re-tagged into your ACR. `docker pull` the image
+  from `ghcr.io/nightbaker/fleans-api:<version>`, then `docker tag` + `docker push` it to your
+  ACR (e.g. `myacr.azurecr.io/fleans-api:<version>`). Optionally verify the upstream image via
+  `cosign verify` first (see [Self-host with Docker Compose](/fleans/guides/self-host-docker-compose/)
+  for the canonical command).
+
+  ```bash
+  VERSION=v0.1.0-beta
+  ACR=myacr.azurecr.io
+  docker pull ghcr.io/nightbaker/fleans-api:$VERSION
+  docker tag ghcr.io/nightbaker/fleans-api:$VERSION $ACR/fleans-api:$VERSION
+  docker push $ACR/fleans-api:$VERSION
+  ```
+
   **Add `fleans-web` only if you also want the management UI in Azure** — it isn't strictly
   needed for the tests themselves.
 


### PR DESCRIPTION
## Summary
- Closes #581. Replace L178's source-tree `dotnet publish Fleans.Api/Fleans.Api.csproj /t:PublishContainer ... pushed to ACR` with a released-artifact `docker pull ghcr.io/nightbaker/fleans-api:<version>` + retag + push recipe.
- Add fenced bash code block (5 lines: `VERSION=`, `ACR=`, pull, tag, push) so the operator can copy-paste directly.
- Cross-link `cosign verify` to the canonical command at `guides/self-host-docker-compose.md` so load-test operators inherit the same supply-chain verification posture.

Smallest scope in the #578-#584 docs-cleanup family: single-bullet edit, +14/-2 lines.

## Test plan
- [x] `npm run build` — 31 pages, 0 errors, 2.72s
- [x] No source-tree residue (`grep -cE 'dotnet publish\|aspire publish\|src/Fleans\|dotnet run'` returns 0)
- [x] Cross-link to `self-host-docker-compose` present (count = 1)
- [x] Released image path `ghcr.io/nightbaker/fleans-api` present (count = 3 — bullet text + 2 bash lines)

## Related
- #577 (PR #602), #578 (PR #603), #579 (PR #604), #580 (PR #605) — precedent docs-rewrites in same family
- #574 — published `guides/self-host-docker-compose.md` (cosign verify section) that this PR cross-links

🤖 Generated with [Claude Code](https://claude.com/claude-code)