### PR TITLE
feat(#669): add Postgres provider option for Orleans reminders

### DIFF
--- a/LICENSE-orleans-vendor
+++ b/LICENSE-orleans-vendor
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE-orleans-vendor
+++ b/LICENSE-orleans-vendor
@@ -1,3 +1,21 @@
+This file exists to satisfy the Apache License 2.0 attribution requirement
+for files vendored from the Microsoft Orleans project (https://github.com/dotnet/orleans).
+
+Vendored files (copied unmodified from upstream tag v10.0.1):
+  - src/Fleans/Fleans.ServiceDefaults/Resources/PostgreSQL-Main.sql
+  - src/Fleans/Fleans.ServiceDefaults/Resources/PostgreSQL-Reminders.sql
+
+These scripts are embedded as resources and executed during
+EnsureDatabaseSchemaAsync when Postgres reminders are enabled, because
+Microsoft.Orleans.Reminders.AdoNet does not ship its schema as an embedded
+resource. Section 4 of the Apache-2.0 license requires the original notice
+and a copy of the license to accompany any distribution containing the
+licensed material — that is what this file provides.
+
+When Microsoft.Orleans.Reminders.AdoNet is bumped, re-fetch both .sql files
+from the matching upstream tag and update their version-pin header comment.
+
+--------------------------------------------------------------------------------
 
                                  Apache License
                            Version 2.0, January 2004

--- a/docs/conventions/reminders.md
+++ b/docs/conventions/reminders.md
@@ -1,18 +1,55 @@
 # Reminders
 
-Orleans reminders persist BPMN timers across silo restarts. Fleans uses
-the **Redis** reminder provider, sharing the `orleans-redis` connection
-used for clustering and Pub-Sub streaming.
+Orleans reminders persist BPMN timers across silo restarts. Fleans defaults to
+the **Redis** reminder provider, sharing the `orleans-redis` connection used
+for clustering and Pub-Sub streaming. Operators on `Persistence:Provider=Postgres`
+can opt their reminders into Postgres too via `Fleans:Reminders:Provider=Postgres`
+(see provider matrix below).
 
-## Why Redis (not AdoNet)
+## Provider matrix
+
+| `Persistence:Provider` | `Fleans:Reminders:Provider` | Outcome |
+|---|---|---|
+| `Sqlite` (default) | `Redis` (default) | Supported. Single-binary story preserved. |
+| `Sqlite` | `Postgres` | **Unsupported — silo refuses to start** (#669). |
+| `Postgres` | `Redis` (default) | Supported. Reminders ride the clustering Redis. |
+| `Postgres` | `Postgres` | Supported per #669. Reminders share `ConnectionStrings:fleans`. |
+
+`Fleans:Reminders:Provider` is bound at startup; values are matched
+case-insensitively. Unknown values throw `ArgumentException`.
+
+## Postgres reminders schema
+
+When `Fleans:Reminders:Provider=Postgres`, `EnsureDatabaseSchemaAsync` runs two
+vendored upstream scripts under the same advisory lock used by app migrations:
+
+- `PostgreSQL-Main.sql` creates the `OrleansQuery` query-template table
+  (required by the reminders script's `INSERT INTO OrleansQuery` statements).
+- `PostgreSQL-Reminders.sql` creates `OrleansRemindersTable` plus the upsert /
+  read / delete query templates.
+
+The scripts are bundled as `<EmbeddedResource>` in `Fleans.ServiceDefaults`
+(under `Resources/`) and are pinned to the matching `Microsoft.Orleans.Reminders.AdoNet`
+package version (10.0.1 today). Apache-2.0 attribution lives in each file's
+header and in `LICENSE-orleans-vendor` at the repo root.
+
+The schema-init is idempotent — it checks for `OrleansQuery` existence via
+`SELECT EXISTS (... FROM pg_class WHERE relname = 'orleansquery')` and skips
+both scripts if already present. Concurrent silos serialise via the existing
+session-level advisory lock (`pg_advisory_lock`).
+
+If schema-init throws (script error, connection failure), the exception
+propagates and the silo refuses to start — same registration-vs-cleanup
+asymmetry that the Redis fail-fast guard enforces.
+
+## Why Redis (not AdoNet) by default
 
 - Redis is already required for clustering + streaming — no new infrastructure.
 - `Microsoft.Orleans.Reminders.AdoNet` does not support SQLite, which would
   force every SQLite quick-start user to also install Postgres for timer
   durability — breaking the SQLite single-binary story.
-- Reminders are decoupled from the application persistence pivot
-  (`FLEANS_PERSISTENCE_PROVIDER={Sqlite,Postgres}`). SQLite users get full
-  timer durability via Redis.
+- Reminders are decoupled from the application persistence pivot. SQLite
+  users get full timer durability via Redis.
 
 ## Fail-fast semantics
 
@@ -23,9 +60,11 @@ would re-create the exact bug this configuration prevents.
 
 The wiring lives in `Fleans.ServiceDefaults/Reminders/`:
 
-- `FleansReminderOptions.cs` — pins the connection name (`orleans-redis`).
+- `FleansReminderOptions.cs` — pins the Redis connection name (`orleans-redis`).
 - `FleansRemindersExtensions.cs` — `AddFleansReminders(IConfiguration)` extension
   used from `Fleans.Api/Program.cs` and `Fleans.WorkerHost/Program.cs`.
+  `ResolveRemindersConfiguration(IConfiguration)` is the testable validation
+  surface (see `Fleans.ServiceDefaults.Tests/FleansRemindersExtensionsTests.cs`).
 
 ## Multi-silo cluster invariants
 

--- a/src/Fleans/Fleans.Persistence/FleansPersistenceOptions.cs
+++ b/src/Fleans/Fleans.Persistence/FleansPersistenceOptions.cs
@@ -15,4 +15,12 @@ public sealed class FleansPersistenceOptions
     /// (see WorkflowInstance.ApplyUpdatesToStorage).
     /// </summary>
     public int MaxEventsPerLoad { get; set; } = 1000;
+
+    /// <summary>
+    /// Reminder backing store. Bound from <c>Fleans:Reminders:Provider</c>; default
+    /// <c>Redis</c> (matches the #650 ship). When set to <c>Postgres</c>,
+    /// <see cref="Provider"/> must also be <c>Postgres</c> — mixed storage is
+    /// rejected at startup (see #669).
+    /// </summary>
+    public string RemindersProvider { get; set; } = "Redis";
 }

--- a/src/Fleans/Fleans.ServiceDefaults.Tests/EmbeddedSchemaResourceTests.cs
+++ b/src/Fleans/Fleans.ServiceDefaults.Tests/EmbeddedSchemaResourceTests.cs
@@ -1,0 +1,39 @@
+namespace Fleans.ServiceDefaults.Tests;
+
+/// <summary>
+/// Verifies the embedded-resource layout for the vendored Orleans Postgres-reminder
+/// schema scripts (#669). The schema-init in <c>EnsureDatabaseSchemaAsync</c> loads
+/// these by manifest name — a missing or renamed resource would only blow up at
+/// silo startup against a Postgres-reminders deployment. These tests catch the
+/// drift at build time instead.
+/// </summary>
+[TestClass]
+public class EmbeddedSchemaResourceTests
+{
+    [DataTestMethod]
+    [DataRow("Fleans.ServiceDefaults.Resources.PostgreSQL_Main.sql")]
+    [DataRow("Fleans.ServiceDefaults.Resources.PostgreSQL_Reminders.sql")]
+    public void EmbeddedResource_IsPresent(string resourceName)
+    {
+        var asm = typeof(FleansPersistenceExtensions).Assembly;
+        using var stream = asm.GetManifestResourceStream(resourceName);
+        Assert.IsNotNull(stream, $"Embedded SQL resource '{resourceName}' missing — check csproj <EmbeddedResource> entries.");
+        Assert.IsGreaterThan(0, stream.Length, $"Embedded SQL resource '{resourceName}' is empty.");
+    }
+
+    [DataTestMethod]
+    [DataRow("Fleans.ServiceDefaults.Resources.PostgreSQL_Main.sql")]
+    [DataRow("Fleans.ServiceDefaults.Resources.PostgreSQL_Reminders.sql")]
+    public async Task EmbeddedResource_ContainsVersionPin(string resourceName)
+    {
+        // Drift guard. A silent SDK bump that forgets to re-vendor would skip
+        // the version-pin comment we add in the Apache-2.0 attribution header.
+        var asm = typeof(FleansPersistenceExtensions).Assembly;
+        await using var stream = asm.GetManifestResourceStream(resourceName)!;
+        using var reader = new StreamReader(stream);
+        var content = await reader.ReadToEndAsync();
+
+        StringAssert.Contains(content, "Microsoft.Orleans.Reminders.AdoNet v10.0.1",
+            $"{resourceName} is missing the version-pin comment — re-vendor against the matching SDK version (see LICENSE-orleans-vendor).");
+    }
+}

--- a/src/Fleans/Fleans.ServiceDefaults.Tests/FleansRemindersExtensionsTests.cs
+++ b/src/Fleans/Fleans.ServiceDefaults.Tests/FleansRemindersExtensionsTests.cs
@@ -1,0 +1,107 @@
+using Fleans.ServiceDefaults.Reminders;
+using Microsoft.Extensions.Configuration;
+
+namespace Fleans.ServiceDefaults.Tests;
+
+/// <summary>
+/// Covers <see cref="FleansRemindersExtensions.ResolveRemindersConfiguration"/> —
+/// the provider-switch and fail-fast surface (issue #669).
+/// </summary>
+[TestClass]
+public class FleansRemindersExtensionsTests
+{
+    [TestMethod]
+    public void Default_provider_is_Redis_when_unset()
+    {
+        var cfg = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:orleans-redis"] = "localhost:6379",
+            }).Build();
+
+        var resolved = FleansRemindersExtensions.ResolveRemindersConfiguration(cfg);
+
+        Assert.AreEqual(RemindersProvider.Redis, resolved.Provider);
+        Assert.AreEqual("localhost:6379", resolved.ConnectionString);
+    }
+
+    [TestMethod]
+    public void Redis_provider_throws_when_orleans_redis_connection_missing()
+    {
+        var cfg = new ConfigurationBuilder().AddInMemoryCollection().Build();
+
+        var ex = Assert.ThrowsExactly<InvalidOperationException>(
+            () => FleansRemindersExtensions.ResolveRemindersConfiguration(cfg));
+
+        StringAssert.Contains(ex.Message, "orleans-redis");
+        StringAssert.Contains(ex.Message, "silent fallback to in-memory reminders is");
+    }
+
+    [TestMethod]
+    public void Postgres_provider_throws_when_persistence_is_Sqlite()
+    {
+        var cfg = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Fleans:Reminders:Provider"] = "Postgres",
+                ["Persistence:Provider"] = "Sqlite",
+                ["ConnectionStrings:fleans"] = "Host=localhost;Database=fleans;Username=u;Password=p",
+            }).Build();
+
+        var ex = Assert.ThrowsExactly<InvalidOperationException>(
+            () => FleansRemindersExtensions.ResolveRemindersConfiguration(cfg));
+
+        StringAssert.Contains(ex.Message, "Persistence:Provider=Postgres");
+        StringAssert.Contains(ex.Message, "Mixed-storage");
+    }
+
+    [TestMethod]
+    public void Postgres_provider_throws_when_fleans_connection_missing()
+    {
+        var cfg = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Fleans:Reminders:Provider"] = "Postgres",
+                ["Persistence:Provider"] = "Postgres",
+            }).Build();
+
+        var ex = Assert.ThrowsExactly<InvalidOperationException>(
+            () => FleansRemindersExtensions.ResolveRemindersConfiguration(cfg));
+
+        StringAssert.Contains(ex.Message, "'fleans'");
+        StringAssert.Contains(ex.Message, "Fleans:Reminders:Provider=Postgres");
+    }
+
+    [TestMethod]
+    public void Postgres_provider_resolves_when_persistence_and_fleans_present()
+    {
+        var cfg = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Fleans:Reminders:Provider"] = "Postgres",
+                ["Persistence:Provider"] = "Postgres",
+                ["ConnectionStrings:fleans"] = "Host=localhost;Database=fleans;Username=u;Password=p",
+            }).Build();
+
+        var resolved = FleansRemindersExtensions.ResolveRemindersConfiguration(cfg);
+
+        Assert.AreEqual(RemindersProvider.Postgres, resolved.Provider);
+        StringAssert.Contains(resolved.ConnectionString, "Host=localhost");
+    }
+
+    [TestMethod]
+    public void Unknown_provider_throws_ArgumentException()
+    {
+        var cfg = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Fleans:Reminders:Provider"] = "MySQL",
+            }).Build();
+
+        var ex = Assert.ThrowsExactly<ArgumentException>(
+            () => FleansRemindersExtensions.ResolveRemindersConfiguration(cfg));
+
+        StringAssert.Contains(ex.Message, "MySQL");
+        StringAssert.Contains(ex.Message, "Supported: Redis (default), Postgres");
+    }
+}

