### PR TITLE
fix(#660): narrow SqliteSchemaInitializer catch (fail-fast on non-race errors)

### DIFF
--- a/src/Fleans/Fleans.Persistence.Sqlite/SqliteSchemaInitializer.cs
+++ b/src/Fleans/Fleans.Persistence.Sqlite/SqliteSchemaInitializer.cs
@@ -1,6 +1,7 @@
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using SQLitePCL;
 
 namespace Fleans.Persistence.Sqlite;
 
@@ -10,13 +11,22 @@ namespace Fleans.Persistence.Sqlite;
 public static class SqliteSchemaInitializer
 {
     /// <summary>
-    /// Calls <see cref="DatabaseFacade.EnsureCreated"/> and swallows
-    /// <see cref="SqliteException"/>s thrown when another process (e.g. a sibling silo
+    /// Calls <see cref="DatabaseFacade.EnsureCreated"/> and swallows the specific
+    /// <see cref="SqliteException"/> thrown when another process (e.g. a sibling silo
     /// sharing the same .db file) has already created the tables.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// This exists so host projects do not need a direct reference to
     /// <c>Microsoft.Data.Sqlite</c> just for the race-catch block.
+    /// </para>
+    /// <para>
+    /// The catch is narrowed to <c>SQLITE_ERROR (1)</c> with message containing
+    /// "already exists" — the canonical race signature. Any other
+    /// <see cref="SqliteException"/> (CANTOPEN, READONLY, CORRUPT, FULL, NOTADB, etc.)
+    /// rethrows so a misconfigured deploy surfaces as a fail-fast crash at boot
+    /// rather than silent breakage on first query. See issue #659/#660.
+    /// </para>
     /// </remarks>
     public static void EnsureCreatedIgnoreRaces(DatabaseFacade database)
     {
@@ -24,9 +34,15 @@ public static class SqliteSchemaInitializer
         {
             database.EnsureCreated();
         }
-        catch (SqliteException)
+        catch (SqliteException ex) when (
+            ex.SqliteErrorCode == raw.SQLITE_ERROR
+            && ex.Message.Contains("already exists", StringComparison.OrdinalIgnoreCase))
         {
-            // Tables already created by a concurrent process sharing the same SQLite file.
+            // Concurrent EnsureCreated race: a sibling process created the schema
+            // first. SQLite reports SQLITE_ERROR (primary code 1) with message
+            // "<entity> already exists" (e.g. "table X already exists",
+            // "index X already exists"). Swallow only this exact signature —
+            // every other SqliteException surfaces as a startup crash.
         }
 
         // Enable WAL once. Sticky across connections via the database header — subsequent

--- a/src/Fleans/Fleans.Persistence.Tests/SqliteSchemaInitializerTests.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/SqliteSchemaInitializerTests.cs
@@ -1,0 +1,42 @@
+using Fleans.Persistence;
+using Fleans.Persistence.Sqlite;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using SQLitePCL;
+
+namespace Fleans.Persistence.Tests;
+
+/// <summary>
+/// Regression coverage for #660 — verifies <see cref="SqliteSchemaInitializer.EnsureCreatedIgnoreRaces"/>
+/// narrows its exception filter to the "table/index already exists" race only.
+/// Any other <see cref="SqliteException"/> (permission denied, corruption, disk full,
+/// can't-open) must surface as a startup crash, not silent breakage at first query.
+/// </summary>
+[TestClass]
+public class SqliteSchemaInitializerTests
+{
+    [TestMethod]
+    public void EnsureCreatedIgnoreRaces_RethrowsOnUnopenableDatabase()
+    {
+        // Arrange — Data Source pointing at a directory that does not exist.
+        // SQLite cannot create the file there, so EnsureCreated() throws
+        // SqliteException with SQLITE_CANTOPEN (14). Maps directly to the
+        // issue body's "permission-denied / corrupt-file" scenario without
+        // needing any platform-specific filesystem manipulation.
+        var ctx = new FleanCommandDbContext(new DbContextOptionsBuilder<FleanCommandDbContext>()
+            .UseFleansSqlite("Data Source=/nonexistent/__fleans_660_test_dir__/foo.db")
+            .Options);
+
+        // Act + Assert — must throw, must not be swallowed.
+        var ex = Assert.ThrowsExactly<SqliteException>(() =>
+            SqliteSchemaInitializer.EnsureCreatedIgnoreRaces(ctx.Database));
+
+        // The error code must be SQLITE_CANTOPEN (14), NOT the swallowed
+        // SQLITE_ERROR (1). If the filter regresses to a bare
+        // catch (SqliteException), Assert.ThrowsException above fails first;
+        // this check additionally pins the *kind* of error to prevent future
+        // false positives.
+        Assert.AreEqual(raw.SQLITE_CANTOPEN, ex.SqliteErrorCode,
+            "expected SQLITE_CANTOPEN to be rethrown, not the swallowed SQLITE_ERROR race");
+    }
+}


### PR DESCRIPTION
Closes #660.

## Summary

`SqliteSchemaInitializer.EnsureCreatedIgnoreRaces` previously caught **every** `SqliteException` thrown by `database.EnsureCreated()`. The intent — swallow the race when a sibling silo creates the schema first — was correct, but the filter was too broad: SQLITE_CANTOPEN (permission denied / parent directory missing), SQLITE_READONLY, SQLITE_CORRUPT, SQLITE_FULL, and SQLITE_NOTADB were all silently swallowed → silent runtime breakage on the first real query instead of a fail-fast crash at boot.

Narrow the `catch ... when` clause to the actual race signature:

```csharp
catch (SqliteException ex) when (
    ex.SqliteErrorCode == raw.SQLITE_ERROR
    && ex.Message.Contains("already exists", StringComparison.OrdinalIgnoreCase))
```

SQLite reports `SQLITE_ERROR` (primary code 1) with message `"<entity> X already exists"` for both `CREATE TABLE` and `CREATE INDEX` races. Anything else surfaces as a startup crash now.

## Test plan

- [x] `dotnet build` — 0 errors (build is clean with the new `SQLitePCL.raw.SQLITE_ERROR` constant; `using SQLitePCL;` resolves via the transitive `SQLitePCLRaw.core` package pulled in by `Microsoft.Data.Sqlite`).
- [x] `dotnet test Fleans.Persistence.Tests --filter "FullyQualifiedName~SqliteSchemaInitializer"` — 1 passed, 0 failed. The new `EnsureCreatedIgnoreRaces_RethrowsOnUnopenableDatabase` test proves the rethrow path: `Data Source=/nonexistent/.../foo.db` → `SqliteException` with `SqliteErrorCode == SQLITE_CANTOPEN (14)`, asserted on the specific code (positive assertion, not just "AreNotEqual" — prevents future false positives).

## Notes

- **Constant source**: used `SQLitePCL.raw.SQLITE_ERROR` and `SQLitePCL.raw.SQLITE_CANTOPEN` (both reachable via `using SQLitePCL;` — the `SQLitePCLRaw.core` package is transitively included via `Microsoft.Data.Sqlite`). No new package reference needed.
- **`using Fleans.Persistence;` for `FleanCommandDbContext`** — corrected from the round-2 design's draft (which had `using Fleans.Persistence.Events;`). Flagged in the analysis-review.
- **WAL pragma block untouched** — it has its own `catch (SqliteException)` with a log-and-continue policy that's a separate concern (out of scope for #660). 

🤖 Generated with [Claude Code](https://claude.com/claude-code)