### PR TITLE
fix(web): instance-page properties panel shows the full element schema (task-definition type, mappings, multi-instance, …)

### DIFF
--- a/src/Fleans/Fleans.Web/Components/Pages/CustomTaskParameterEditor.razor
+++ b/src/Fleans/Fleans.Web/Components/Pages/CustomTaskParameterEditor.razor
@@ -43,6 +43,7 @@
                     <FluentTextField Value="@currentValue"
                                      Placeholder="@(spec.DefaultValue ?? "")"
                                      ValueChanged="@(v => OnValueChanged(spec.Name, v))"
+                                     Disabled="@ReadOnly"
                                      Style="@($"width: 100%; {(hasError ? "border-color: var(--error);" : "")}")" />
                     <FluentLabel Typo="Typography.Body" Style="color: var(--neutral-foreground-hint); font-size: 0.8em;">
                         Type a literal value, or <code>=variableName</code> to reference a workflow variable.
@@ -53,19 +54,22 @@
                                        Value="@(int.TryParse(currentValue, out var n) ? n : (int?)null)"
                                        Placeholder="@(spec.DefaultValue ?? "")"
                                        ValueChanged="@(v => OnValueChanged(spec.Name, v?.ToString() ?? ""))"
-                                       Style="@($"width: 100%; {(hasError ? "border-color: var(--error);" : "")}")" />
+                                       Disabled="@ReadOnly"
+                                     Style="@($"width: 100%; {(hasError ? "border-color: var(--error);" : "")}")" />
                     <FluentLabel Typo="Typography.Body" Style="color: var(--neutral-foreground-hint); font-size: 0.8em;">
                         Type a literal number, or use the parameter as <code>=variableName</code> in raw BPMN to reference a workflow variable.
                     </FluentLabel>
                     break;
                 case CustomTaskParameterType.Boolean:
                     <FluentCheckbox Value="@(string.Equals(currentValue, "true", StringComparison.OrdinalIgnoreCase))"
+                                    Disabled="@ReadOnly"
                                     ValueChanged="@(v => OnValueChanged(spec.Name, v ? "true" : "false"))" />
                     break;
                 case CustomTaskParameterType.Expression:
                     <FluentTextArea Value="@currentValue"
                                     Placeholder="=workflowVar  or  literal"
                                     ValueChanged="@(v => OnValueChanged(spec.Name, v))"
+                                    Disabled="@ReadOnly"
                                     Style="@($"width: 100%; font-family: monospace; {(hasError ? "border-color: var(--error);" : "")}")"
                                     Rows="2" />
                     <FluentLabel Typo="Typography.Body" Style="color: var(--neutral-foreground-hint); font-size: 0.8em;">
@@ -76,6 +80,7 @@
                     <FluentTextArea Value="@currentValue"
                                     Placeholder="@(spec.DefaultValue ?? "")"
                                     ValueChanged="@(v => OnValueChanged(spec.Name, v))"
+                                    Disabled="@ReadOnly"
                                     Style="@($"width: 100%; {(hasError ? "border-color: var(--error);" : "")}")"
                                     Rows="4" />
                     <FluentLabel Typo="Typography.Body" Style="color: var(--neutral-foreground-hint); font-size: 0.8em;">
@@ -89,6 +94,7 @@
                     <FluentTextField Value="@currentValue"
                                      Placeholder="=workflowVariableName"
                                      ValueChanged="@(v => OnValueChanged(spec.Name, v))"
+                                     Disabled="@ReadOnly"
                                      Style="@($"width: 100%; {(hasError ? "border-color: var(--error);" : "")}")" />
                     <FluentLabel Typo="Typography.Body" Style="color: var(--neutral-foreground-hint); font-size: 0.8em;">
                         @(spec.Type == CustomTaskParameterType.List ? "List" : "Map") parameter — reference a workflow variable
