### PR TITLE
feat(#659): defend CustomTaskCatalogGrain against silent self-wipe

### DIFF
--- a/src/Fleans/Fleans.Application.Tests/CustomTasks/ReconcileGuardTests.cs
+++ b/src/Fleans/Fleans.Application.Tests/CustomTasks/ReconcileGuardTests.cs
@@ -1,0 +1,31 @@
+using Fleans.Application.CustomTasks;
+
+namespace Fleans.Application.Tests.CustomTasks;
+
+[TestClass]
+public class ReconcileGuardTests
+{
+    [TestMethod]
+    public void IsAnomalousEmptyAliveSilos_ZeroSilosWithEntries_ReturnsTrue()
+    {
+        Assert.IsTrue(ReconcileGuard.IsAnomalousEmptyAliveSilos(aliveSilosCount: 0, currentEntryCount: 3));
+    }
+
+    [TestMethod]
+    public void IsAnomalousEmptyAliveSilos_ZeroSilosWithZeroEntries_ReturnsFalse()
+    {
+        Assert.IsFalse(ReconcileGuard.IsAnomalousEmptyAliveSilos(aliveSilosCount: 0, currentEntryCount: 0));
+    }
+
+    [TestMethod]
+    public void IsAnomalousEmptyAliveSilos_SomeSilosWithEntries_ReturnsFalse()
+    {
+        Assert.IsFalse(ReconcileGuard.IsAnomalousEmptyAliveSilos(aliveSilosCount: 2, currentEntryCount: 3));
+    }
+
+    [TestMethod]
+    public void IsAnomalousEmptyAliveSilos_SomeSilosWithZeroEntries_ReturnsFalse()
+    {
+        Assert.IsFalse(ReconcileGuard.IsAnomalousEmptyAliveSilos(aliveSilosCount: 2, currentEntryCount: 0));
+    }
+}

--- a/src/Fleans/Fleans.Application/CustomTasks/CustomTaskCatalogGrain.cs
+++ b/src/Fleans/Fleans.Application/CustomTasks/CustomTaskCatalogGrain.cs
@@ -8,6 +8,24 @@ using Orleans.Runtime;
 namespace Fleans.Application.CustomTasks;
 
 /// <summary>
+/// Pure logic for the catalog reconcile sanity guard. Extracted so unit tests
+/// can target the guard's decision directly without standing up a TestCluster
+/// or mocking <see cref="IManagementGrain"/>. See #659.
+/// </summary>
+internal static class ReconcileGuard
+{
+    /// <summary>
+    /// Detects the "membership directory anomaly" case where the catalog has
+    /// entries but the management grain reports zero alive silos — almost
+    /// certainly a transient Redis/membership-table blip, not a real "every
+    /// silo left the cluster" event. The reconciler must skip writes in this
+    /// case to avoid silently wiping the persisted catalog.
+    /// </summary>
+    public static bool IsAnomalousEmptyAliveSilos(int aliveSilosCount, int currentEntryCount)
+        => aliveSilosCount == 0 && currentEntryCount > 0;
+}
+
+/// <summary>
 /// Catalog of custom-task plugin registrations announced by Worker silos.
 /// State is persisted via <see cref="IPersistentState{T}"/> backed by an EF Core
 /// grain-storage provider (sub-issue A2 of #357 / PR #434), so the catalog survives
@@ -137,6 +155,12 @@ public sealed partial class CustomTaskCatalogGrain : Grain, ICustomTaskCatalogGr
                 .Where(n => !string.IsNullOrEmpty(n))
                 .ToHashSet(StringComparer.Ordinal);
 
+            if (ReconcileGuard.IsAnomalousEmptyAliveSilos(aliveSilos.Count, _state.State.Entries.Count))
+            {
+                LogReconcileSkippedAnomalousEmptyAliveSilos(_state.State.Entries.Count);
+                return;
+            }
+
             var removed = _state.State.RemoveWhere(e => !aliveSilos.Contains(e.SiloName));
             if (removed > 0)
             {
@@ -161,6 +185,10 @@ public sealed partial class CustomTaskCatalogGrain : Grain, ICustomTaskCatalogGr
     [LoggerMessage(EventId = 9322, Level = LogLevel.Warning,
         Message = "Custom-task catalog reconcile failed; will retry next tick")]
     private partial void LogReconcileFailed(Exception ex);
+
+    [LoggerMessage(EventId = 9323, Level = LogLevel.Warning,
+        Message = "Custom-task catalog reconcile observed empty alive-silos list with {EntryCount} catalog entries still present — treating as transient membership anomaly; skipping this reconcile tick.")]
+    private partial void LogReconcileSkippedAnomalousEmptyAliveSilos(int entryCount);
 
     [LoggerMessage(EventId = 9325, Level = LogLevel.Warning,
         Message = "Custom-task catalog: failed to deserialize ParameterSchemaJson for taskType='{TaskType}'; returning null schema (UI will hide parameter widgets for this plugin)")]

--- a/src/Fleans/Fleans.Application/Fleans.Application.csproj
+++ b/src/Fleans/Fleans.Application/Fleans.Application.csproj
@@ -20,4 +20,8 @@
     <ProjectReference Include="..\Fleans.Domain\Fleans.Domain.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Fleans.Application.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/Fleans/Fleans.Persistence.Tests/EfCoreCustomTaskCatalogGrainStorageTests.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/EfCoreCustomTaskCatalogGrainStorageTests.cs
@@ -1,5 +1,6 @@
 using Fleans.Domain.States;
 using Fleans.Persistence.Tests.Infrastructure;
+using Microsoft.EntityFrameworkCore;
 using Orleans.Runtime;
 
 namespace Fleans.Persistence.Tests;
@@ -165,6 +166,44 @@ public class EfCoreCustomTaskCatalogGrainStorageTests : PersistenceTestBase
         Assert.HasCount(2, read.State.Entries);
         var silos = read.State.Entries.Select(e => e.SiloName).OrderBy(s => s).ToList();
         CollectionAssert.AreEqual(new[] { "worker-A", "worker-B" }, silos);
+    }
+
+    [TestMethod]
+    public async Task ReadStateAsync_DbContextFactoryThrows_PropagatesException()
+    {
+        // Regression for #659: Orleans must abort grain activation when the
+        // underlying store throws on read. Caller-visible behaviour: the
+        // exception propagates AND no positive "loaded" markers are stamped
+        // onto the IGrainState — otherwise the catalog grain would be
+        // activated with State={} and the membership-reconcile timer would
+        // happily persist that empty state on the next tick.
+        var factory = new ThrowingDbContextFactory(new InvalidOperationException("simulated transient"));
+        var storage = new EfCoreCustomTaskCatalogGrainStorage(factory);
+        var read = CreateEmptyGrainState();
+
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
+            storage.ReadStateAsync(StateName, NewGrainId(), read));
+
+        Assert.AreEqual("simulated transient", ex.Message);
+        Assert.IsFalse(read.RecordExists, "grain state must not be marked as populated on read failure");
+        Assert.IsNull(read.ETag, "ETag must not be set on read failure");
+    }
+
+    /// <summary>
+    /// Inline test-only factory used by <see cref="ReadStateAsync_DbContextFactoryThrows_PropagatesException"/>.
+    /// Wraps the <see cref="IDbContextFactory{TContext}"/> surface used by
+    /// <see cref="EfCoreCustomTaskCatalogGrainStorage"/> and unconditionally
+    /// throws the configured exception on every create call.
+    /// </summary>
+    private sealed class ThrowingDbContextFactory : IDbContextFactory<FleanCommandDbContext>
+    {
+        private readonly Exception _toThrow;
+        public ThrowingDbContextFactory(Exception toThrow) => _toThrow = toThrow;
+
+        public FleanCommandDbContext CreateDbContext() => throw _toThrow;
+
+        public Task<FleanCommandDbContext> CreateDbContextAsync(CancellationToken ct = default)
+            => Task.FromException<FleanCommandDbContext>(_toThrow);
     }
 
     [DataTestMethod]