--- a/src/Fleans/Fleans.ServiceDefaults/Fleans.ServiceDefaults.csproj
+++ b/src/Fleans/Fleans.ServiceDefaults/Fleans.ServiceDefaults.csproj
@@ -29,6 +29,9 @@
          for clustering + streaming). BPMN timer durability across silo restarts. See #650 +
          docs/conventions/reminders.md. -->
     <PackageReference Include="Microsoft.Orleans.Reminders.Redis" Version="10.0.1" />
+    <!-- Postgres-backed reminder service (opt-in via Fleans:Reminders:Provider=Postgres).
+         Pin to 10.0.1 to match the Microsoft.Orleans.* sibling versions. See #669. -->
+    <PackageReference Include="Microsoft.Orleans.Reminders.AdoNet" Version="10.0.1" />
     <!-- Third-party Redis stream provider (MIT, Orleans 10.x compatible). Date-versioned;
          bump deliberately and re-run manual test #45. See CLAUDE.md for swap-out path. -->
     <PackageReference Include="Universley.OrleansContrib.StreamsProvider.Redis" Version="2026.4.19" />
@@ -37,6 +40,16 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.14.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Vendored Orleans Postgres-reminders schema scripts. Run by EnsureDatabaseSchemaAsync
+         on first startup when Fleans:Reminders:Provider=Postgres. Re-vendor when the
+         AdoNet package version is bumped. See #669 + LICENSE-orleans-vendor. -->
+    <EmbeddedResource Include="Resources/PostgreSQL-Main.sql"
+                      LogicalName="Fleans.ServiceDefaults.Resources.PostgreSQL_Main.sql" />
+    <EmbeddedResource Include="Resources/PostgreSQL-Reminders.sql"
+                      LogicalName="Fleans.ServiceDefaults.Resources.PostgreSQL_Reminders.sql" />
   </ItemGroup>
 
 </Project>

