### PR TITLE
docs(#623): zeebe: → fleans: in website docs

### DIFF
--- a/website/src/content/docs/concepts/activities/tasks.mdx
+++ b/website/src/content/docs/concepts/activities/tasks.mdx
@@ -74,9 +74,10 @@ exposes a claim → complete (or fail / cancel) lifecycle via REST and the admin
 
 **BPMN:**
 ```xml
+<!-- Requires xmlns:fleans="https://fleans.io/schema/bpmn/1.0" on <bpmn:definitions> -->
 <bpmn:userTask id="Task_1" name="Approve request">
   <bpmn:extensionElements>
-    <zeebe:assignmentDefinition assignee="manager" candidateGroups="approvers" />
+    <fleans:assignmentDefinition assignee="manager" candidateGroups="approvers" />
   </bpmn:extensionElements>
 </bpmn:userTask>
 ```
@@ -99,17 +100,18 @@ task is completed via `POST /Workflow/{id}/complete-activity`. Source: `BpmnConv
 
 A **Service Task** (`<bpmn:serviceTask type="…">`) delegates execution to a plugin grain
 identified by the `type` attribute. Plugins live on a Worker silo and implement
-`CustomTaskHandlerBase`. Output variables are mapped back via `<zeebe:output>` bindings.
+`CustomTaskHandlerBase`. Output variables are mapped back via `<fleans:output>` bindings.
 
 **BPMN:**
 ```xml
+<!-- Requires xmlns:fleans="https://fleans.io/schema/bpmn/1.0" on <bpmn:definitions> -->
 <bpmn:serviceTask id="Task_1" name="Call external API">
   <bpmn:extensionElements>
-    <zeebe:taskDefinition type="rest-caller" />
-    <zeebe:ioMapping>
-      <zeebe:input source="=apiUrl"  target="url" />
-      <zeebe:output source="=__response.body" target="result" />
-    </zeebe:ioMapping>
+    <fleans:taskDefinition type="rest-caller" />
+    <fleans:ioMapping>
+      <fleans:input source="=apiUrl"  target="url" />
+      <fleans:output source="=__response.body" target="result" />
+    </fleans:ioMapping>
   </bpmn:extensionElements>
 </bpmn:serviceTask>
 ```

--- a/website/src/content/docs/concepts/custom-tasks.md
+++ b/website/src/content/docs/concepts/custom-tasks.md
@@ -9,7 +9,7 @@ This is the recommended pattern for anything Fleans doesn't ship in the box: RES
 
 ## How it works
 
-1. **BPMN parsing.** The converter sees `<serviceTask type="rest-call">` (or the Camunda equivalent `<extensionElements><zeebe:taskDefinition type="rest-call"/></extensionElements>`) and produces a `CustomTaskActivity` carrying the task type and any `<zeebe:ioMapping>` declarations.
+1. **BPMN parsing.** The converter sees `<serviceTask type="rest-call">` (or the Camunda equivalent `<extensionElements><zeebe:taskDefinition type="rest-call"/></extensionElements>`) and produces a `CustomTaskActivity` carrying the task type and any `<fleans:ioMapping>` declarations.
 2. **Activity emits an event.** When the workflow reaches the activity, it publishes `ExecuteCustomTaskEvent { TaskType, InputMappings, OutputMappings, VariablesId, … }` on the per-type Orleans stream `events.ExecuteCustomTaskEvent.{TaskType}` — partitioned by `TaskType` so each plugin's handler grain class only receives events it actually claims.
 3. **Plugin handler is dispatched directly.** Each plugin's `CustomTaskHandlerBase` subclass implicit-subscribes to its own per-type namespace (`[ImplicitStreamSubscription("events.ExecuteCustomTaskEvent.<task-type>")]`), so Orleans activates only the matching plugin's grain. No filter-after-deliver waste: silos no longer deserialize events for plugins they don't host.
 4. **Plugin runs.** The base class resolves input mappings against the workflow's variable scope, calls your `ExecuteAsync(...)`, projects outputs against the result, then calls `IWorkflowInstanceGrain.CompleteActivity` (or `FailActivity` on exception).
@@ -23,7 +23,7 @@ For a step-by-step tutorial — project setup, handler, schema, DI wiring, BPMN 
 
 ## Parameter types
 
-Parameter schemas drive what the management UI's BPMN editor renders for each `<zeebe:input>` row. The five primitive types map to typed widgets:
+Parameter schemas drive what the management UI's BPMN editor renders for each `<fleans:input>` row. The five primitive types map to typed widgets:
 
 | Type | Widget | Notes |
 |---|---|---|
@@ -44,7 +44,7 @@ Nested `List`/`Map` (a list whose items are themselves objects with three fields
 
 ## Mapping grammar
 
-Sources and targets in `<zeebe:input>` / `<zeebe:output>` follow this grammar (validated at BPMN deploy time):
+Sources and targets in `<fleans:input>` / `<fleans:output>` follow this grammar (validated at BPMN deploy time):
 
 | Form | Example | Meaning |
 |------|---------|---------|
@@ -53,7 +53,7 @@ Sources and targets in `<zeebe:input>` / `<zeebe:output>` follow this grammar (v
 | `=42` / `=3.14` / `=true` / `=false` / `=null` | `=true` | Primitive literal |
 | Bare string | `application/json` | Treated as a string literal |
 
-Targets must be valid identifiers (`^[a-zA-Z_][a-zA-Z0-9_]*$`). The target `__response` is **reserved** on `<zeebe:output>` — plugins write their result under that key in the dictionary they return, and your output mappings reference it via `=__response.body` or similar.
+Targets must be valid identifiers (`^[a-zA-Z_][a-zA-Z0-9_]*$`). The target `__response` is **reserved** on `<fleans:output>` — plugins write their result under that key in the dictionary they return, and your output mappings reference it via `=__response.body` or similar.
 
 ## What lives where
 
@@ -89,7 +89,7 @@ Fleans ships one custom-task plugin out of the box: `Fleans.Plugins.RestCaller`.
 |---|---|---|---|---|
 | `url` | `String` | yes | — | Absolute URI |
 | `method` | `String` | yes | `GET` | One of GET / POST / PUT / PATCH / DELETE / HEAD / OPTIONS |
-| `headers` | `Map<String>` | no | `null` | Each `(name, value)` pair sent as a header. **v1 only sources from a workflow variable** (e.g. `<zeebe:input source="=requestHeaders" target="headers" />`). |
+| `headers` | `Map<String>` | no | `null` | Each `(name, value)` pair sent as a header. **v1 only sources from a workflow variable** (e.g. `<fleans:input source="=requestHeaders" target="headers" />`). |
 | `body` | `MultilineString` | no | `null` | Sent verbatim. If non-empty and no `Content-Type` header is supplied, defaults to `application/json` |
 | `successCodes` | `List<Integer>` | no | `null` | When null/empty, defaults to `200..299`. Pass an explicit list (e.g. `[200, 201, 404]`) when you want non-2xx codes treated as success. **v1 only sources from a workflow variable.** |
 | `timeoutSec` | `Integer` | yes | `30` | Whole seconds; clamped to `[1, 300]`. Timeout fails the activity with `code="504"` |
@@ -109,16 +109,17 @@ Workflow authors route via boundary error events with `errorCode="404"`, `errorC
 ### Worked example
 
 ```xml
+<!-- Requires xmlns:fleans="https://fleans.io/schema/bpmn/1.0" on <bpmn:definitions> -->
 <bpmn:serviceTask id="getUser" type="rest-call">
   <bpmn:extensionElements>
-    <zeebe:ioMapping>
-      <zeebe:input  source="=userApiUrl"        target="url" />
-      <zeebe:input  source="GET"                target="method" />
-      <zeebe:input  source="=requestHeaders"    target="headers" />
-      <zeebe:input  source="10"                 target="timeoutSec" />
-      <zeebe:output source="=__response.body"   target="user" />
-      <zeebe:output source="=__response.statusCode" target="status" />
-    </zeebe:ioMapping>
+    <fleans:ioMapping>
+      <fleans:input  source="=userApiUrl"        target="url" />
+      <fleans:input  source="GET"                target="method" />
+      <fleans:input  source="=requestHeaders"    target="headers" />
+      <fleans:input  source="10"                 target="timeoutSec" />
+      <fleans:output source="=__response.body"   target="user" />
+      <fleans:output source="=__response.statusCode" target="status" />
+    </fleans:ioMapping>
   </bpmn:extensionElements>
 </bpmn:serviceTask>
 ```

--- a/website/src/content/docs/guides/call-activities-and-subprocesses.md
+++ b/website/src/content/docs/guides/call-activities-and-subprocesses.md
@@ -112,18 +112,19 @@ foreach (var output in extensionElements.Elements()
     .Where(e => e.Name.LocalName == "outputMapping"))
 ```
 
-:::caution[`<zeebe:input>` / `<zeebe:output>` are NOT accepted by CallActivity]
-The `<zeebe:input>` / `<zeebe:output>` form is reserved for **service tasks
-and custom tasks** — its parser is at `BpmnConverter.cs:1286-1322` and is
-never invoked for `<callActivity>`.
+:::caution[`<fleans:input>` / `<fleans:output>` are NOT accepted by CallActivity]
+The `<fleans:input>` / `<fleans:output>` form is reserved for **service tasks
+and custom tasks** (and the equivalent `<zeebe:input>` / `<zeebe:output>` from
+Camunda exports, accepted via the same parser). Its parser is at
+`BpmnConverter.cs:1286-1322` and is never invoked for `<callActivity>`.
 
 Mixing the two forms — for example writing
-`<zeebe:input source="…" target="…"/>` inside a
+`<fleans:input source="…" target="…"/>` inside a
 `<callActivity><extensionElements>` block — will silently produce **zero
 mappings**: the call-activity parser only walks elements whose local-name
 is `inputMapping` / `outputMapping`, and the engine emits no parse warning
-for stray zeebe elements there. The child workflow will start with whatever
-the propagation flags pull in (and nothing else).
+for stray service-task-style elements there. The child workflow will start with
+whatever the propagation flags pull in (and nothing else).
 
 If you copy mapping XML from a service task into a call activity, you must
 rename the elements.

--- a/website/src/content/docs/guides/message-correlation.md
+++ b/website/src/content/docs/guides/message-correlation.md
@@ -32,10 +32,10 @@ The canonical XML shape is taken verbatim from `tests/manual/09-message-events/m
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
-             xmlns:zeebe="http://camunda.org/schema/zeebe/1.0">
+             xmlns:fleans="https://fleans.io/schema/bpmn/1.0">
   <message id="msg1" name="approvalReceived">
     <extensionElements>
-      <zeebe:subscription correlationKey="= requestId" />
+      <fleans:subscription correlationKey="= requestId" />
     </extensionElements>
   </message>
   <process id="message-catch-test" isExecutable="true">
@@ -57,12 +57,12 @@ The canonical XML shape is taken verbatim from `tests/manual/09-message-events/m
 
 Three load-bearing details:
 
-1. **The `xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"` namespace declaration** must appear on `<definitions>`. Without it, `<zeebe:subscription>` is parsed as an unknown element and silently ignored (no correlation key, no error).
+1. **The `xmlns:fleans="https://fleans.io/schema/bpmn/1.0"` namespace declaration** must appear on `<definitions>`. Without it, `<fleans:subscription>` is parsed as an unknown element and silently ignored (no correlation key, no error). Files exported from Camunda's modeler may use `xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"` instead — that's also accepted via Fleans's back-compat probe order.
 2. **The `=` prefix** is the Zeebe expression marker. Fleans strips a literal `"= "` (equals-sign + space) at parse time and treats the remainder as a single variable name. The engine does **not** evaluate arbitrary expressions — see [Variable resolution semantics](#variable-resolution-semantics) below.
 3. **Placement of `<extensionElements>` is project-specific** — read the caution that follows.
 
 :::caution[Place `<extensionElements>` inside `<bpmn:message>`, not inside the message-event element]
-Fleans only walks `<extensionElements>` that are **direct children of `<bpmn:message>`** (parser at `BpmnConverter.cs:895-925`). Putting the `<zeebe:subscription>` block under the `<intermediateCatchEvent>` or the `<startEvent>` is **silently ignored** — the engine treats the message as "no correlation key" and your `POST /Workflow/message` will never match.
+Fleans only walks `<extensionElements>` that are **direct children of `<bpmn:message>`** (parser at `BpmnConverter.cs:895-925`). Putting the `<fleans:subscription>` block under the `<intermediateCatchEvent>` or the `<startEvent>` is **silently ignored** — the engine treats the message as "no correlation key" and your `POST /Workflow/message` will never match.
 
 This is the single most common authoring mistake. The pattern is captured as a canonical rule in `CLAUDE.md` under *BPMN Fixture Authoring Rules*. Always check fixture #09 / #21 before authoring a new message-event workflow.
 :::
@@ -110,7 +110,7 @@ public record SendMessageRequest(string MessageName, string? CorrelationKey, Exp
 Field semantics:
 
 - **`MessageName`** (required, **case-sensitive**) — must match the BPMN `<message name="...">` exactly. Capitalization mismatch returns 404.
-- **`CorrelationKey`** (optional) — the runtime string the subscriber's correlation expression resolved to. May be omitted only for messages whose BPMN definition has no `<zeebe:subscription>` (e.g. message start events with no key).
+- **`CorrelationKey`** (optional) — the runtime string the subscriber's correlation expression resolved to. May be omitted only for messages whose BPMN definition has no `<fleans:subscription>` (e.g. message start events with no key).
 - **`Variables`** (optional) — extra variables to merge into the receiving workflow's scope before it resumes. Useful for delivering response payloads (e.g. an `approvalDecision` field).
 
 Responses:
@@ -157,9 +157,10 @@ If you change `req-456` to `req-999` in the third request, the response is `404 
 A workflow kicks off some external work, then waits for the result keyed by a per-instance request id. This is fixture #09's pattern.
 
 ```xml
+<!-- Requires xmlns:fleans="https://fleans.io/schema/bpmn/1.0" on <bpmn:definitions> -->
 <message id="responseMsg" name="serviceResponse">
   <extensionElements>
-    <zeebe:subscription correlationKey="= requestId" />
+    <fleans:subscription correlationKey="= requestId" />
   </extensionElements>
 </message>
 <process id="rpc-pattern" isExecutable="true">
@@ -198,11 +199,12 @@ The process is created **by** the message, not waiting for one. Each unique corr
 A long-running workflow correlates against more than one message at different points. Each correlation value is set by a script task before the relevant catch.
 
 ```xml
+<!-- Requires xmlns:fleans="https://fleans.io/schema/bpmn/1.0" on <bpmn:definitions> -->
 <message id="paymentMsg" name="paymentReceived">
-  <extensionElements><zeebe:subscription correlationKey="= orderId" /></extensionElements>
+  <extensionElements><fleans:subscription correlationKey="= orderId" /></extensionElements>
 </message>
 <message id="shipMsg" name="shipmentDispatched">
-  <extensionElements><zeebe:subscription correlationKey="= shipmentId" /></extensionElements>
+  <extensionElements><fleans:subscription correlationKey="= shipmentId" /></extensionElements>
 </message>
 <process id="order-saga" isExecutable="true">
   <!-- seed orderId on /start, await paymentReceived, allocate shipmentId, await shipmentDispatched -->
@@ -226,7 +228,7 @@ The engine performs a **plain variable lookup**, not expression evaluation. `cor
 </scriptTask>
 <!-- ... then ... -->
 <message id="m" name="something">
-  <extensionElements><zeebe:subscription correlationKey="= compositeKey" /></extensionElements>
+  <extensionElements><fleans:subscription correlationKey="= compositeKey" /></extensionElements>
 </message>
 ```
 :::

--- a/website/src/content/docs/guides/multi-instance-activities.md
+++ b/website/src/content/docs/guides/multi-instance-activities.md
@@ -19,8 +19,8 @@ This guide is the developer's tour, anchored to the runnable fixtures under `tes
 | Situation | Pick this |
 | --- | --- |
 | Run a task exactly *N* times, where *N* is a fixed compile-time number. | Parallel + `<loopCardinality>` |
-| Iterate over a workflow-variable list/array; iterations are independent. | Parallel + `zeebe:collection` |
-| Iterate over a list, but iteration *N+1* must observe iteration *N*'s side effects on the enclosing scope. | Sequential + `zeebe:collection` |
+| Iterate over a workflow-variable list/array; iterations are independent. | Parallel + `fleans:collection` |
+| Iterate over a list, but iteration *N+1* must observe iteration *N*'s side effects on the enclosing scope. | Sequential + `fleans:collection` |
 
 Two short rules of thumb:
 
@@ -32,11 +32,11 @@ Two short rules of thumb:
 Multi-instance configuration lives inside `<bpmn:multiInstanceLoopCharacteristics>` nested in the activity element. Fleans honours four attributes:
 
 - `isSequential="true|false"` — defaults to `false` (parallel).
-- **One of**: `<loopCardinality>N</loopCardinality>` (static count) **or** `zeebe:collection="varName"` (iterate over a workflow variable that resolves to a `List`/array).
-- `zeebe:elementVariable="..."` — names the per-iteration item variable inside the iteration's child scope. Only meaningful with `zeebe:collection`.
-- `zeebe:outputCollection="..."` + `zeebe:outputElement="..."` — names the aggregated output array on the **enclosing** scope and the per-iteration value to harvest from each child scope on completion.
+- **One of**: `<loopCardinality>N</loopCardinality>` (static count) **or** `fleans:collection="varName"` (iterate over a workflow variable that resolves to a `List`/array).
+- `fleans:elementVariable="..."` — names the per-iteration item variable inside the iteration's child scope. Only meaningful with `fleans:collection`.
+- `fleans:outputCollection="..."` + `fleans:outputElement="..."` — names the aggregated output array on the **enclosing** scope and the per-iteration value to harvest from each child scope on completion.
 
-Both bare-name and `zeebe:`-prefixed attributes are accepted by the parser (`zeebe:collection` ↔ `collection`, `zeebe:elementVariable` ↔ `elementVariable`, `zeebe:outputCollection` ↔ `outputCollection`, `zeebe:outputElement` ↔ `outputElement`). The fixtures in this guide use the `zeebe:` prefix to match what the BPMN editor emits.
+Both bare-name and `fleans:`-prefixed attributes are accepted by the parser (`fleans:collection` ↔ `collection`, `fleans:elementVariable` ↔ `elementVariable`, `fleans:outputCollection` ↔ `outputCollection`, `fleans:outputElement` ↔ `outputElement`). The editor and the canonical examples in this guide use the `fleans:` prefix; files exported from Camunda's modeler may use `zeebe:` and parse via the same back-compat probe.
 
 The constructor on `MultiInstanceActivity` (`Fleans.Domain/Activities/MultiInstanceActivity.cs:1-126`) enforces that exactly one of `LoopCardinality` or `InputCollection` is set, and that cardinality is non-negative. Violations throw at deploy time, not at runtime.
 
@@ -45,11 +45,12 @@ The constructor on `MultiInstanceActivity` (`Fleans.Domain/Activities/MultiInsta
 Citation: [`tests/manual/13-multi-instance/parallel-collection.bpmn`](https://github.com/nightBaker/fleans/blob/main/tests/manual/13-multi-instance/parallel-collection.bpmn).
 
 ```xml
+<!-- Requires xmlns:fleans="https://fleans.io/schema/bpmn/1.0" on <bpmn:definitions> -->
 <scriptTask id="processItem" scriptFormat="csharp">
   <script>_context.result = "processed-" + _context.item</script>
   <multiInstanceLoopCharacteristics isSequential="false"
-    zeebe:collection="items" zeebe:elementVariable="item"
-    zeebe:outputCollection="results" zeebe:outputElement="result" />
+    fleans:collection="items" fleans:elementVariable="item"
+    fleans:outputCollection="results" fleans:outputElement="result" />
 </scriptTask>
 ```
 
@@ -77,7 +78,7 @@ Citation: [`tests/manual/13-multi-instance/parallel-cardinality.bpmn`](https://g
 </scriptTask>
 ```
 
-With `<loopCardinality>3</loopCardinality>` and no `zeebe:collection`, three iterations spawn but only `loopCounter` is bound on each child scope — there is no per-iteration item variable. The script body uses `_context.loopCounter` directly to differentiate iterations. After completion `_context.results == ["iter-0", "iter-1", "iter-2"]`.
+With `<loopCardinality>3</loopCardinality>` and no `fleans:collection`, three iterations spawn but only `loopCounter` is bound on each child scope — there is no per-iteration item variable. The script body uses `_context.loopCounter` directly to differentiate iterations. After completion `_context.results == ["iter-0", "iter-1", "iter-2"]`.
 
 This is the right pattern when you need exactly *N* concurrent runs of the same logic and the iterations can be distinguished by index alone (e.g. quorum reads, fanout to *N* identical workers).
 
@@ -86,11 +87,12 @@ This is the right pattern when you need exactly *N* concurrent runs of the same 
 Citation: [`tests/manual/13-multi-instance/sequential-collection.bpmn`](https://github.com/nightBaker/fleans/blob/main/tests/manual/13-multi-instance/sequential-collection.bpmn).
 
 ```xml
+<!-- Requires xmlns:fleans="https://fleans.io/schema/bpmn/1.0" on <bpmn:definitions> -->
 <scriptTask id="processItem" scriptFormat="csharp">
   <script>_context.result = "seq-" + _context.item</script>
   <multiInstanceLoopCharacteristics isSequential="true"
-    zeebe:collection="items" zeebe:elementVariable="item"
-    zeebe:outputCollection="results" zeebe:outputElement="result" />
+    fleans:collection="items" fleans:elementVariable="item"
+    fleans:outputCollection="results" fleans:outputElement="result" />
 </scriptTask>
 ```
 
@@ -142,7 +144,8 @@ Event sub-processes also do not support multi-instance — by BPMN spec, not a F
 `<bpmn:completionCondition>` is fully supported. It lets you finish a multi-instance activity early — before all spawned iterations complete:
 
 ```xml
-<bpmn:multiInstanceLoopCharacteristics zeebe:collection="approvers" zeebe:elementVariable="approver">
+<!-- Requires xmlns:fleans="https://fleans.io/schema/bpmn/1.0" on <bpmn:definitions> -->
+<bpmn:multiInstanceLoopCharacteristics fleans:collection="approvers" fleans:elementVariable="approver">
   <bpmn:completionCondition>_context.nrOfCompletedInstances >= 1</bpmn:completionCondition>
 </bpmn:multiInstanceLoopCharacteristics>
 ```

--- a/website/src/content/docs/guides/user-tasks.md
+++ b/website/src/content/docs/guides/user-tasks.md
@@ -194,7 +194,7 @@ The full error-handling pattern is the subject of the [Error Handling guide (#39
 
 ## Limitations & roadmap
 
-- **`camunda:formKey`, `dueDate`, `zeebe:assignmentDefinition` not honoured today.** Each is parsed by `BpmnConverter.cs` but has no engine wiring; document them in your BPMN for future-tool readers but do not rely on them at runtime.
+- **Several attributes are parsed but not honoured today.** See the *Recognised attributes* table above for the complete list (currently `camunda:formKey`, `dueDate`, and the Camunda-export `zeebe:assignmentDefinition`). Each is read by the parser but has no engine wiring; document them in your BPMN for future-tool readers but do not rely on them at runtime.
 - **`candidateGroups` is advisory (filter-only).** It scopes the `GET /Workflow/tasks?candidateGroup=…` response so a UI can show the right inbox, but it does **not** prevent a non-member from claiming a task they got the `activityInstanceId` for some other way. Enforce group membership at the front-end or gateway.
 - **Unclaim accepts any caller.** Enforce ownership in your front-end / gateway. Do not rely on the engine to refuse cross-user unclaims.
 - **Claim is not exclusive.** Any caller authorized per [Who can claim?](#who-can-claim) can `claim` a task that is already in the `Claimed` state; the previous `claimedBy` is silently overwritten without a 409 or a domain event distinguishing it from a fresh claim. If your workflow needs first-claim-wins semantics, enforce it in the front-end / API gateway by gating `claim` calls on `task.state == "Created"` from the read model.

--- a/website/src/content/docs/guides/writing-custom-tasks.mdx
+++ b/website/src/content/docs/guides/writing-custom-tasks.mdx
@@ -42,14 +42,15 @@ If your situation isn't on this list, lean toward external completion — it's t
 A trivial "say hello" plugin. The workflow author writes:
 
 ```xml
+<!-- Requires xmlns:fleans="https://fleans.io/schema/bpmn/1.0" on <bpmn:definitions> -->
 <bpmn:serviceTask id="greet" type="hello">
   <bpmn:extensionElements>
-    <zeebe:taskDefinition type="hello" />
-    <zeebe:ioMapping>
-      <zeebe:input  source="=customerName"     target="name" />
-      <zeebe:input  source="true"              target="excitement" />
-      <zeebe:output source="=__response.text"  target="greeting" />
-    </zeebe:ioMapping>
+    <fleans:taskDefinition type="hello" />
+    <fleans:ioMapping>
+      <fleans:input  source="=customerName"     target="name" />
+      <fleans:input  source="true"              target="excitement" />
+      <fleans:output source="=__response.text"  target="greeting" />
+    </fleans:ioMapping>
   </bpmn:extensionElements>
 </bpmn:serviceTask>
 ```
@@ -322,11 +323,11 @@ URLs use plain HTTP because the compose bundle does not terminate TLS — front 
 
 Open `http://localhost:8080/editor`. Drag a Service Task onto the canvas and click it.
 
-In the right-hand properties panel, find the "Plugin (custom task)" dropdown and pick **Say hello (hello)**. The editor seeds the defaults — your task now has `<zeebe:input source="world" target="name"/>` and `<zeebe:input source="false" target="excitement"/>` written under `<zeebe:ioMapping>`.
+In the right-hand properties panel, find the "Plugin (custom task)" dropdown and pick **Say hello (hello)**. The editor seeds the defaults — your task now has `<fleans:input source="world" target="name"/>` and `<fleans:input source="false" target="excitement"/>` written under `<fleans:ioMapping>`.
 
 Type `=customerName` into the `name` field. The help text under each primitive widget reminds you the field accepts either a literal value or `=variableName`. Toggle `excitement` on with the checkbox.
 
-Add an `<zeebe:output source="=__response.text" target="greeting"/>` row by editing the BPMN XML directly (the editor's UI for output mappings is shared with `expectedOutputs` on User Tasks; see [BPMN Editor](/guides/editor/)).
+Add an `<fleans:output source="=__response.text" target="greeting"/>` row by editing the BPMN XML directly (the editor's UI for output mappings is shared with `expectedOutputs` on User Tasks; see [BPMN Editor](/guides/editor/)).
 
 Save the diagram. The BPMN XML now contains the snippet from the [What you'll build](#what-youll-build) section above.
 
@@ -376,10 +377,10 @@ Three common causes:
 
 The exception's first argument is a string for the code (`"400"`, `"503"`, etc.). Boundary error events match by `errorCode` string equality, so authors typically choose HTTP-shaped codes. Codes outside `[100, 599]` will surface but won't be matched by HTTP-style boundary events.
 
-**`<zeebe:input>` not parsed at deploy time.**
+**`<fleans:input>` not parsed at deploy time.**
 
 Two possible causes:
-1. The BPMN file is missing `xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"` on `<bpmn:definitions>`. Add the namespace declaration.
+1. The BPMN file is missing `xmlns:fleans="https://fleans.io/schema/bpmn/1.0"` on `<bpmn:definitions>`. Add the namespace declaration. (Files exported from Camunda's modeler may use `xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"` instead — that's also accepted via Fleans's back-compat probe order.)
 2. The `target` attribute isn't a valid identifier (`^[a-zA-Z_][a-zA-Z0-9_]*$`). Rename or fix the typo.
 
 **Catalog shows the plugin on a stopped silo.**


### PR DESCRIPTION
## Summary

Migrates the 7 website doc files that documented BPMN extensions with the legacy `zeebe:` prefix to use the canonical `fleans:` prefix at the 1.0 URI (`https://fleans.io/schema/bpmn/1.0`), matching what the editor emits and what `CLAUDE.md` flags as the canonical authoring form.

Per-file occurrence partition (verified against `main` before edits):

| File | Outside-DRIFT-GUARD (in scope) | In DRIFT-GUARD (out — owned by #634) |
|---|---|---|
| `guides/multi-instance-activities.md` | 24 → 1 (intentional back-compat) | 0 |
| `concepts/custom-tasks.md` | 15 → 1 (intentional back-compat) | 0 |
| `guides/writing-custom-tasks.mdx` | 11 → 0 (back-compat carried as `xmlns:zeebe=`) | 0 |
| `guides/message-correlation.md` | 8 → 0 (back-compat carried as `xmlns:zeebe=`) | 1 |
| `concepts/activities/tasks.mdx` | 7 → 0 | 0 |
| `guides/call-activities-and-subprocesses.md` | 5 → 2 (intentional, in (c3) `:::caution`) | 2 |
| `guides/user-tasks.md` | 2 → 2 (table cell + roadmap, documenting parsed-but-ignored attribute) | 0 |
| **TOTAL** | **72 → 6** | **3** |

Approach follows the round-2 design comment (a)/(b)/(c1)/(c2)/(c3) audit categories:

- **(a) BPMN snippets inside `<bpmn:definitions xmlns:zeebe=…>` code-fence**: flip both the namespace declaration AND the inline prefixes. URI changes from `http://camunda.org/schema/zeebe/1.0` → `https://fleans.io/schema/bpmn/1.0`.
- **(b) Inline-fragment BPMN snippets (no `<definitions>` root)**: flip to `fleans:` and add a comment line indicating `xmlns:fleans=` is required on the consumer's `<bpmn:definitions>`.
- **(c1) Troubleshooting tips, (c2) back-compat policy explanations, (c3) `:::caution` callouts**: rewrite as canonical `fleans:`, with a Camunda-export back-compat parenthetical so users with operator-supplied `zeebe:`-prefixed BPMN aren't stranded.

`guides/multi-instance-activities.md:39` had a stale claim that "the BPMN editor emits `zeebe:`" — rewritten to reflect the canonical `fleans:` form per CLAUDE.md line 159.

## Scope honesty

- **DRIFT-GUARD blocks NOT touched.** The 3 `zeebe:` occurrences inside `<!-- DRIFT-GUARD: -->` blocks (2 in `call-activities-and-subprocesses.md` line 10, 1 in `message-correlation.md` line 9) are owned by #634 Phase 2 (block-level removal). This PR explicitly skips them.
- **No `tests/manual/**/*.bpmn` fixtures modified.** Back-compat regression coverage preserved. Verified via `git diff --stat origin/main..HEAD -- 'tests/manual/**/*.bpmn'` returns empty.
- **`CLAUDE.md` lines 90, 155, 159 untouched** — those are authoritative descriptions of the back-compat policy, not prescriptive examples to migrate.
- **`tools/website-pin-allowlist.txt` not touched.** Hard prerequisite #635 (Phase 0 CI guard) has not merged yet; per the round-2 plan's coordination section, when #635 doesn't merge first, #623 ships without coordinating with the allow-list. #635's allow-list regeneration job will inherit the post-`fleans:` content when it rebases.

## Test plan

- [x] `grep -rE '\bzeebe:' website/src/content/docs/` returns 9 matches: 3 in-DRIFT-GUARD (#634-owned) + 6 intentional Camunda-export back-compat parentheticals (acceptance #8). All 72 mechanical migrations done.
- [x] `xmlns:zeebe=` declarations in code-fenced BPMN snippets all flipped to `xmlns:fleans=`. The 2 remaining `xmlns:zeebe=` mentions live in prose troubleshooting tips as back-compat parentheticals.
- [x] `guides/multi-instance-activities.md:39` no longer claims the editor emits `zeebe:`.
- [x] `npm run build` clean — 31 pages built in 2.22s with no errors.
- [x] `git diff --stat origin/main..HEAD -- 'tests/manual/**/*.bpmn'` returns empty (back-compat regression fixtures preserved).
- [x] `CLAUDE.md` untouched.

Closes #623.

🤖 Generated with [Claude Code](https://claude.com/claude-code)