### PR TITLE
fix(#656): enable SQLite WAL journal_mode on schema init

### DIFF
--- a/src/Fleans/Fleans.Persistence.Sqlite/SqliteSchemaInitializer.cs
+++ b/src/Fleans/Fleans.Persistence.Sqlite/SqliteSchemaInitializer.cs
@@ -28,5 +28,39 @@ public static class SqliteSchemaInitializer
         {
             // Tables already created by a concurrent process sharing the same SQLite file.
         }
+
+        // Enable WAL once. Sticky across connections via the database header — subsequent
+        // opens on any thread or process see the file in WAL mode without re-running the
+        // pragma. Idempotent: re-running on an already-WAL file is a no-op.
+        //
+        // PRAGMA returns the resulting mode as a 1-row result set, so we use ExecuteScalar
+        // (not ExecuteNonQuery — some provider versions treat that as undefined behaviour
+        // for PRAGMA).
+        //
+        // busy_timeout intentionally NOT set here: Microsoft.Data.Sqlite already defaults
+        // SqliteCommand.CommandTimeout to 30s and internally calls sqlite3_busy_timeout
+        // before each command. The PRAGMA-level setting would be per-connection and not
+        // worth the maintenance cost given the provider default suffices.
+        var conn = (SqliteConnection)database.GetDbConnection();
+        var wasClosed = conn.State != System.Data.ConnectionState.Open;
+        try
+        {
+            if (wasClosed) conn.Open();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "PRAGMA journal_mode=WAL;";
+            _ = cmd.ExecuteScalar(); // returns "wal" for file-backed, "memory" for in-memory — we don't care which
+        }
+        catch (SqliteException ex)
+        {
+            // Likely an in-memory or read-only DB. WAL doesn't apply to those; safe to
+            // proceed. Surface the message so a misconfigured writable DB (e.g.,
+            // directory permission lost between deploys) isn't silently downgraded to
+            // DELETE-mode journaling.
+            Console.Error.WriteLine($"[Fleans] WARNING: Failed to set journal_mode=WAL: {ex.Message}");
+        }
+        finally
+        {
+            if (wasClosed && conn.State == System.Data.ConnectionState.Open) conn.Close();
+        }
     }
 }

--- a/src/Fleans/Fleans.Persistence.Tests/SqlitePragmaTests.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/SqlitePragmaTests.cs
@@ -1,0 +1,72 @@
+using Fleans.Persistence.Events;
+using Fleans.Persistence.Sqlite;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace Fleans.Persistence.Tests;
+
+/// <summary>
+/// #656 — verifies <c>SqliteSchemaInitializer.EnsureCreatedIgnoreRaces</c> sets
+/// <c>PRAGMA journal_mode=WAL</c> on file-backed databases and silently no-ops
+/// (without throwing) on in-memory databases where WAL is inapplicable.
+/// </summary>
+[TestClass]
+public class SqlitePragmaTests
+{
+    [TestMethod]
+    public void EnsureCreatedIgnoreRaces_SetsWalJournalMode_OnFileBackedDb()
+    {
+        // Arrange — real temp file. In-memory would no-op the pragma ("memory" mode)
+        // and not exercise WAL persistence in the file header.
+        var dbPath = Path.GetTempFileName();
+        try
+        {
+            using (var ctx = new FleanCommandDbContext(
+                new DbContextOptionsBuilder<FleanCommandDbContext>()
+                    .UseFleansSqlite($"DataSource={dbPath}")
+                    .Options))
+            {
+                SqliteSchemaInitializer.EnsureCreatedIgnoreRaces(ctx.Database);
+            }
+
+            // Open a *fresh* connection (not reusing the ctx that ran the pragma)
+            // to prove WAL persisted in the file header, not just in the connection
+            // that set it.
+            using var verifyConn = new SqliteConnection($"DataSource={dbPath}");
+            verifyConn.Open();
+            using var cmd = verifyConn.CreateCommand();
+            cmd.CommandText = "PRAGMA journal_mode;";
+            var mode = (string?)cmd.ExecuteScalar();
+            Assert.AreEqual("wal", mode, ignoreCase: true);
+        }
+        finally
+        {
+            // Microsoft.Data.Sqlite pools connections per connection-string. On Windows
+            // the file handle stays held even after Dispose, so File.Delete fails with
+            // "process cannot access the file". Clearing the pool releases the handles.
+            SqliteConnection.ClearAllPools();
+
+            // WAL creates -wal and -shm sidecar files. Clean all three.
+            foreach (var suffix in new[] { "", "-wal", "-shm" })
+                if (File.Exists(dbPath + suffix)) File.Delete(dbPath + suffix);
+        }
+    }
+
+    [DataTestMethod]
+    [DataRow("DataSource=:memory:")]
+    [DataRow("DataSource=file::memory:?cache=shared")]
+    public void EnsureCreatedIgnoreRaces_DoesNotThrow_OnInMemoryDb(string connStr)
+    {
+        // In-memory DBs return "memory" (not "wal") from PRAGMA journal_mode=WAL.
+        // The helper must not throw on that case. Both common in-memory forms are
+        // covered: bare `:memory:` and the shared-cache form used by WorkflowTestBase.
+        using var ctx = new FleanCommandDbContext(
+            new DbContextOptionsBuilder<FleanCommandDbContext>()
+                .UseFleansSqlite(connStr)
+                .Options);
+
+        SqliteSchemaInitializer.EnsureCreatedIgnoreRaces(ctx.Database);
+        // No assertion needed beyond "did not throw" — the in-memory case has no
+        // file header to verify, and the helper's contract here is just "don't crash".
+    }
+}