@@ -111,6 +117,7 @@
     [Parameter, EditorRequired] public CustomTaskParameterSchema? Schema { get; set; }
     [Parameter, EditorRequired] public IReadOnlyDictionary<string, string> Values { get; set; } = new Dictionary<string, string>();
     [Parameter] public EventCallback<(string Target, string Source)> OnInputChanged { get; set; }
+    [Parameter] public bool ReadOnly { get; set; }
 
     private readonly Dictionary<string, CancellationTokenSource> _debounceTokens = new();
     private static readonly TimeSpan DebounceInterval = TimeSpan.FromMilliseconds(300);

--- a/src/Fleans/Fleans.Web/Components/Pages/ElementPropertiesPanel.razor
+++ b/src/Fleans/Fleans.Web/Components/Pages/ElementPropertiesPanel.razor
@@ -436,7 +436,7 @@
                 </div>
             }
 
-            @if (Element.Type == "bpmn:ServiceTask" && !ReadOnly)
+            @if (Element.Type == "bpmn:ServiceTask")
             {
                 <div>
                     <FluentLabel Typo="Typography.Body" Weight="FontWeight.Bold">Plugin (custom task)</FluentLabel>
@@ -452,7 +452,7 @@
                     }
                     else
                     {
-                        <FluentSelect TOption="string" Value="@(currentPluginType ?? "")" @onchange="OnPluginTypeChange" Style="width: 100%;">
+                        <FluentSelect TOption="string" Value="@(currentPluginType ?? "")" @onchange="OnPluginTypeChange" Disabled="@ReadOnly" Style="width: 100%;">
                             <FluentOption TOption="string" Value="" Selected="@(string.IsNullOrEmpty(currentPluginType))">Select a plugin…</FluentOption>
                             @foreach (var entry in catalogEntries)
                             {
@@ -501,7 +501,8 @@
                 {
                     <CustomTaskParameterEditor Schema="@currentSchema"
                                                Values="@currentParameterValues"
-                                               OnInputChanged="OnParameterChanged" />
+                                               OnInputChanged="OnParameterChanged"
+                                               ReadOnly="@ReadOnly" />
                 }
 
                 @* Output Mappings stay free-form — CustomTaskParameterSchema models inputs only,
@@ -768,14 +769,17 @@
             var entries = await catalog.GetAll();
             catalogEntries = entries.ToList();
 
-            // Read current type from the BPMN element via JS interop.
-            currentPluginType = await JS.InvokeAsync<string?>("bpmnEditor.getServiceTaskType", Element.Id);
+            // Read current type from the BPMN element via JS interop. The
+            // instance page has no modeler — use the viewer's read-only
+            // mirrors of these helpers when ReadOnly is true.
+            var jsBpmn = ReadOnly ? "bpmnViewer" : "bpmnEditor";
+            currentPluginType = await JS.InvokeAsync<string?>($"{jsBpmn}.getServiceTaskType", Element.Id);
             currentSchema = !string.IsNullOrEmpty(currentPluginType)
                 ? entries.FirstOrDefault(e => string.Equals(e.TaskType, currentPluginType, StringComparison.OrdinalIgnoreCase))?.ParameterSchema
                 : null;
 
             // Read current input mappings from the BPMN element.
-            var ioMappings = await JS.InvokeAsync<List<IoMappingDto>>("bpmnEditor.getIoMappings", Element.Id) ?? new();
+            var ioMappings = await JS.InvokeAsync<List<IoMappingDto>>($"{jsBpmn}.getIoMappings", Element.Id) ?? new();
             currentParameterValues = ioMappings
                 .Where(m => m.kind == "input" && !string.IsNullOrEmpty(m.target))
                 .ToDictionary(m => m.target, m => m.source ?? "", StringComparer.Ordinal);

--- a/src/Fleans/Fleans.Web/wwwroot/js/bpmnViewer.js
+++ b/src/Fleans/Fleans.Web/wwwroot/js/bpmnViewer.js
@@ -21,7 +21,20 @@ window.bpmnViewer = {
         }
 
         this._clickHandlerRegistered = false;
-        this._viewer = new BpmnViewer({ container: container });
+        // Register the same moddle extensions as the editor so that bpmn-js
+        // parses <fleans:taskDefinition>, <fleans:ioMapping>, <zeebe:*>, etc.
+        // as typed moddle elements instead of opaque $children blobs. Without
+        // this, the property-extraction helpers (which match on PascalCase
+        // $type and read typed `.inputs`/`.outputs`/`.type` properties) come
+        // back empty even though the XML has the data.
+        this._viewer = new BpmnViewer({
+            container: container,
+            moddleExtensions: Object.assign(
+                {},
+                window.fleansModdleExtension ? { fleans: window.fleansModdleExtension } : {},
+                window.zeebeModdleExtension ? { zeebe: window.zeebeModdleExtension } : {}
+            )
+        });
 
         try {
             await this._viewer.importXML(bpmnXml);
@@ -283,58 +296,26 @@ window.bpmnViewer = {
         var element = elementRegistry.get(elementId);
         if (!element) return null;
 
-        var bo = element.businessObject;
-        var data = {
-            id: bo.id || '',
-            type: element.type || '',
-            name: bo.name || '',
-            scriptFormat: bo.scriptFormat || '',
-            script: bo.script || '',
-            conditionExpression: (bo.conditionExpression && bo.conditionExpression.body) || '',
-            timerType: '',
-            timerExpression: '',
-            hasTimerDefinition: false,
-            hasMessageDefinition: false,
-            messageName: '',
-            correlationKey: '',
-            isInterrupting: true
-        };
+        // Reuse the editor's full extractor so the read-only instance panel
+        // surfaces the same schema as the editor — task-definition type,
+        // input/output mappings, expected outputs, user-task fields,
+        // multi-instance loop characteristics, etc. The extractor only
+        // touches `this._modeler.get('elementRegistry')`; bpmn-js Modeler
+        // and Viewer expose the same registry surface, so binding `this`
+        // to a stub with `_modeler` pointing at the viewer works.
+        return window.bpmnEditor._extractElementData.call({ _modeler: this._viewer }, element);
+    },
 
-        if (bo.eventDefinitions && bo.eventDefinitions.length > 0) {
-            for (var i = 0; i < bo.eventDefinitions.length; i++) {
-                if (bo.eventDefinitions[i].$type === 'bpmn:TimerEventDefinition') {
-                    data.hasTimerDefinition = true;
-                    var timerDef = bo.eventDefinitions[i];
-                    if (timerDef.timeDuration) {
-                        data.timerType = 'duration';
-                        data.timerExpression = timerDef.timeDuration.body || '';
-                    } else if (timerDef.timeDate) {
-                        data.timerType = 'date';
-                        data.timerExpression = timerDef.timeDate.body || '';
-                    } else if (timerDef.timeCycle) {
-                        data.timerType = 'cycle';
-                        data.timerExpression = timerDef.timeCycle.body || '';
-                    }
-                    break;
-                }
-                if (bo.eventDefinitions[i].$type === 'bpmn:MessageEventDefinition') {
-                    data.hasMessageDefinition = true;
-                    var msgDef = bo.eventDefinitions[i];
-                    if (msgDef.messageRef) {
-                        data.messageName = msgDef.messageRef.name || '';
-                    }
-                    var attrs = bo.$attrs || {};
-                    data.correlationKey = attrs['fleans:correlationKey'] || attrs['zeebe:correlationKey'] || '';
-                    break;
-                }
-            }
-        }
+    // Read-only counterparts of bpmnEditor.getServiceTaskType / getIoMappings
+    // for the instance page's properties panel (which has no modeler).
+    getServiceTaskType: function (elementId) {
+        if (!this._viewer) return null;
+        return window.bpmnEditor.getServiceTaskType.call({ _modeler: this._viewer }, elementId);
+    },
 
-        if (bo.$type === 'bpmn:BoundaryEvent') {
-            data.isInterrupting = bo.cancelActivity !== false;
-        }
-
-        return data;
+    getIoMappings: function (elementId) {
+        if (!this._viewer) return [];
+        return window.bpmnEditor.getIoMappings.call({ _modeler: this._viewer }, elementId);
     },
 
     destroy: function () {


### PR DESCRIPTION
## Summary

`ProcessInstance.razor` passes `ReadOnly=true` to `ElementPropertiesPanel`, but three independent gaps combined to leave the panel showing only id/name/timer/message basics for ServiceTasks (and a reduced view for several other element types):

1. **`bpmnViewer.getElementProperties` returned a hand-rolled ~15-field subset.** The editor's `_extractElementData` returns ~50 fields (task-definition type, IO mappings, expected outputs, user-task fields, multi-instance, event definitions, …). Reuse it via `this`-binding — the extractor only touches `this._modeler.get('elementRegistry')`, and bpmn-js Modeler and Viewer expose the same registry surface.
2. **`new BpmnViewer({ container })` had no `moddleExtensions`.** Without them bpmn-js parses `<fleans:taskDefinition>` / `<fleans:ioMapping>` / `<zeebe:*>` as opaque `$children` blobs with lowercase `$type` — the helpers' PascalCase `_isExt` checks and typed `.inputs`/`.outputs` accessors then all see empty. Register the same `fleansModdleExtension` + `zeebeModdleExtension` the editor uses.
3. **`ElementPropertiesPanel.razor:439` gated the entire ServiceTask section on `!ReadOnly`.** Drop that — the inner `<FluentTextField>`s already carry `Disabled="@ReadOnly"` and the mutating buttons (`Add`/`Remove` mapping, confirm-replace dialog) are individually `!ReadOnly`-gated. Add `Disabled="@ReadOnly"` to the plugin-select that was missing it, and thread `ReadOnly` through to `CustomTaskParameterEditor` (new `[Parameter] bool ReadOnly`, wired to every input).

`bpmnViewer.getServiceTaskType` / `getIoMappings` get viewer-side mirrors that delegate to the editor versions via the same `this`-binding so the panel picks the right JS surface based on `ReadOnly`.

## Test plan

- [x] `dotnet build src/Fleans/Fleans.Web/Fleans.Web.csproj` → 0 errors.
- [x] Reproduced empty panel against the v0.4.1 docker-compose stack with the [`fleans-custom-worker-example`](https://github.com/nightBaker/fleans-custom-worker-example) template (HelloWorld plugin in the catalog). Clicking the `<serviceTask type="hello-world">` on a running instance showed only `Service Task / ID / Name / Plugin (custom task)` — no plugin dropdown selection, no parameters, no mappings.
- [x] Applied this fix, swapped a local `fleans-web:0.4.1-panelfix4` image into the same stack, re-clicked the service task. Verified via DOM probe:
  - Plugin select: `Hello World (hello-world)` selected, `disabled=true`.
  - Schema-driven `Name` parameter input: `value="world"` (matches `<fleans:input source="world" target="name"/>`), `disabled=true`.
  - `Output Mappings` section rendered.
  - All text fields disabled (read-only contract preserved).
- [x] Same path on a freshly deployed BPMN with a custom-task service task — same parity.
- [x] Editor page (`@page "/editor"`) still works — passes `ReadOnly=false` so all the inputs are interactive, identical behavior to `main`.

## Notes

- The `this`-binding pattern (`fn.call({ _modeler: this._viewer }, …)`) is used three times in `bpmnViewer.js`. Concise and avoids dragging the editor's ~200-LOC extractor into a shared file — if either side adds new `this.*` lookups beyond `_modeler.get('elementRegistry')`, this breaks loudly (no silent partial reads) and the right answer at that point is the shared-helper refactor.
- The viewer needs `window.fleansModdleExtension` / `window.zeebeModdleExtension` to be defined before `init` is called. `App.razor` already loads `js/fleansModdleExtension.js` (line 30) and `js/zeebeModdleExtension.js` (line 31) globally on every page, so the dependency is satisfied at page-mount time when `OnAfterRenderAsync` invokes the viewer's init.

🤖 Generated with [Claude Code](https://claude.com/claude-code)