### PR TITLE
feat(#654): catch child-workflow start failures + fail parent activity

### DIFF
--- a/src/Fleans/Fleans.Application.Tests/ChildWorkflowStartFailureTests.cs
+++ b/src/Fleans/Fleans.Application.Tests/ChildWorkflowStartFailureTests.cs
@@ -1,0 +1,58 @@
+using Fleans.Application.Grains;
+using Fleans.Domain;
+using Fleans.Domain.Activities;
+using Fleans.Domain.Sequences;
+
+namespace Fleans.Application.Tests;
+
+[TestClass]
+public class ChildWorkflowStartFailureTests : WorkflowTestBase
+{
+    [TestMethod]
+    public async Task ChildWorkflowStart_DefinitionLoadFails_FailsParentCallActivity()
+    {
+        // Arrange — parent workflow with a CallActivity pointing at a process key
+        // that was never deployed. IProcessDefinitionGrain.GetLatestDefinition()
+        // throws KeyNotFoundException. The safety-net catch in
+        // WorkflowLifecycleEffectHandler.PerformStartChildWorkflow must route
+        // this through IEffectContext.ProcessFailureEffects so the parent
+        // activity is failed rather than the grain turn exploding.
+        var parentStart = new StartEvent("start");
+        var call1 = new CallActivity("call1", "nonExistentChildProcess", [], []);
+        var parentEnd = new EndEvent("end");
+
+        var parentWorkflow = new WorkflowDefinition
+        {
+            WorkflowId = "parentProcessFailingChildStart",
+            Activities = [parentStart, call1, parentEnd],
+            SequenceFlows =
+            [
+                new SequenceFlow("ps1", parentStart, call1),
+                new SequenceFlow("ps2", call1, parentEnd)
+            ]
+        };
+
+        var parentProcessGrain = Cluster.GrainFactory.GetGrain<IProcessDefinitionGrain>(
+            "parentProcessFailingChildStart");
+        await parentProcessGrain.DeployVersion(parentWorkflow, "<xml/>");
+
+        var parentInstance = await parentProcessGrain.CreateInstance();
+        var parentInstanceId = parentInstance.GetPrimaryKey();
+
+        // Act — start parent. Without the safety net this would propagate the
+        // KeyNotFoundException to the caller and leave the parent wedged.
+        await parentInstance.StartWorkflow();
+
+        // Assert — the call activity must end up failed (in CompletedActivities
+        // with ErrorState set), and the grain must remain queryable.
+        var snapshot = await QueryService.GetStateSnapshot(parentInstanceId);
+        Assert.IsNotNull(snapshot, "Parent state snapshot should exist after the safety net catches the child-start failure");
+
+        var failedCall = snapshot.CompletedActivities
+            .FirstOrDefault(a => a.ActivityId == "call1");
+        Assert.IsNotNull(failedCall, "call1 should be in CompletedActivities after the child-start failure");
+        Assert.IsNotNull(failedCall.ErrorState, "call1 must carry an ErrorState reflecting the child-start failure");
+        Assert.IsFalse(string.IsNullOrEmpty(failedCall.ErrorState.Message),
+            "ErrorState.Message should describe the child-start failure");
+    }
+}

--- a/src/Fleans/Fleans.Application/Effects/WorkflowLifecycleEffectHandler.cs
+++ b/src/Fleans/Fleans.Application/Effects/WorkflowLifecycleEffectHandler.cs
@@ -57,23 +57,42 @@ public partial class WorkflowLifecycleEffectHandler : IEffectHandler
 
     private async Task PerformStartChildWorkflow(StartChildWorkflowEffect startChild, IEffectContext context)
     {
-        var processGrain = context.GrainFactory.GetGrain<IProcessDefinitionGrain>(startChild.ProcessDefinitionKey);
-        var childDefinition = await processGrain.GetLatestDefinition();
+        try
+        {
+            var processGrain = context.GrainFactory.GetGrain<IProcessDefinitionGrain>(startChild.ProcessDefinitionKey);
+            var childDefinition = await processGrain.GetLatestDefinition();
 
-        var child = context.GrainFactory.GetGrain<IWorkflowInstanceGrain>(startChild.ChildInstanceId);
+            var child = context.GrainFactory.GetGrain<IWorkflowInstanceGrain>(startChild.ChildInstanceId);
 
-        LogStartingChildWorkflow(startChild.ProcessDefinitionKey, startChild.ChildInstanceId);
+            LogStartingChildWorkflow(startChild.ProcessDefinitionKey, startChild.ChildInstanceId);
 
-        await child.SetWorkflow(childDefinition);
-        await child.SetParentInfo(context.WorkflowInstanceId, startChild.ParentActivityId);
+            await child.SetWorkflow(childDefinition);
+            await child.SetParentInfo(context.WorkflowInstanceId, startChild.ParentActivityId);
 
-        if (((IDictionary<string, object?>)startChild.InputVariables).Count > 0)
-            await child.SetInitialVariables(startChild.InputVariables);
+            if (((IDictionary<string, object?>)startChild.InputVariables).Count > 0)
+                await child.SetInitialVariables(startChild.InputVariables);
 
-        await child.StartWorkflow();
+            await child.StartWorkflow();
+        }
+        catch (Exception ex)
+        {
+            LogChildStartFailed(
+                context.WorkflowInstanceId,
+                startChild.ChildInstanceId,
+                startChild.ProcessDefinitionKey,
+                ex.Message);
+            await context.ProcessFailureEffects(
+                startChild.ParentActivityId,
+                startChild.ParentActivityInstanceId,
+                ex);
+        }
     }
 
     [LoggerMessage(EventId = 1013, Level = LogLevel.Information,
         Message = "Starting child workflow: CalledProcessKey={CalledProcessKey}, ChildId={ChildId}")]
     private partial void LogStartingChildWorkflow(string calledProcessKey, Guid childId);
+
+    [LoggerMessage(EventId = 4070, Level = LogLevel.Error,
+        Message = "Child workflow start failed (parent={ParentInstanceId}, child={ChildInstanceId}, definition={DefinitionKey}): {Reason}")]
+    private partial void LogChildStartFailed(Guid parentInstanceId, Guid childInstanceId, string definitionKey, string reason);
 }