### PR DESCRIPTION
## Summary

Enables SQLite **WAL journal mode** on schema init so the shared SQLite file used by Api and Web concurrently doesn't have writers blocking readers under load. Round-2 plan from [#656](https://github.com/nightBaker/fleans/issues/656).

Closes #656.

## What changed

Two files, no production-code touched outside `Fleans.Persistence.Sqlite`:

- **`SqliteSchemaInitializer.cs`** — `EnsureCreatedIgnoreRaces` now runs `PRAGMA journal_mode=WAL` once via direct `SqliteCommand` + `ExecuteScalar` after `EnsureCreated`. WAL is sticky in the database file header — every subsequent connection sees the file in WAL mode without re-running the pragma. Idempotent.
- **`SqlitePragmaTests.cs`** (new) — three test methods.

## Key design decisions

### Why `ExecuteScalar` (not `ExecuteSqlRaw`)

PRAGMA returns a 1-row result set with the resulting mode. `ExecuteNonQuery`-style execution (which `database.ExecuteSqlRaw` uses) may be treated as undefined behaviour for PRAGMA by some provider versions — analysis-review round 1 flagged this. Direct `SqliteCommand` + `ExecuteScalar` is the documented pattern.

### Why no `busy_timeout` change

Originally scoped in round-1 plan but **dropped in round 2**. Inline-verified via [Microsoft.Data.Sqlite docs](https://learn.microsoft.com/dotnet/api/microsoft.data.sqlite.sqlitecommand.commandtimeout):

> *Internally, SqliteCommand uses CommandTimeout to set a busy timeout on the connection before executing each command.*

`SqliteCommand.CommandTimeout` defaults to 30s. Pre-impl `grep "CommandTimeout" src/Fleans/Fleans.Persistence/` confirmed zero overrides exist, so the 30s default flows through to every command via the ADO.NET layer. The issue body's "no `busy_timeout`" claim was technically accurate at the PRAGMA level but functionally inaccurate.

### Why `Console.Error.WriteLine` on PRAGMA failure

The initializer is a static bootstrap helper with no `ILogger` available. `Console.Error` lets operators see when a writable production DB silently downgrades to DELETE-mode journaling (e.g., directory permission lost between deploys). Matches the project's pattern in `Fleans.Persistence.Sqlite` (low-level bootstrap helpers; `[LoggerMessage]` is for application code).

### Why a fresh verification connection in the test

Round-1 review caught that reusing the same `SqliteConnection` to verify WAL might pass spuriously by reading connection-local state rather than the file header. Test 1 opens a *new* `SqliteConnection` after the helper runs, then queries `PRAGMA journal_mode;` — proves WAL persisted in the file header.

### Windows-specific: `SqliteConnection.ClearAllPools()`

Microsoft.Data.Sqlite pools connections per connection-string. On Windows the file handle stays held even after `Dispose`, so `File.Delete` fails. Added `ClearAllPools()` to the test's `finally` block. Discovered during initial test run — the test failed with `System.IO.IOException: process cannot access the file` until pools were cleared.

## Test results

- `SqlitePragmaTests` — **3/3 passed** (1 file-backed WAL persistence verification, 2 in-memory no-throw cases via `[DataTestMethod]`).
- `EventSourcingIntegrationTests` regression baseline — **6/6 passed** (24s). In-memory SQLite via `WorkflowTestBase`, where the WAL pragma returns `"memory"` no-op.

## Test plan

- [ ] CI green
- [ ] Optional: after merge, observe Api+Web log volume around SQLITE_BUSY (should drop to zero under normal concurrent load).

## Out of scope (per round-2 plan)

- `PRAGMA synchronous=NORMAL` on the query context — separate optimization, perf-driven, requires per-context configuration.
- EF query-side retry policy — WAL + 30s default busy_timeout should eliminate the original SQLITE_BUSY failure mode.
- The `DbConnection` overload of `UseFleansSqlite` — test base owns the connection in that path.
- Postgres counterpart — SQLite-specific issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