--- a/src/Fleans/Fleans.Persistence/EfCoreCustomTaskCatalogGrainStorage.cs
+++ b/src/Fleans/Fleans.Persistence/EfCoreCustomTaskCatalogGrainStorage.cs
@@ -26,17 +26,10 @@ public class EfCoreCustomTaskCatalogGrainStorage : IGrainStorage
 
         var rows = await db.CustomTaskCatalogEntries.AsNoTracking().ToListAsync();
 
-        var state = new CustomTaskCatalogState
-        {
-            Entries = rows
-        };
-
-        if (rows.Count > 0)
-        {
-            grainState.State = (T)(object)state;
-            grainState.ETag = "loaded";
-            grainState.RecordExists = true;
-        }
+        var state = new CustomTaskCatalogState { Entries = rows };
+        grainState.State = (T)(object)state;
+        grainState.ETag = rows.Count > 0 ? "loaded" : null;
+        grainState.RecordExists = rows.Count > 0;
     }
 
     public async Task WriteStateAsync<T>(string stateName, GrainId grainId, IGrainState<T> grainState)


### PR DESCRIPTION
Closes #659.

## Summary

`CustomTaskCatalogGrain.ReconcileWithMembership` (`Fleans.Application/CustomTasks/CustomTaskCatalogGrain.cs:128-160`) used to strip every catalog entry — and persist the empty state — when `IManagementGrain.GetDetailedHosts(onlyActive: false)` returned a successful but anomalous empty list. That signature is overwhelmingly a transient Redis/membership-table blip, not a real "every silo left the cluster" event, so the persisted catalog was being silently wiped on a non-fatal hiccup.