--- a/src/Fleans/Fleans.Domain.Tests/InfrastructureEffectsTests.cs
+++ b/src/Fleans/Fleans.Domain.Tests/InfrastructureEffectsTests.cs
@@ -18,7 +18,7 @@ public class InfrastructureEffectsTests
             new SubscribeSignalEffect("sig", Guid.NewGuid(), "act1", Guid.NewGuid()),
             new UnsubscribeSignalEffect("sig", Guid.NewGuid(), "act1"),
             new ThrowSignalEffect("sig"),
-            new StartChildWorkflowEffect(Guid.NewGuid(), "process-key", new System.Dynamic.ExpandoObject(), "callAct"),
+            new StartChildWorkflowEffect(Guid.NewGuid(), "process-key", new System.Dynamic.ExpandoObject(), "callAct", Guid.NewGuid()),
             new NotifyParentCompletedEffect(Guid.NewGuid(), "parentAct", new System.Dynamic.ExpandoObject()),
             new NotifyParentFailedEffect(Guid.NewGuid(), "parentAct", new Exception("err")),
             new PublishDomainEventEffect(new WorkflowCompleted()),

--- a/src/Fleans/Fleans.Domain/Aggregates/WorkflowExecution.cs
+++ b/src/Fleans/Fleans.Domain/Aggregates/WorkflowExecution.cs
@@ -1197,7 +1197,8 @@ public class WorkflowExecution
 
         return new StartChildWorkflowEffect(
             childInstanceId, callActivity.CalledProcessKey,
-            inputVariables, callActivity.ActivityId);
+            inputVariables, callActivity.ActivityId,
+            activityInstanceId);
     }
 
     private IInfrastructureEffect ProcessEvaluateActivationCondition(

--- a/src/Fleans/Fleans.Domain/Effects/InfrastructureEffects.cs
+++ b/src/Fleans/Fleans.Domain/Effects/InfrastructureEffects.cs
@@ -32,7 +32,8 @@ public record ThrowSignalEffect(string SignalName) : IInfrastructureEffect;
 // Child workflows
 public record StartChildWorkflowEffect(
     Guid ChildInstanceId, string ProcessDefinitionKey,
-    ExpandoObject InputVariables, string ParentActivityId) : IInfrastructureEffect;
+    ExpandoObject InputVariables, string ParentActivityId,
+    Guid ParentActivityInstanceId) : IInfrastructureEffect;
 
 // Parent notifications
 public record NotifyParentCompletedEffect(


### PR DESCRIPTION
## Summary

Adds a safety net so child-workflow start failures fail the parent CallActivity instead of escaping the grain turn and wedging the parent. PR A of the #654 two-part plan ([round-2 design](https://github.com/nightBaker/fleans/issues/654#issuecomment-4503578197), [round-2 review verdict Ready](https://github.com/nightBaker/fleans/issues/654#issuecomment-4503620466)).

Closes #654 (PR A scope only — see "Follow-up" below).

## What changed

- `WorkflowLifecycleEffectHandler.PerformStartChildWorkflow` now wraps the entire spawn sequence (`GetLatestDefinition` → `SetWorkflow` → `SetParentInfo` → `SetInitialVariables` → `StartWorkflow`) in `try/catch`. On any throw, the handler calls `IEffectContext.ProcessFailureEffects(parentActivityId, parentActivityInstanceId, ex)` — the canonical fail-from-handler API verified at `IEffectContext.cs` (xmldoc explicitly endorses the recursive Handler → FailActivity → new effects → DispatchAsync pattern).
- `StartChildWorkflowEffect` gains a `Guid ParentActivityInstanceId` field so the fail-path can target the exact in-flight activity instance (needed for multi-instance CallActivity scenarios where the same BPMN-level activity id has multiple in-flight instances).
- Single emit site at `WorkflowExecution.cs:1198` passes `activityInstanceId` (the method parameter — confirmed in scope via inline-verification per round-2 review 🟢 #1).
- `LogChildStartFailed` partial method at EventId 4070 — verified no collision in the 4000-4099 "Event handlers" range (used: 4000-4006, 4010-4015, 4020-4026, 4030-4037, 4050).
- Unit test `ChildWorkflowStartFailureTests.cs` covers the definition-load-fails path: parent CallActivity points at a never-deployed process key → `GetLatestDefinition` throws `KeyNotFoundException` → catch routes through `ProcessFailureEffects` → parent's `call1` ends up in `CompletedActivities` with `ErrorState` set, and the grain remains queryable.

## Persistence flow (confirmed in round-2 review)

`ProcessFailureEffects` doesn't call `PersistStateAsync` directly. Persistence is handled by the outer grain method (e.g. `WorkflowInstance.FailActivity`, `StartWorkflow`, etc.) via the mandatory post-effects `RunExecutionLoop()` + `ProcessPendingEvents()` calls. This matches the existing recursive-failure pattern used by other effect handlers — no explicit persist needed in the catch.

## Test results

- New test: `ChildWorkflowStartFailureTests.ChildWorkflowStart_DefinitionLoadFails_FailsParentCallActivity` — **passed**.
- CallActivityTests (7 tests, regression baseline) — **all passed**.
- Fleans.Application.Tests full suite — **323 passed, 0 failed, 6 pre-existing skips**.
- Fleans.Domain.Tests full suite — **440 passed, 0 failed**.

## Test plan

- [ ] CI rollup green
- [ ] Manual smoke: deploy a parent workflow with a CallActivity pointing at an undeployed `calledProcessKey`; start the parent; confirm the parent's call activity appears in CompletedActivities with `ErrorState` and the grain stays responsive (no exception bubble-up to caller).

## Follow-up

PR B — the durable-retry path (stream-deliverable child workflow start, Option 4 from #654 round-1 matrix). Will be filed as a separate issue at this PR's merge time, since today's catch is purely additive: it converts a previously-thrown-to-caller exception into a clean failed-activity state, but doesn't yet add retry semantics. Out of scope for this safety-net PR per round-2 plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
