### PR TITLE
docs(website): drop source-tree smoke-test step from multi-instance-activities guide (#583)

### DIFF
--- a/website/src/content/docs/guides/multi-instance-activities.md
+++ b/website/src/content/docs/guides/multi-instance-activities.md
@@ -163,16 +163,6 @@ Event sub-processes also do not support multi-instance — by BPMN spec, not a F
 - **Transactions reject multi-instance at parse time.** `<transaction>` elements cannot carry `<multiInstanceLoopCharacteristics>` — the converter throws an explicit error. Wrap individual transactions in an outer multi-instance subprocess instead.
 - **Event sub-processes cannot be multi-instance** — by BPMN spec, not a Fleans limitation.
 
-## Try it locally
-
-The fixtures in `tests/manual/13-multi-instance/` are runnable end-to-end against a freshly-started Aspire stack:
-
-1. `dotnet run --project src/Fleans/Fleans.Aspire` (from the repo root).
-2. Open the [Web UI](https://localhost:7124) and navigate to **Editor**.
-3. Paste in one of the `.bpmn` files and click **Deploy**.
-4. From the **Workflows** page, **Start** the deployed process (set `approvers: ["alice","bob","charlie"]` for `completion-condition-1-of-N.bpmn`).
-5. Open the resulting instance and confirm the expected state per `tests/manual/13-multi-instance/test-plan.md`.
-
 ## Related guides
 
 - [Variables and Scope](/fleans/guides/variables-and-scope/) — full model for child-scope inheritance and merge-back.


### PR DESCRIPTION
## Summary

- Deletes the `## Try it locally` H2 section (lines 166–175) from `website/src/content/docs/guides/multi-instance-activities.md` — its 5-step procedure required `git clone` + `dotnet run --project src/Fleans/Fleans.Aspire`, which is a source-checkout workflow not a released-artifact one.
- Per CLAUDE.md's **Documentation scope split** rule, source-checkout instructions belong in the repo's README / CLAUDE.md / docs/plans, not the website. The Quick Start already covers the canonical released-artifact path (`gh release download` + `docker compose up`).
- Informational GitHub URL citations at lines 15 / 45 / 68 / 86 (`tests/manual/13-multi-instance/*.bpmn`) are **intentionally retained** — they link readers to the fixture XML in the repo and work for any reader regardless of source checkout. Precedent: cycle 76 (#580 / PR #605, `[deploy]` cross-link retained on observability page).

Closes #583

## Diff scope

Single file, 10 deletions, 0 additions. No source-tree changes.

## Notes for reviewers

- **External-anchor breakage caveat**: while `grep -rn 'try-it-locally' src/content/docs/` returned 0 matches within the website, external bookmarks (Discord, GitHub issue bodies, third-party blogs) to `/fleans/guides/multi-instance-activities/#try-it-locally` cannot be enumerated and will 404 to the page top after this merges. Acceptable soft loss inherent to any docs deletion.
- No corresponding test-plan edit: `tests/manual/website/multi-instance-guide/test-plan.md` exists but does not reference the deleted section (verified via grep for `Try it locally|try-it-locally|dotnet run`).

## Test plan

- [x] `cd website && npm run build` passes (31 pages built, zero errors).
- [x] `grep -c 'Try it locally' dist/guides/multi-instance-activities/index.html` → 0
- [x] `grep -c 'dotnet run --project src/Fleans/Fleans.Aspire' dist/guides/multi-instance-activities/index.html` → 0
- [x] `grep -c '13-multi-instance/test-plan.md' dist/guides/multi-instance-activities/index.html` → 0
- [x] H2 ordering verified — `## Limitations` is now immediately followed by `## Related guides`.
- [x] Out-of-scope informational citations retained: `grep -c 'tests/manual/13-multi-instance'` → 4 (unchanged from main).
- [x] `git diff main..feature/583-drop-source-tree-smoke-test --name-only | grep -vE '^website/'` is empty (zero source-tree residue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)