This PR adds 5 layered defenses against that wipe path, per round-2 design.

## Layers (round-2 design ↔ this PR)

- **A — `ReconcileGuard.IsAnomalousEmptyAliveSilos` (pure helper)**: extracted as an `internal static` class above the grain. `ReconcileWithMembership` now calls it between `aliveSilos` computation and `RemoveWhere`. If the guard returns true (alive=0 ∧ entries>0), the reconcile tick logs at Warning level (EventId 9323, `LogReconcileSkippedAnomalousEmptyAliveSilos`) and returns without writing.
- **B — `EfCoreCustomTaskCatalogGrainStorage.ReadStateAsync` symmetric assignment**: removes the asymmetric `if (rows.Count > 0) { … }` branch; state is always assigned, and ETag/`RecordExists` are explicit non-loaded markers when the table is empty. No behavioural change on the happy path.
- **C — Read-failure propagation test**: `ReadStateAsync_DbContextFactoryThrows_PropagatesException` in `EfCoreCustomTaskCatalogGrainStorageTests` proves a throwing `IDbContextFactory` (`ThrowingDbContextFactory` inlined as `private sealed class` in the test file) propagates its exception and leaves `RecordExists=false` / `ETag=null`. Provider-agnostic — no `[DataRow]` because the exception happens before any DB interaction.
- **D — `ReconcileGuardTests`**: 4 pure-function unit tests covering the (alive × entries) {0, >0} matrix. No TestCluster, no `IManagementGrain` mocking.
- **E — Spot-check on flagged peers**: checked `ConditionalStartEventRegistryGrain` and `TimerStartEventSchedulerGrain` inline. Neither reconciles against external membership state — `ConditionalStartEventRegistryGrain` mutates only on explicit caller-driven `Register` / `Unregister[All]`; `TimerStartEventSchedulerGrain` writes only on caller-driven `Activate` / `FireTimerStartEvent`. CustomTaskCatalogGrain is the only grain with the wipe-prone shape.

## Visibility note

`ReconcileGuard` is `internal static` because it's a defensive helper, not a public contract. To let Layer D target it, added `<InternalsVisibleTo Include=\"Fleans.Application.Tests\" />` to `Fleans.Application.csproj`. First InternalsVisibleTo in the repo — preferred over making the helper public because it's a pure private invariant of the grain's reconcile path.

## How to test

```bash
cd src/Fleans
dotnet build
dotnet test Fleans.Application.Tests/Fleans.Application.Tests.csproj --filter \"FullyQualifiedName~ReconcileGuard|FullyQualifiedName~CustomTaskCatalog\"
dotnet test Fleans.Persistence.Tests/Fleans.Persistence.Tests.csproj --filter \"FullyQualifiedName~CustomTaskCatalog\"
```

Local results: Application.Tests 338/338 passed (6 skipped, 0 failed), Persistence.Tests 148/148 passed (124 PG rows skipped without `FLEANS_PG_TESTS=1`, 0 failed).

## Out of scope (filed elsewhere if confirmed)

- Partial-disjoint anomaly: `aliveSilos.Count > 0` but disjoint from registered silos still wipes all. Requires a different signal (threshold-based removal count or external "minimum cluster size"). Acknowledged in round-1 review as 🟢 minor; not blocking this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)