--- a/src/Fleans/Fleans.ServiceDefaults/FleansPersistenceExtensions.cs
+++ b/src/Fleans/Fleans.ServiceDefaults/FleansPersistenceExtensions.cs
@@ -27,6 +27,11 @@ public static class FleansPersistenceExtensions
             opts.Provider = provider;
             builder.Configuration.GetSection("Persistence").Bind(opts);
             if (string.IsNullOrWhiteSpace(opts.Provider)) opts.Provider = provider;
+
+            // Bind Fleans:Reminders:Provider here so EnsureDatabaseSchemaAsync can
+            // see it via IOptions without re-reading IConfiguration after Build().
+            var remindersProvider = builder.Configuration["Fleans:Reminders:Provider"];
+            if (!string.IsNullOrWhiteSpace(remindersProvider)) opts.RemindersProvider = remindersProvider;
         });
 
         if (provider.Equals("Postgres", StringComparison.OrdinalIgnoreCase))
@@ -86,6 +91,26 @@ public static class FleansPersistenceExtensions
                 await db.Database.ExecuteSqlRawAsync(
                     $"SELECT pg_advisory_lock({migrationLockKey})");
                 await db.Database.MigrateAsync();
+
+                if (options.RemindersProvider.Equals("Postgres", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Idempotent guard. ExecuteSqlRawAsync returns -1 for SELECT in Npgsql
+                    // (rows-affected is undefined for queries) so we use raw ADO.NET
+                    // ExecuteScalarAsync. The OrleansQuery table (created by Main.sql) is
+                    // the sentinel: present → already initialised → skip; absent → run both.
+                    bool alreadyInitialised;
+                    await using (var cmd = db.Database.GetDbConnection().CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT EXISTS (SELECT 1 FROM pg_class WHERE relname = 'orleansquery')";
+                        alreadyInitialised = (bool)(await cmd.ExecuteScalarAsync() ?? false);
+                    }
+
+                    if (!alreadyInitialised)
+                    {
+                        await ExecuteEmbeddedScriptAsync(db, "Fleans.ServiceDefaults.Resources.PostgreSQL_Main.sql");
+                        await ExecuteEmbeddedScriptAsync(db, "Fleans.ServiceDefaults.Resources.PostgreSQL_Reminders.sql");
+                    }
+                }
             }
             finally
             {
@@ -106,5 +131,16 @@ public static class FleansPersistenceExtensions
             using var db = dbFactory.CreateDbContext();
             SqliteSchemaInitializer.EnsureCreatedIgnoreRaces(db.Database);
         }
