### PR TITLE
test(#652): verify every grain command appends events to journal

### DIFF
--- a/src/Fleans/Fleans.Application.Tests/EventStoreDurabilityTests.cs
+++ b/src/Fleans/Fleans.Application.Tests/EventStoreDurabilityTests.cs
@@ -1,0 +1,139 @@
+using Fleans.Application.Grains;
+using Fleans.Domain;
+using Fleans.Domain.Activities;
+using Fleans.Domain.Sequences;
+using Fleans.Persistence;
+using Microsoft.EntityFrameworkCore;
+using System.Dynamic;
+
+namespace Fleans.Application.Tests;
+
+[TestClass]
+public class EventStoreDurabilityTests : WorkflowTestBase
+{
+    /// <summary>
+    /// #652 — proves the load-bearing durability invariant: every confirmed
+    /// batch of domain events round-trips to the WorkflowEvents journal
+    /// before the grain method returns. If any confirm were buffered in
+    /// memory and not persisted, an ungraceful kill would lose those events
+    /// and reactivation would replay an incomplete journal.
+    ///
+    /// Approach: drive the grain through several public methods. After each
+    /// call, count rows in WorkflowEvents by grain id via a separate
+    /// IDbContextFactory&lt;FleanCommandDbContext&gt; (same shared in-memory
+    /// SQLite the grain writes to). Three layered assertions cover three
+    /// bug classes:
+    ///   • strict monotonicity → catches "ConfirmEvents skipped the append"
+    ///   • contiguous 1..N version sequence → catches "ConfirmEvents skipped
+    ///     a version" (pure count comparisons would miss)
+    ///   • max-version == row-count → catches duplicate-version bugs
+    ///
+    /// Why this and not a silo-restart test: cycles 69 and 73 documented two
+    /// orthogonal failures in the silo-restart framing
+    /// (`TestCluster.KillSiloAsync` destroys membership; deleting the
+    /// snapshot row then reactivating hangs 30s). The row-count check covers
+    /// the actual load-bearing property without inviting those infrastructure
+    /// failure modes.
+    /// </summary>
+    [TestMethod]
+    public async Task GrainCommands_PersistEventsToJournal()
+    {
+        // Arrange — 3-task sequential workflow
+        var start = new StartEvent("start");
+        var task1 = new TaskActivity("task1");
+        var task2 = new TaskActivity("task2");
+        var end = new EndEvent("end");
+        var workflow = new WorkflowDefinition
+        {
+            WorkflowId = "durability-invariant-workflow",
+            Activities = [start, task1, task2, end],
+            SequenceFlows =
+            [
+                new SequenceFlow("seq1", start, task1),
+                new SequenceFlow("seq2", task1, task2),
+                new SequenceFlow("seq3", task2, end),
+            ]
+        };
+
+        var instanceId = Guid.NewGuid();
+        var grain = Cluster.GrainFactory.GetGrain<IWorkflowInstanceGrain>(instanceId);
+        // grainKey format matches WorkflowInstance.cs:119/146/171:
+        //     var grainId = this.GetPrimaryKey().ToString();
+        var grainKey = instanceId.ToString();
+        var dbContextFactory = GetSiloService<IDbContextFactory<FleanCommandDbContext>>();
+
+        async Task<int> EventCount()
+        {
+            await using var db = await dbContextFactory.CreateDbContextAsync();
+            return await db.WorkflowEvents.CountAsync(e => e.GrainId == grainKey);
+        }
+
+        async Task<int> MaxVersion()
+        {
+            await using var db = await dbContextFactory.CreateDbContextAsync();
+            var query = db.WorkflowEvents.Where(e => e.GrainId == grainKey);
+            return await query.AnyAsync() ? await query.MaxAsync(e => e.Version) : 0;
+        }
+
+        // Act + Assert — every grain method call that confirms events must
+        // grow the row count. The exact per-call event counts are
+        // implementation-defined; we lock in strict monotonicity, not
+        // specific numbers.
+
+        Assert.AreEqual(0, await EventCount(), "no events before any grain method");
+
+        // SetWorkflow may or may not emit events (pure-setter is plausible);
+        // tolerate both. The load-bearing assertions come next.
+        await grain.SetWorkflow(workflow);
+        int afterSet = await EventCount();
+        Assert.IsTrue(afterSet >= 0,
+            $"row count never negative (got {afterSet})");
+
+        await grain.StartWorkflow();
+        int afterStart = await EventCount();
+        Assert.IsTrue(afterStart > afterSet,
+            $"StartWorkflow must append events to the journal " +
+            $"(afterSet={afterSet}, afterStart={afterStart})");
+
+        await grain.CompleteActivity("task1", new ExpandoObject());
+        int afterTask1 = await EventCount();
+        Assert.IsTrue(afterTask1 > afterStart,
+            $"CompleteActivity(task1) must append events " +
+            $"(afterStart={afterStart}, afterTask1={afterTask1})");
+
+        await grain.CompleteActivity("task2", new ExpandoObject());
+        int afterTask2 = await EventCount();
+        Assert.IsTrue(afterTask2 > afterTask1,
+            $"CompleteActivity(task2) must append events " +
+            $"(afterTask1={afterTask1}, afterTask2={afterTask2})");
+
+        // The journal must form a contiguous 0..N-1 version sequence
+        // (`WorkflowInstance.ApplyUpdatesToStorage` passes the pre-confirm
+        // version as the starting version; first event therefore has
+        // Version=0). A skipped version would still satisfy the count
+        // growth above, but replay would later reconstruct an incomplete
+        // state.
+        await using (var db = await dbContextFactory.CreateDbContextAsync())
+        {
+            var versions = await db.WorkflowEvents
+                .Where(e => e.GrainId == grainKey)
+                .OrderBy(e => e.Version)
+                .Select(e => e.Version)
+                .ToListAsync();
+            Assert.AreEqual(afterTask2, versions.Count,
+                "row count must match version count");
+            for (int i = 0; i < versions.Count; i++)
+            {
+                Assert.AreEqual(i, versions[i],
+                    $"versions must form a contiguous 0..N-1 sequence; " +
+                    $"gap at index {i}: expected {i}, got {versions[i]}");
+            }
+        }
+
+        // Max version equals (row count - 1) for 0-indexed versions —
+        // catches duplicate-version bugs that would slip past the
+        // contiguous-sequence assertion (e.g., the grain confirms a version
+        // twice and the second insert silently overwrites or duplicates).
+        Assert.AreEqual(afterTask2 - 1, await MaxVersion());
+    }
+}


### PR DESCRIPTION
## Summary

Adds an integration test that proves the load-bearing durability invariant from #652: **every confirmed batch of domain events round-trips to the `WorkflowEvents` journal before the grain method returns.** If any confirm were buffered in memory and not persisted, an ungraceful kill would lose those events and reactivation would replay an incomplete journal.

This is option (B) from the [cycle 69 dev-flaw matrix](https://github.com/nightBaker/fleans/issues/652#issuecomment-4504095479), chosen in [round 4](https://github.com/nightBaker/fleans/issues/652#issuecomment-4504356902) after cycles 69 + 73 found two orthogonal failures in the silo-kill framing.

Closes #652.

## What changed

One new test file, no production changes:

- `src/Fleans/Fleans.Application.Tests/EventStoreDurabilityTests.cs` (139 LoC).
  - `GrainCommands_PersistEventsToJournal` drives a 3-task sequential workflow through `SetWorkflow → StartWorkflow → CompleteActivity(task1) → CompleteActivity(task2)`. After each call, opens a separate `IDbContextFactory<FleanCommandDbContext>` via the existing `GetSiloService<T>()` helper and counts rows in `WorkflowEvents` by grain id.

## Three layered assertions

| Assertion | Catches |
|---|---|
| **Strict monotonicity** (`afterStart > afterSet`, etc.) | "ConfirmEvents skipped the append" |
| **Contiguous 0..N-1 version sequence** | "ConfirmEvents skipped a version" — versions are 0-indexed per `WorkflowInstance.ApplyUpdatesToStorage` (confirmed empirically during implementation) |
| **`MaxVersion == row-count - 1`** | Duplicate-version bugs that slip past the sequence check |

## Empirical findings during implementation

These are noted in the commit message and captured in test comments:

- **`SetWorkflow` is a pure setter** — emits no events. The test tolerates both behaviors (`afterSet >= 0`) and locks load-bearing monotonicity only at grain methods known to confirm events. This addressed [round-4 review 🟢 #1](https://github.com/nightBaker/fleans/issues/652#issuecomment-4504400738).
- **Versions are 0-indexed**, not 1-indexed as the original round-4 plan assumed. The first event has `Version = 0` because `ApplyUpdatesToStorage` passes the pre-confirm version as the starting version. Caught by the initial test run; assertion updated to `expected i`, `MaxVersion == count - 1`. Updates the round-4 plan's implicit assumption.
- **`AppendEventsAsync` commits writes immediately** on `SaveChangesAsync` (no transaction-batch deferral), so mid-test reads via a separate DbContext see committed rows.

## What this PR does NOT cover (intentional)

- **True ungraceful silo kill.** Cycle 69 found `TestCluster.KillSiloAsync(primary)` destroys the in-memory membership table; `StartAdditionalSiloAsync` then hangs 5 min on `RefreshInternal` retries. The row-count check covers the actually-load-bearing invariant ("events persist before the grain method returns") without inviting that infrastructure failure mode. A multi-silo or Redis-clustering follow-up could prove cluster-side reactivation routing — that's a different, also valuable property and would warrant its own issue.
- **Post-snapshot replay path.** Cycle 73's option-C attempt (delete snapshot row, force pure journal replay) hung 30s on `ReadStateFromStorage` for reasons that weren't root-caused. The row-count test makes that path unnecessary.
- **`ProjectStateAsync` write invariant.** Round-4 review 🟢 #4 suggested also asserting `QueryService.GetStateSnapshot` non-null after each call to additionally exercise the projection write path. Out of scope for this PR; potential follow-up.

## Test results

- New test passes: `GrainCommands_PersistEventsToJournal` — **passed** (3s).
- Existing `EventSourcingIntegrationTests` regression baseline — **6/6 passed** (22s).

## Test plan

- [ ] CI green.
- [ ] Maintainer review confirms the row-count framing covers the original #652 concern adequately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
