### PR TITLE
fix: render BPMN diagram after LoadInstance completes (firstRender race in ProcessInstance.razor)

### DIFF
--- a/src/Fleans/Fleans.Web/Components/Pages/ProcessInstance.razor
+++ b/src/Fleans/Fleans.Web/Components/Pages/ProcessInstance.razor
@@ -338,6 +338,7 @@
     private ElementPropertiesPanel.BpmnElementData? selectedElementData;
     private int canvasHeight = 400;
     private DotNetObjectReference<ProcessInstance>? dotNetRef;
+    private bool diagramRendered;
 
     // Activities tab
     private List<ActivityInstanceSnapshot> allActivitiesList = [];
@@ -383,8 +384,14 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (firstRender && bpmnXml != null)
+        // Don't gate on firstRender: with InteractiveServer, the first await in
+        // LoadInstance suspends OnInitializedAsync, so firstRender fires once
+        // with bpmnXml/snapshot still null — and subsequent renders have
+        // firstRender=false, so the diagram would never initialize. Gate on
+        // the fields being populated and a "done it once" flag instead.
+        if (!diagramRendered && bpmnXml != null && snapshot != null)
         {
+            diagramRendered = true;
             await RenderDiagram();
         }
     }


### PR DESCRIPTION
## Summary

- `ProcessInstance.razor`'s `OnAfterRenderAsync` gated `RenderDiagram` on `firstRender && bpmnXml != null`, but with `InteractiveServer` render mode the first await in `LoadInstance` suspends `OnInitializedAsync` and Blazor emits an interim render — `firstRender` fires there while `bpmnXml`/`snapshot` are still `null`, the guard skips, and no subsequent render satisfies `firstRender` again. Result: empty BPMN canvas, no error, no spinner.
- Per-instance flakiness explained: instances whose EF query completed synchronously (terminal state, never-started rows) fell through without an interim render and worked; in-flight instances with mid-execution rows suspended and triggered the race.
- Fix: replace the `firstRender` guard with a `diagramRendered` sentinel + a populated-fields gate. `RenderDiagram` already has its own `if (bpmnXml == null || snapshot == null) return;` early-out, so the dual-guard is intentional.

## Test plan

- [x] `dotnet build src/Fleans/Fleans.Web/Fleans.Web.csproj` → 0 errors.
- [x] Reproduced empty canvas against an in-flight instance (`IsStarted=true, IsCompleted=false`) on `ghcr.io/nightbaker/fleans-web:0.4.1`: `<div id=\"bpmn-canvas\">` present, `window.bpmnViewer._viewer` unset, `canvasChildren=0`.
- [x] Built a local `fleans-web:0.4.1-canvasfix` image with this change, swapped into the same docker-compose stack, re-navigated to the same instance — `canvasChildren=1`, `window.bpmnViewer._viewer` set, BPMN rendered.
- [x] Re-verified that previously-working instances (terminal + never-started) still render after the change.

## Notes

- No reset of `diagramRendered` on parameter change is needed — `@page \"/process-instance/{InstanceId:guid}\"` triggers a full component recreate on navigation, so the field starts fresh each time.
- This is pre-existing, not a v0.4.1 regression — the `InteractiveServer` interim-render behavior has been in place since the page was added. The bug was masked whenever the snapshot query completed synchronously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)