+    }
+
+    private static async Task ExecuteEmbeddedScriptAsync(Microsoft.EntityFrameworkCore.DbContext db, string resourceName)
+    {
+        var assembly = typeof(FleansPersistenceExtensions).Assembly;
+        await using var stream = assembly.GetManifestResourceStream(resourceName)
+            ?? throw new InvalidOperationException(
+                $"Embedded SQL resource '{resourceName}' not found — check Fleans.ServiceDefaults.csproj <EmbeddedResource> entries.");
+        using var reader = new StreamReader(stream);
+        var sql = await reader.ReadToEndAsync();
+        await db.Database.ExecuteSqlRawAsync(sql);
     }
 }

--- a/src/Fleans/Fleans.ServiceDefaults/Reminders/FleansRemindersExtensions.cs
+++ b/src/Fleans/Fleans.ServiceDefaults/Reminders/FleansRemindersExtensions.cs
@@ -7,34 +7,91 @@ namespace Fleans.ServiceDefaults.Reminders;
 public static class FleansRemindersExtensions
 {
     /// <summary>
-    /// Configures the silo to use the Redis-backed Orleans reminder service.
-    /// Reminders share the <c>orleans-redis</c> connection used for clustering and
-    /// streaming — see <c>docs/conventions/reminders.md</c>.
+    /// Configures the silo's Orleans reminder service. The provider is selected via
+    /// <c>Fleans:Reminders:Provider</c> (default <c>Redis</c>, case-insensitive;
+    /// supported: <c>Redis</c>, <c>Postgres</c>).
     ///
-    /// Fails fast (throws <see cref="InvalidOperationException"/>) if the
-    /// <c>orleans-redis</c> connection string is unavailable, per the
-    /// "Registration-vs-cleanup error asymmetry" load-bearing invariant in
-    /// CLAUDE.md. BPMN timer durability is a correctness invariant — silent
-    /// fallback to in-memory reminders would re-create the exact bug this
-    /// configuration prevents (#650).
+    /// <c>Redis</c> shares the <c>orleans-redis</c> connection used for clustering and
+    /// streaming; <c>Postgres</c> shares the <c>fleans</c> connection used by
+    /// <c>Persistence:Provider=Postgres</c> and is only allowed when persistence is
+    /// also Postgres (mixed-storage is rejected at startup). See
+    /// <c>docs/conventions/reminders.md</c>.
+    ///
+    /// Fails fast (throws <see cref="InvalidOperationException"/>) if the chosen
+    /// provider's connection string is missing, per CLAUDE.md's "Registration-vs-
+    /// cleanup error asymmetry" load-bearing invariant. BPMN timer durability is a
+    /// correctness invariant — silent fallback to in-memory reminders is disallowed.
     /// </summary>
-    /// <remarks>
-    /// The 1-minute reminder period used by <c>TimerCallbackGrain</c> is
-    /// Orleans's required minimum granularity, not a bug — that grain
-    /// unregisters in <c>ReceiveReminder</c> after the first fire
-    /// (see <c>TimerCallbackGrain.cs:44, :66</c>).
-    /// </remarks>
     public static ISiloBuilder AddFleansReminders(this ISiloBuilder siloBuilder, IConfiguration configuration)
     {
-        var connString = configuration.GetConnectionString(FleansReminderOptions.ConnectionName)
-            ?? throw new InvalidOperationException(
-                $"'{FleansReminderOptions.ConnectionName}' connection string is required for Fleans reminders. " +
-                "BPMN timer durability is a correctness invariant — silent fallback to in-memory reminders is " +
-                "explicitly disallowed (see docs/conventions/reminders.md).");
+        var resolved = ResolveRemindersConfiguration(configuration);
 
-        siloBuilder.UseRedisReminderService(options =>
-            options.ConfigurationOptions = ConfigurationOptions.Parse(connString));
-
+        switch (resolved.Provider)
+        {
+            case RemindersProvider.Redis:
+                siloBuilder.UseRedisReminderService(options =>
+                    options.ConfigurationOptions = ConfigurationOptions.Parse(resolved.ConnectionString));
+                break;
+            case RemindersProvider.Postgres:
+                siloBuilder.UseAdoNetReminderService(options =>
+                {
+                    options.Invariant = "Npgsql";
+                    options.ConnectionString = resolved.ConnectionString;
+                });
+                break;
+        }
         return siloBuilder;
     }
+
+    /// <summary>
+    /// Validates the reminders config and resolves the provider + connection string,
+    /// or throws. Exposed for unit tests so the throw paths can be exercised without
+    /// standing up an <see cref="ISiloBuilder"/> / TestCluster.
+    /// </summary>
+    public static ResolvedRemindersConfiguration ResolveRemindersConfiguration(IConfiguration configuration)
+    {
+        var providerRaw = configuration.GetValue<string>("Fleans:Reminders:Provider") ?? "Redis";
+
+        switch (providerRaw.ToLowerInvariant())
+        {
+            case "redis":
+                {
+                    var connString = configuration.GetConnectionString(FleansReminderOptions.ConnectionName)
+                        ?? throw new InvalidOperationException(
+                            $"'{FleansReminderOptions.ConnectionName}' connection string is required for Fleans reminders. " +
+                            "BPMN timer durability is a correctness invariant — silent fallback to in-memory reminders is " +
+                            "explicitly disallowed (see docs/conventions/reminders.md).");
+                    return new ResolvedRemindersConfiguration(RemindersProvider.Redis, connString);
+                }
+            case "postgres":
+                {
+                    // D4: SQLite-app + Postgres-reminders is operationally odd (re-introduces the
+                    // external-DB dependency the SQLite single-binary story exists to avoid).
+                    // Fail fast — operator can argue for it with a follow-up issue.
+                    var persistenceProvider = configuration["Persistence:Provider"] ?? "Sqlite";
+                    if (!persistenceProvider.Equals("Postgres", StringComparison.OrdinalIgnoreCase))
+                        throw new InvalidOperationException(
+                            $"Fleans:Reminders:Provider=Postgres requires Persistence:Provider=Postgres (got '{persistenceProvider}'). " +
+                            "Mixed-storage (SQLite app + Postgres reminders) is unsupported — see #669.");
+
+                    var connString = configuration.GetConnectionString("fleans")
+                        ?? throw new InvalidOperationException(
+                            "Connection string 'fleans' is required when Fleans:Reminders:Provider=Postgres " +
+                            "(reuses the Persistence:Provider=Postgres connection — see docs/conventions/reminders.md).");
+                    return new ResolvedRemindersConfiguration(RemindersProvider.Postgres, connString);
+                }
+            default:
+                throw new ArgumentException(
+                    $"Unknown reminders provider '{providerRaw}'. Supported: Redis (default), Postgres. " +
+                    $"Set Fleans:Reminders:Provider in configuration.");
+        }
+    }
 }
+
+public enum RemindersProvider
+{
+    Redis,
+    Postgres,
+}
+
+public readonly record struct ResolvedRemindersConfiguration(RemindersProvider Provider, string ConnectionString);

--- a/src/Fleans/Fleans.ServiceDefaults/Resources/PostgreSQL-Main.sql
+++ b/src/Fleans/Fleans.ServiceDefaults/Resources/PostgreSQL-Main.sql
@@ -1,0 +1,46 @@
+-- Vendored unmodified from Microsoft.Orleans.Reminders.AdoNet v10.0.1
+-- Source: https://github.com/dotnet/orleans/blob/v10.0.1/src/AdoNet/Shared/PostgreSQL-Main.sql
+-- Copyright (c) .NET Foundation and Contributors, Apache-2.0 licensed.
+-- See LICENSE-orleans-vendor at the repo root for the full license text.
+-- Re-vendor whenever Microsoft.Orleans.Reminders.AdoNet is bumped.
+
+-- requires Postgres 9.5 (or perhaps higher)
+
+/*
+Implementation notes:
+
+1) The general idea is that data is read and written through Orleans specific queries.
+   Orleans operates on column names and types when reading and on parameter names and types when writing.
+
+2) The implementations *must* preserve input and output names and types. Orleans uses these parameters to reads query results by name and type.
+   Vendor and deployment specific tuning is allowed and contributions are encouraged as long as the interface contract
+   is maintained.
+
+3) The implementation across vendor specific scripts *should* preserve the constraint names. This simplifies troubleshooting
+   by virtue of uniform naming across concrete implementations.
+
+5) ETag for Orleans is an opaque column that represents a unique version. The type of its actual implementation
+   is not important as long as it represents a unique version. In this implementation we use integers for versioning
+
+6) For the sake of being explicit and removing ambiguity, Orleans expects some queries to return either TRUE as >0 value
+   or FALSE as =0 value. That is, affected rows or such does not matter. If an error is raised or an exception is thrown
+   the query *must* ensure the entire transaction is rolled back and may either return FALSE or propagate the exception.
+   Orleans handles exception as a failure and will retry.
+
+7) The implementation follows the Extended Orleans membership protocol. For more information, see at:
+        https://learn.microsoft.com/dotnet/orleans/implementation/cluster-management
+        https://github.com/dotnet/orleans/blob/main/src/Orleans.Core/SystemTargetInterfaces/IMembershipTable.cs
+*/
+
+
+
+-- This table defines Orleans operational queries. Orleans uses these to manage its operations,
+-- these are the only queries Orleans issues to the database.
+-- These can be redefined (e.g. to provide non-destructive updates) provided the stated interface principles hold.
+CREATE TABLE OrleansQuery
+(
+    QueryKey varchar(64) NOT NULL,
+    QueryText varchar(8000) NOT NULL,
+
+    CONSTRAINT OrleansQuery_Key PRIMARY KEY(QueryKey)
+);

--- a/src/Fleans/Fleans.ServiceDefaults/Resources/PostgreSQL-Reminders.sql
+++ b/src/Fleans/Fleans.ServiceDefaults/Resources/PostgreSQL-Reminders.sql
@@ -1,0 +1,194 @@
+-- Vendored unmodified from Microsoft.Orleans.Reminders.AdoNet v10.0.1
+-- Source: https://github.com/dotnet/orleans/blob/v10.0.1/src/AdoNet/Orleans.Reminders.AdoNet/PostgreSQL-Reminders.sql
+-- Copyright (c) .NET Foundation and Contributors, Apache-2.0 licensed.
+-- See LICENSE-orleans-vendor at the repo root for the full license text.
+-- Re-vendor whenever Microsoft.Orleans.Reminders.AdoNet is bumped.
+
+-- Orleans Reminders table - https://learn.microsoft.com/dotnet/orleans/grains/timers-and-reminders
+CREATE TABLE OrleansRemindersTable
+(
+    ServiceId varchar(150) NOT NULL,
+    GrainId varchar(150) NOT NULL,
+    ReminderName varchar(150) NOT NULL,
+    StartTime timestamptz(3) NOT NULL,
+    Period bigint NOT NULL,
+    GrainHash integer NOT NULL,
+    Version integer NOT NULL,
+
+    CONSTRAINT PK_RemindersTable_ServiceId_GrainId_ReminderName PRIMARY KEY(ServiceId, GrainId, ReminderName)
+);
+
+CREATE FUNCTION upsert_reminder_row(
+    ServiceIdArg    OrleansRemindersTable.ServiceId%TYPE,
+    GrainIdArg      OrleansRemindersTable.GrainId%TYPE,
+    ReminderNameArg OrleansRemindersTable.ReminderName%TYPE,
+    StartTimeArg    OrleansRemindersTable.StartTime%TYPE,
+    PeriodArg       OrleansRemindersTable.Period%TYPE,
+    GrainHashArg    OrleansRemindersTable.GrainHash%TYPE
+  )
+  RETURNS TABLE(version integer) AS
+$func$
+DECLARE
+    VersionVar int := 0;
+BEGIN
+
+    INSERT INTO OrleansRemindersTable
+    (
+        ServiceId,
+        GrainId,
+        ReminderName,
+        StartTime,
+        Period,
+        GrainHash,
+        Version
+    )
+    SELECT
+        ServiceIdArg,
+        GrainIdArg,
+        ReminderNameArg,
+        StartTimeArg,
+        PeriodArg,
+        GrainHashArg,
+        0
+    ON CONFLICT (ServiceId, GrainId, ReminderName)
+        DO UPDATE SET
+            StartTime = excluded.StartTime,
+            Period = excluded.Period,
+            GrainHash = excluded.GrainHash,
+            Version = OrleansRemindersTable.Version + 1
+    RETURNING
+        OrleansRemindersTable.Version INTO STRICT VersionVar;
+
+    RETURN QUERY SELECT VersionVar AS versionr;
+
+END
+$func$ LANGUAGE plpgsql;
+
+INSERT INTO OrleansQuery(QueryKey, QueryText)
+VALUES
+(
+    'UpsertReminderRowKey','
+    SELECT * FROM upsert_reminder_row(
+        @ServiceId,
+        @GrainId,
+        @ReminderName,
+        @StartTime,
+        @Period,
+        @GrainHash
+    );
+');
+
+INSERT INTO OrleansQuery(QueryKey, QueryText)
+VALUES
+(
+    'ReadReminderRowsKey','
+    SELECT
+        GrainId,
+        ReminderName,
+        StartTime,
+        Period,
+        Version
+    FROM OrleansRemindersTable
+    WHERE
+        ServiceId = @ServiceId AND @ServiceId IS NOT NULL
+        AND GrainId = @GrainId AND @GrainId IS NOT NULL;
+');
+
+INSERT INTO OrleansQuery(QueryKey, QueryText)
+VALUES
+(
+    'ReadReminderRowKey','
+    SELECT
+        GrainId,
+        ReminderName,
+        StartTime,
+        Period,
+        Version
+    FROM OrleansRemindersTable
+    WHERE
+        ServiceId = @ServiceId AND @ServiceId IS NOT NULL
+        AND GrainId = @GrainId AND @GrainId IS NOT NULL
+        AND ReminderName = @ReminderName AND @ReminderName IS NOT NULL;
+');
+
+INSERT INTO OrleansQuery(QueryKey, QueryText)
+VALUES
+(
+    'ReadRangeRows1Key','
+    SELECT
+        GrainId,
+        ReminderName,
+        StartTime,
+        Period,
+        Version
+    FROM OrleansRemindersTable
+    WHERE
+        ServiceId = @ServiceId AND @ServiceId IS NOT NULL
+        AND GrainHash > @BeginHash AND @BeginHash IS NOT NULL
+        AND GrainHash <= @EndHash AND @EndHash IS NOT NULL;
+');
+
+INSERT INTO OrleansQuery(QueryKey, QueryText)
+VALUES
+(
+    'ReadRangeRows2Key','
+    SELECT
+        GrainId,
+        ReminderName,
+        StartTime,
+        Period,
+        Version
+    FROM OrleansRemindersTable
+    WHERE
+        ServiceId = @ServiceId AND @ServiceId IS NOT NULL
+        AND ((GrainHash > @BeginHash AND @BeginHash IS NOT NULL)
+        OR (GrainHash <= @EndHash AND @EndHash IS NOT NULL));
+');
+
+CREATE FUNCTION delete_reminder_row(
+    ServiceIdArg    OrleansRemindersTable.ServiceId%TYPE,
+    GrainIdArg      OrleansRemindersTable.GrainId%TYPE,
+    ReminderNameArg OrleansRemindersTable.ReminderName%TYPE,
+    VersionArg      OrleansRemindersTable.Version%TYPE
+)
+  RETURNS TABLE(row_count integer) AS
+$func$
+DECLARE
+    RowCountVar int := 0;
+BEGIN
+
+
+    DELETE FROM OrleansRemindersTable
+    WHERE
+        ServiceId = ServiceIdArg AND ServiceIdArg IS NOT NULL
+        AND GrainId = GrainIdArg AND GrainIdArg IS NOT NULL
+        AND ReminderName = ReminderNameArg AND ReminderNameArg IS NOT NULL
+        AND Version = VersionArg AND VersionArg IS NOT NULL;
+
+    GET DIAGNOSTICS RowCountVar = ROW_COUNT;
+
+    RETURN QUERY SELECT RowCountVar;
+
+END
+$func$ LANGUAGE plpgsql;
+
+INSERT INTO OrleansQuery(QueryKey, QueryText)
+VALUES
+(
+    'DeleteReminderRowKey','
+    SELECT * FROM delete_reminder_row(
+        @ServiceId,
+        @GrainId,
+        @ReminderName,
+        @Version
+    );
+');
+
+INSERT INTO OrleansQuery(QueryKey, QueryText)
+VALUES
+(
+    'DeleteReminderRowsKey','
+    DELETE FROM OrleansRemindersTable
+    WHERE
+        ServiceId = @ServiceId AND @ServiceId IS NOT NULL;
+');

--- a/tests/manual/65-persistent-reminders/test-plan.md
+++ b/tests/manual/65-persistent-reminders/test-plan.md
@@ -49,7 +49,39 @@ same as 'restart everything', which Step A already covers.
 - `fleans-core` logs show the reminder service initialised against Redis on
   silo startup (search for `Microsoft.Orleans.Reminders.Redis` / `Redis reminder`).
 
-## Failure-mode regression (fail-fast)
+### Step C — Postgres reminders single-silo restart (#669)
+
+1. `cd out/compose && docker compose up -d` with `FLEANS_PERSISTENCE_PROVIDER=Postgres`
+   AND `Fleans__Reminders__Provider=Postgres` on the `fleans-core` service.
+2. After startup, confirm the reminder table was auto-created:
+   ```bash
+   docker compose exec postgres psql -U fleans -d fleans \
+     -c 'SELECT count(*) FROM "OrleansRemindersTable";'
+   # → 0 (table exists, no rows yet)
+   docker compose exec postgres psql -U fleans -d fleans \
+     -c "SELECT count(*) FROM \"OrleansQuery\" WHERE \"QueryKey\" = 'ReadRangeRows1Key';"
+   # → 1 (Main.sql ran and inserted the query template)
+   ```
+3. Deploy `timer-restart.bpmn` and start an instance (same as Step A 2-3).
+4. Confirm a reminder row was persisted:
+   ```bash
+   docker compose exec postgres psql -U fleans -d fleans \
+     -c 'SELECT "GrainId","ReminderName","StartTime" FROM "OrleansRemindersTable";'
+   ```
+5. Restart `fleans-core`. Wait for the timer to fire.
+6. **Pass:** the workflow completes and the reminder row disappears
+   (TimerCallbackGrain unregistered itself in `ReceiveReminder`).
+
+### Step D — Mixed-storage fail-fast (SQLite app + Postgres reminders)
+
+With the default `FLEANS_PERSISTENCE_PROVIDER=Sqlite` set, set
+`Fleans__Reminders__Provider=Postgres` on the `fleans-core` service and restart.
+
+**Pass:** silo refuses to start. `fleans-core` logs show
+`InvalidOperationException: Fleans:Reminders:Provider=Postgres requires
+Persistence:Provider=Postgres (got 'Sqlite'). Mixed-storage … unsupported`.
+
+## Failure-mode regression (fail-fast, Redis path)
 
 A separate check: with `orleans-redis` unset (e.g. `docker compose stop redis`),
 restart `fleans-core` and confirm the silo **fails to start** with an


### PR DESCRIPTION
Closes #669.

## Summary

Adds opt-in **Postgres-backed Orleans reminders** alongside the default Redis reminders shipped in #663. Operators on `Persistence:Provider=Postgres` can now uniform their app + reminder durability on Postgres by setting `Fleans:Reminders:Provider=Postgres`.

Per the round-3 design — 3 analysis rounds caught real flaws (broken sentinel under EF Core's `ExecuteSqlRawAsync` SELECT semantics, manifest-resource naming defaults, Apache-2.0 attribution specifics, vendored-script dependency on `OrleansQuery` from `PostgreSQL-Main.sql`).

## Provider matrix

| `Persistence:Provider` | `Fleans:Reminders:Provider` | Outcome |
|---|---|---|
| `Sqlite` (default) | `Redis` (default) | Supported. Single-binary story preserved. |
| `Sqlite` | `Postgres` | **Unsupported — silo refuses to start.** |
| `Postgres` | `Redis` (default) | Supported. Reminders ride the clustering Redis. |
| `Postgres` | `Postgres` | Supported. Reminders share `ConnectionStrings:fleans` with app persistence. |

## What ships

- New config key `Fleans:Reminders:Provider` (matched case-insensitively; default `Redis` — back-compat with #663). Bound to a new `FleansPersistenceOptions.RemindersProvider` field at registration time so `EnsureDatabaseSchemaAsync` reads it via `IOptions` without re-accessing `IConfiguration` after `Build()`.
- `FleansRemindersExtensions.AddFleansReminders` becomes provider-switching with three fail-fast guards: (a) Postgres+SQLite-app combo, (b) missing connection string for the chosen provider, (c) unknown provider value.
- `Microsoft.Orleans.Reminders.AdoNet 10.0.1` added to `Fleans.ServiceDefaults`, **pinned** to match the `Microsoft.Orleans.*` sibling versions.
- `PostgreSQL-Main.sql` + `PostgreSQL-Reminders.sql` vendored unmodified from the upstream Orleans `v10.0.1` tag into `src/Fleans/Fleans.ServiceDefaults/Resources/` (Apache-2.0; per-file header + `LICENSE-orleans-vendor` at the repo root).
- `EnsureDatabaseSchemaAsync` runs both scripts under the existing advisory lock when Postgres reminders are enabled. Idempotent via the `OrleansQuery` existence sentinel checked via raw ADO.NET `ExecuteScalarAsync` (EF Core's `ExecuteSqlRawAsync` returns -1 on SELECT in Npgsql so it cannot be used as a sentinel).

## Tests

- `Fleans.ServiceDefaults.Tests/FleansRemindersExtensionsTests.cs` — 6 tests covering the provider-switch + fail-fast matrix via the testable `ResolveRemindersConfiguration()` pure function (extracted so unit tests don't need a TestCluster).
- `Fleans.ServiceDefaults.Tests/EmbeddedSchemaResourceTests.cs` — 4 tests (via `[DataRow]`) verifying (a) both vendored .sql files are embedded under the expected manifest names and (b) carry the version-pin comment as a drift guard against silent SDK bumps that forget to re-vendor.
- All `Fleans.ServiceDefaults.Tests` (15/15) and `Fleans.Persistence.Tests` (147/147 — 124 PG rows skipped without `FLEANS_PG_TESTS=1`) pass locally.

## Docs + manual

- `docs/conventions/reminders.md` gets a provider matrix and a "Postgres reminders schema" subsection covering the vendored-script approach and the idempotent sentinel.
- `tests/manual/65-persistent-reminders/test-plan.md` gets **Step C** (Postgres reminders single-silo restart with table-creation verification queries) and **Step D** (mixed-storage fail-fast regression).

## Out of scope (filed as follow-ups if a real operator asks)

- Dedicated `ConnectionStrings:reminders` override (separate Postgres instance from app persistence).
- SQLite reminders provider (`Microsoft.Orleans.Reminders.AdoNet` doesn't bundle a SQLite invariant; upstream SDK work).
- Helm chart `reminders.provider` knob (separate issue against the chart repo).

## Re-vendoring runbook

When `Microsoft.Orleans.Reminders.AdoNet` is bumped, the two `.sql` files in `Resources/` must be re-fetched from the matching upstream tag and their version-pin comment updated. The `EmbeddedResource_ContainsVersionPin` test will fail immediately if a bump forgets the re-vendor step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)