### PR TITLE
feat(#661): enforce CQRS read-side via IFleanQueryContext interface

### DIFF
--- a/docs/plans/2026-02-15-cqrs-query-service-design.md
+++ b/docs/plans/2026-02-15-cqrs-query-service-design.md
@@ -203,3 +203,18 @@ public static void AddQueryServices(this IServiceCollection services)
 
 **Remove:**
 - Any tests that call `GetStateSnapshot` through the grain interface
+
+## CQRS read-side enforcement (#661)
+
+The CQRS read contract is enforced at compile time by `IFleanQueryContext` — a read-only projection of `FleanQueryDbContext` exposing only `IQueryable<T>` properties (plus `IAsyncDisposable` for `await using` compatibility). `IFleanQueryContextFactory` (Singleton, wrapping the EF Core `IDbContextFactory<FleanQueryDbContext>`) creates per-call instances for Singleton consumers.
+
+**Migrated consumer (1):** `EfCoreProcessDefinitionRepository` — all 4 read methods resolve the read-only interface.
+
+**Deliberate carve-outs (3, all keep concrete `FleanQueryDbContext`):**
+1. `WorkflowQueryService` — body delegates to `IUserTaskFilterStrategy.GetFilteredBase(db, ...)`, which by contract takes `FleanQueryDbContext`. Migrating the service would break the strategy call.
+2. `PostgresUserTaskFilterStrategy` — implementation calls `db.UserTasks.FromSqlInterpolated(...)`, an EF Core extension on `DbSet<TEntity>` only.
+3. `InMemoryUserTaskFilterStrategy` — pairs with (2) under the same `IUserTaskFilterStrategy` contract.
+
+Each production-code carve-out (`WorkflowQueryService.cs`, `PostgresUserTaskFilterStrategy.cs`) carries an explanatory comment referencing #661.
+
+Future work (separate issue): tighten `IUserTaskFilterStrategy.GetFilteredBase` to accept `DbSet<UserTaskState>` only (the one entity it needs), which would let `WorkflowQueryService` migrate to `IFleanQueryContextFactory`. Out of scope for #661.

--- a/src/Fleans/Fleans.Application.Tests/EventPublisherTests.cs
+++ b/src/Fleans/Fleans.Application.Tests/EventPublisherTests.cs
@@ -202,6 +202,7 @@ public class EventPublisherTests
                     services.AddSingleton<IEventStore>(sp => sp.GetRequiredService<EfCoreEventStore>());
                     services.AddApplication();
 
+                    services.AddSingleton<IFleanQueryContextFactory, FleanQueryContextFactory>();
                     services.AddSingleton<IProcessDefinitionRepository, EfCoreProcessDefinitionRepository>();
                     services.AddSingleton<ISieveProcessor, ApplicationSieveProcessor>();
                     services.Configure<SieveOptions>(options =>

--- a/src/Fleans/Fleans.Application.Tests/WorkflowTestBase.cs
+++ b/src/Fleans/Fleans.Application.Tests/WorkflowTestBase.cs
@@ -205,6 +205,7 @@ public abstract class WorkflowTestBase
                         (sp, _) => new EfCoreProcessDefinitionGrainStorage(
                             sp.GetRequiredService<IDbContextFactory<FleanCommandDbContext>>()));
 
+                    services.AddSingleton<IFleanQueryContextFactory, FleanQueryContextFactory>();
                     services.AddSingleton<IProcessDefinitionRepository, EfCoreProcessDefinitionRepository>();
                     services.AddSingleton<ISieveProcessor, ApplicationSieveProcessor>();
                     services.Configure<SieveOptions>(options =>

--- a/src/Fleans/Fleans.Infrastructure.Tests/MultiInstanceScriptIntegrationTests.cs
+++ b/src/Fleans/Fleans.Infrastructure.Tests/MultiInstanceScriptIntegrationTests.cs
@@ -362,6 +362,7 @@ public class MultiInstanceScriptIntegrationTests
                         (sp, _) => new EfCoreTimerSchedulerGrainStorage(
                             sp.GetRequiredService<IDbContextFactory<FleanCommandDbContext>>()));
 
+                    services.AddSingleton<IFleanQueryContextFactory, FleanQueryContextFactory>();
                     services.AddSingleton<IProcessDefinitionRepository, EfCoreProcessDefinitionRepository>();
                     services.AddSingleton<ISieveProcessor, ApplicationSieveProcessor>();
                     services.Configure<SieveOptions>(options =>

--- a/src/Fleans/Fleans.Persistence.PostgreSql/PostgresUserTaskFilterStrategy.cs
+++ b/src/Fleans/Fleans.Persistence.PostgreSql/PostgresUserTaskFilterStrategy.cs
@@ -21,6 +21,11 @@ public sealed class PostgresUserTaskFilterStrategy : IUserTaskFilterStrategy
 
     // Path C: use FromSqlInterpolated to push the JSON-text LIKE filter to PostgreSQL.
     // Sieve sort + additional LINQ WHERE clauses compose correctly on top of FromSqlInterpolated.
+    //
+    // CQRS carve-out (see #661): parameter type stays FleanQueryDbContext rather than
+    // IFleanQueryContext because FromSqlInterpolated is an EF Core extension on
+    // DbSet<TEntity>, not IQueryable<T>. The interface deliberately exposes IQueryable<T>
+    // only — see IFleanQueryContext xmldoc.
     public IQueryable<UserTaskState> GetFilteredBase(
         FleanQueryDbContext db, string? assignee, string? candidateGroup)
     {

--- a/src/Fleans/Fleans.Persistence.Tests/EfCoreProcessDefinitionRepositoryTests.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/EfCoreProcessDefinitionRepositoryTests.cs
@@ -16,7 +16,7 @@ public class EfCoreProcessDefinitionRepositoryTests : PersistenceTestBase
     public async Task SaveAndGetById_RoundTrip_ReturnsAllScalarFields(PersistenceProvider provider)
     {
         await using var fixture = await TestFixtureFactory.CreateAsync(provider);
-        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryFactory);
+        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryContextFactory);
 
         var deployedAt = DateTimeOffset.UtcNow;
         var definition = CreateDefinition("key1:1:ts", "key1", 1, deployedAt);
@@ -39,7 +39,7 @@ public class EfCoreProcessDefinitionRepositoryTests : PersistenceTestBase
     public async Task SaveAndGetById_WorkflowJsonRoundTrip_PolymorphicActivityTypes(PersistenceProvider provider)
     {
         await using var fixture = await TestFixtureFactory.CreateAsync(provider);
-        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryFactory);
+        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryContextFactory);
 
         var definition = CreateDefinitionWithMixedActivities();
 
@@ -66,7 +66,7 @@ public class EfCoreProcessDefinitionRepositoryTests : PersistenceTestBase
     public async Task SaveAndGetById_WorkflowJsonRoundTrip_PolymorphicSequenceFlowTypes(PersistenceProvider provider)
     {
         await using var fixture = await TestFixtureFactory.CreateAsync(provider);
-        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryFactory);
+        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryContextFactory);
 
         var definition = CreateDefinitionWithMixedActivities();
 
@@ -93,7 +93,7 @@ public class EfCoreProcessDefinitionRepositoryTests : PersistenceTestBase
     public async Task SaveAndGetById_WorkflowJsonRoundTrip_SharedActivityReferences(PersistenceProvider provider)
     {
         await using var fixture = await TestFixtureFactory.CreateAsync(provider);
-        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryFactory);
+        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryContextFactory);
 
         var definition = CreateDefinitionWithMixedActivities();
 
@@ -120,7 +120,7 @@ public class EfCoreProcessDefinitionRepositoryTests : PersistenceTestBase
     public async Task GetByKey_ReturnsVersionsOrderedByVersion(PersistenceProvider provider)
     {
         await using var fixture = await TestFixtureFactory.CreateAsync(provider);
-        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryFactory);
+        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryContextFactory);
 
         await repository.SaveAsync(CreateDefinition("key1:3:ts", "key1", 3, DateTimeOffset.UtcNow));
         await repository.SaveAsync(CreateDefinition("key1:1:ts", "key1", 1, DateTimeOffset.UtcNow));
@@ -140,7 +140,7 @@ public class EfCoreProcessDefinitionRepositoryTests : PersistenceTestBase
     public async Task GetAll_ReturnsAllDefinitionsOrderedByKeyThenVersion(PersistenceProvider provider)
     {
         await using var fixture = await TestFixtureFactory.CreateAsync(provider);
-        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryFactory);
+        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryContextFactory);
 
         await repository.SaveAsync(CreateDefinition("beta:2:ts", "beta", 2, DateTimeOffset.UtcNow));
         await repository.SaveAsync(CreateDefinition("alpha:1:ts", "alpha", 1, DateTimeOffset.UtcNow));
@@ -166,7 +166,7 @@ public class EfCoreProcessDefinitionRepositoryTests : PersistenceTestBase
     public async Task GetById_NonExistent_ReturnsNull(PersistenceProvider provider)
     {
         await using var fixture = await TestFixtureFactory.CreateAsync(provider);
-        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryFactory);
+        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryContextFactory);
 
         var result = await repository.GetByIdAsync("does-not-exist");
 
@@ -179,7 +179,7 @@ public class EfCoreProcessDefinitionRepositoryTests : PersistenceTestBase
     public async Task Delete_RemovesDefinition_SubsequentGetByIdReturnsNull(PersistenceProvider provider)
     {
         await using var fixture = await TestFixtureFactory.CreateAsync(provider);
-        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryFactory);
+        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryContextFactory);
 
         var definition = CreateDefinition("key1:1:ts", "key1", 1, DateTimeOffset.UtcNow);
         await repository.SaveAsync(definition);
@@ -196,7 +196,7 @@ public class EfCoreProcessDefinitionRepositoryTests : PersistenceTestBase
     public async Task Delete_NonExistentId_IsNoOp(PersistenceProvider provider)
     {
         await using var fixture = await TestFixtureFactory.CreateAsync(provider);
-        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryFactory);
+        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryContextFactory);
 
         await repository.DeleteAsync("does-not-exist");
     }
@@ -207,7 +207,7 @@ public class EfCoreProcessDefinitionRepositoryTests : PersistenceTestBase
     public async Task Save_DuplicateProcessDefinitionId_ThrowsInvalidOperationException(PersistenceProvider provider)
     {
         await using var fixture = await TestFixtureFactory.CreateAsync(provider);
-        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryFactory);
+        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryContextFactory);
 
         var definition = CreateDefinition("key1:1:ts", "key1", 1, DateTimeOffset.UtcNow);
         await repository.SaveAsync(definition);
@@ -222,7 +222,7 @@ public class EfCoreProcessDefinitionRepositoryTests : PersistenceTestBase
     public async Task SaveAndGetById_DisabledProcess_IsActiveFalseRoundTrip(PersistenceProvider provider)
     {
         await using var fixture = await TestFixtureFactory.CreateAsync(provider);
-        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryFactory);
+        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryContextFactory);
 
         var definition = CreateDefinition("disabled:1:ts", "disabled", 1, DateTimeOffset.UtcNow);
         definition.Disable();
@@ -241,7 +241,7 @@ public class EfCoreProcessDefinitionRepositoryTests : PersistenceTestBase
     public async Task SaveAndGetById_EnabledProcess_IsActiveTrueByDefault(PersistenceProvider provider)
     {
         await using var fixture = await TestFixtureFactory.CreateAsync(provider);
-        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryFactory);
+        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryContextFactory);
 
         var definition = CreateDefinition("enabled:1:ts", "enabled", 1, DateTimeOffset.UtcNow);
 
@@ -259,7 +259,7 @@ public class EfCoreProcessDefinitionRepositoryTests : PersistenceTestBase
     public async Task UpdateAsync_DisableExistingProcess_PersistsIsActiveFalse(PersistenceProvider provider)
     {
         await using var fixture = await TestFixtureFactory.CreateAsync(provider);
-        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryFactory);
+        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryContextFactory);
 
         var definition = CreateDefinition("upd:1:ts", "upd", 1, DateTimeOffset.UtcNow);
         await repository.SaveAsync(definition);
@@ -278,7 +278,7 @@ public class EfCoreProcessDefinitionRepositoryTests : PersistenceTestBase
     public async Task UpdateAsync_EnableDisabledProcess_PersistsIsActiveTrue(PersistenceProvider provider)
     {
         await using var fixture = await TestFixtureFactory.CreateAsync(provider);
-        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryFactory);
+        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryContextFactory);
 
         var definition = CreateDefinition("upd2:1:ts", "upd2", 1, DateTimeOffset.UtcNow);
         definition.Disable();
@@ -298,7 +298,7 @@ public class EfCoreProcessDefinitionRepositoryTests : PersistenceTestBase
     public async Task UpdateAsync_NonExistentDefinition_ThrowsInvalidOperationException(PersistenceProvider provider)
     {
         await using var fixture = await TestFixtureFactory.CreateAsync(provider);
-        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryFactory);
+        var repository = new EfCoreProcessDefinitionRepository(fixture.CommandFactory, fixture.QueryContextFactory);
 
         var definition = CreateDefinition("missing:1:ts", "missing", 1, DateTimeOffset.UtcNow);
 

--- a/src/Fleans/Fleans.Persistence.Tests/IFleanQueryContextTests.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/IFleanQueryContextTests.cs
@@ -1,0 +1,42 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Fleans.Persistence.Tests;
+
+[TestClass]
+public class IFleanQueryContextTests
+{
+    /// <summary>
+    /// Reflection-based assertion that the interface's own declaration exposes
+    /// no <see cref="Microsoft.EntityFrameworkCore.DbSet{T}"/> properties and no
+    /// mutation methods (Add/Update/Remove). The check filters by
+    /// <c>DeclaringType == typeof(IFleanQueryContext)</c>: inherited
+    /// <see cref="IAsyncDisposable.DisposeAsync"/> is expected and is excluded
+    /// from the read-surface contract assertion. Extension methods on
+    /// <see cref="IQueryable{T}"/> (e.g. <c>.Include</c>, <c>.Where</c>,
+    /// <c>.AsNoTracking</c>) are static and therefore unaffected; consumers
+    /// continue to use them on the returned <c>IQueryable&lt;T&gt;</c> values.
+    /// See #661.
+    /// </summary>
+    [TestMethod]
+    public void IFleanQueryContext_DoesNotExposeMutationMethods()
+    {
+        var interfaceType = typeof(IFleanQueryContext);
+
+        foreach (var prop in interfaceType.GetProperties()
+                                          .Where(p => p.DeclaringType == interfaceType))
+        {
+            Assert.IsTrue(
+                prop.PropertyType.IsGenericType &&
+                prop.PropertyType.GetGenericTypeDefinition() == typeof(IQueryable<>),
+                $"IFleanQueryContext.{prop.Name} must be IQueryable<T>, was {prop.PropertyType}");
+        }
+
+        var declaredMethods = interfaceType.GetMethods()
+            .Where(m => m.DeclaringType == interfaceType && !m.IsSpecialName) // skip property getters
+            .ToList();
+
+        Assert.AreEqual(0, declaredMethods.Count,
+            "IFleanQueryContext should declare no methods beyond IQueryable<T> property getters " +
+            "(inherited IAsyncDisposable.DisposeAsync is expected and excluded by the DeclaringType filter)");
+    }
+}

--- a/src/Fleans/Fleans.Persistence.Tests/Infrastructure/IPersistenceTestFixture.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/Infrastructure/IPersistenceTestFixture.cs
@@ -12,4 +12,14 @@ public interface IPersistenceTestFixture : IAsyncDisposable
     PersistenceProvider Provider { get; }
     IDbContextFactory<FleanCommandDbContext> CommandFactory { get; }
     IDbContextFactory<FleanQueryDbContext> QueryFactory { get; }
+
+    /// <summary>
+    /// CQRS-restricted query-context factory wrapping <see cref="QueryFactory"/>.
+    /// Pass this when constructing components that depend on
+    /// <see cref="IFleanQueryContextFactory"/> (e.g.
+    /// <see cref="EfCoreProcessDefinitionRepository"/>). Default-interface-member
+    /// avoids 15 inline <c>new FleanQueryContextFactory(...)</c> sites in the
+    /// repository test class. See #661.
+    /// </summary>
+    IFleanQueryContextFactory QueryContextFactory => new FleanQueryContextFactory(QueryFactory);
 }

--- a/src/Fleans/Fleans.Persistence/DependencyInjection.cs
+++ b/src/Fleans/Fleans.Persistence/DependencyInjection.cs
@@ -21,6 +21,12 @@ public static class EfCorePersistenceDependencyInjection
         services.AddDbContextFactory<FleanCommandDbContext>(configureCommandDb);
         services.AddDbContextFactory<FleanQueryDbContext>(configureQueryDb ?? configureCommandDb);
 
+        // CQRS read-side wrapper (see #661): wraps the EF Core factory in an
+        // IFleanQueryContextFactory that returns IQueryable<T>-only views. Singleton lifetime
+        // matches the underlying EF Core factory; the per-call IFleanQueryContext is disposed
+        // inside the consumer's `await using` block.
+        services.AddSingleton<IFleanQueryContextFactory, FleanQueryContextFactory>();
+
         services.AddKeyedSingleton<IGrainStorage>(GrainStorageNames.ProcessDefinitions,
             (sp, _) => new EfCoreProcessDefinitionGrainStorage(
                 sp.GetRequiredService<IDbContextFactory<FleanCommandDbContext>>()));

--- a/src/Fleans/Fleans.Persistence/EfCoreProcessDefinitionRepository.cs
+++ b/src/Fleans/Fleans.Persistence/EfCoreProcessDefinitionRepository.cs
@@ -7,11 +7,11 @@ namespace Fleans.Persistence;
 public class EfCoreProcessDefinitionRepository : IProcessDefinitionRepository
 {
     private readonly IDbContextFactory<FleanCommandDbContext> _commandDbFactory;
-    private readonly IDbContextFactory<FleanQueryDbContext> _queryDbFactory;
+    private readonly IFleanQueryContextFactory _queryDbFactory;
 
     public EfCoreProcessDefinitionRepository(
         IDbContextFactory<FleanCommandDbContext> commandDbFactory,
-        IDbContextFactory<FleanQueryDbContext> queryDbFactory)
+        IFleanQueryContextFactory queryDbFactory)
     {
         _commandDbFactory = commandDbFactory;
         _queryDbFactory = queryDbFactory;
@@ -19,14 +19,14 @@ public class EfCoreProcessDefinitionRepository : IProcessDefinitionRepository
 
     public async Task<ProcessDefinition?> GetByIdAsync(string processDefinitionId)
     {
-        await using var db = await _queryDbFactory.CreateDbContextAsync();
+        await using var db = await _queryDbFactory.CreateAsync();
         return await db.ProcessDefinitions
             .FirstOrDefaultAsync(d => d.ProcessDefinitionId == processDefinitionId);
     }
 
     public async Task<List<ProcessDefinition>> GetByKeyAsync(string processDefinitionKey)
     {
-        await using var db = await _queryDbFactory.CreateDbContextAsync();
+        await using var db = await _queryDbFactory.CreateAsync();
         return await db.ProcessDefinitions
             .Where(d => d.ProcessDefinitionKey == processDefinitionKey)
             .OrderBy(d => d.Version)
@@ -35,7 +35,7 @@ public class EfCoreProcessDefinitionRepository : IProcessDefinitionRepository
 
     public async Task<List<ProcessDefinition>> GetAllAsync()
     {
-        await using var db = await _queryDbFactory.CreateDbContextAsync();
+        await using var db = await _queryDbFactory.CreateAsync();
         return await db.ProcessDefinitions
             .OrderBy(d => d.ProcessDefinitionKey)
             .ThenBy(d => d.Version)
@@ -44,7 +44,7 @@ public class EfCoreProcessDefinitionRepository : IProcessDefinitionRepository
 
     public async Task<List<string>> GetAllDistinctKeysAsync()
     {
-        await using var db = await _queryDbFactory.CreateDbContextAsync();
+        await using var db = await _queryDbFactory.CreateAsync();
         return await db.ProcessDefinitions
             .Select(d => d.ProcessDefinitionKey)
             .Distinct()

--- a/src/Fleans/Fleans.Persistence/FleanQueryDbContext.cs
+++ b/src/Fleans/Fleans.Persistence/FleanQueryDbContext.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Fleans.Persistence;
 
-public class FleanQueryDbContext : DbContext
+public class FleanQueryDbContext : DbContext, IFleanQueryContext
 {
     public DbSet<WorkflowInstanceState> WorkflowInstances => Set<WorkflowInstanceState>();
     public DbSet<ProcessDefinition> ProcessDefinitions => Set<ProcessDefinition>();
@@ -31,4 +31,18 @@ public class FleanQueryDbContext : DbContext
     {
         FleanModelConfiguration.Configure(modelBuilder);
     }
+
+    // Explicit IFleanQueryContext implementation — exposes IQueryable<T> only so the
+    // CQRS-restricted view is invisible from the concrete class but reachable via the
+    // interface contract. DbContext already implements IAsyncDisposable.
+    IQueryable<WorkflowInstanceState> IFleanQueryContext.WorkflowInstances => WorkflowInstances;
+    IQueryable<ProcessDefinition> IFleanQueryContext.ProcessDefinitions => ProcessDefinitions;
+    IQueryable<UserTaskState> IFleanQueryContext.UserTasks => UserTasks;
+    IQueryable<WorkflowEventEntity> IFleanQueryContext.WorkflowEvents => WorkflowEvents;
+    IQueryable<WorkflowSnapshotEntity> IFleanQueryContext.WorkflowSnapshots => WorkflowSnapshots;
+    IQueryable<MessageStartEventRegistration> IFleanQueryContext.MessageStartEventRegistrations => MessageStartEventRegistrations;
+    IQueryable<SignalStartEventRegistration> IFleanQueryContext.SignalStartEventRegistrations => SignalStartEventRegistrations;
+    IQueryable<ConditionalStartEventListenerState> IFleanQueryContext.ConditionalStartEventListeners => ConditionalStartEventListeners;
+    IQueryable<MessageSubscription> IFleanQueryContext.MessageSubscriptions => MessageSubscriptions;
+    IQueryable<SignalSubscription> IFleanQueryContext.SignalSubscriptions => SignalSubscriptions;
 }

--- a/src/Fleans/Fleans.Persistence/IFleanQueryContext.cs
+++ b/src/Fleans/Fleans.Persistence/IFleanQueryContext.cs
@@ -1,0 +1,32 @@
+using Fleans.Domain;
+using Fleans.Domain.States;
+using Fleans.Persistence.Events;
+
+namespace Fleans.Persistence;
+
+/// <summary>
+/// Read-side view of the persistence model for the CQRS query path.
+/// Exposes <see cref="IQueryable{T}"/> only — no mutation surface — so the
+/// type system catches accidental writes through the query side at compile time.
+/// Implemented by <see cref="FleanQueryDbContext"/>.
+///
+/// See <c>docs/plans/2026-02-15-cqrs-query-service-design.md</c> for the CQRS
+/// contract and #661 for the originating concern. Two consumers are deliberately
+/// exempt and stay on the concrete <see cref="FleanQueryDbContext"/>:
+/// <see cref="WorkflowQueryService"/> (the body delegates to <c>IUserTaskFilterStrategy</c>
+/// which keeps <see cref="FleanQueryDbContext"/>) and <c>PostgresUserTaskFilterStrategy</c>
+/// (uses <c>FromSqlInterpolated</c>, an EF Core extension on <c>DbSet&lt;TEntity&gt;</c>).
+/// </summary>
+public interface IFleanQueryContext : IAsyncDisposable
+{
+    IQueryable<WorkflowInstanceState> WorkflowInstances { get; }
+    IQueryable<ProcessDefinition> ProcessDefinitions { get; }
+    IQueryable<UserTaskState> UserTasks { get; }
+    IQueryable<WorkflowEventEntity> WorkflowEvents { get; }
+    IQueryable<WorkflowSnapshotEntity> WorkflowSnapshots { get; }
+    IQueryable<MessageStartEventRegistration> MessageStartEventRegistrations { get; }
+    IQueryable<SignalStartEventRegistration> SignalStartEventRegistrations { get; }
+    IQueryable<ConditionalStartEventListenerState> ConditionalStartEventListeners { get; }
+    IQueryable<MessageSubscription> MessageSubscriptions { get; }
+    IQueryable<SignalSubscription> SignalSubscriptions { get; }
+}

--- a/src/Fleans/Fleans.Persistence/IFleanQueryContextFactory.cs
+++ b/src/Fleans/Fleans.Persistence/IFleanQueryContextFactory.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Fleans.Persistence;
+
+/// <summary>
+/// Singleton-safe factory for <see cref="IFleanQueryContext"/>. Wraps the EF Core
+/// <c>IDbContextFactory&lt;FleanQueryDbContext&gt;</c> to expose the CQRS-restricted
+/// read-side view. Use this from Singleton consumers (currently
+/// <see cref="EfCoreProcessDefinitionRepository"/>).
+/// </summary>
+public interface IFleanQueryContextFactory
+{
+    Task<IFleanQueryContext> CreateAsync(CancellationToken cancellationToken = default);
+}
+
+public sealed class FleanQueryContextFactory : IFleanQueryContextFactory
+{
+    private readonly IDbContextFactory<FleanQueryDbContext> _inner;
+
+    public FleanQueryContextFactory(IDbContextFactory<FleanQueryDbContext> inner)
+        => _inner = inner;
+
+    public async Task<IFleanQueryContext> CreateAsync(CancellationToken cancellationToken = default)
+        => await _inner.CreateDbContextAsync(cancellationToken);
+}

--- a/src/Fleans/Fleans.Persistence/WorkflowQueryService.cs
+++ b/src/Fleans/Fleans.Persistence/WorkflowQueryService.cs
@@ -14,6 +14,10 @@ namespace Fleans.Persistence;
 
 public class WorkflowQueryService : IWorkflowQueryService
 {
+    // CQRS carve-out (see #661): field type stays IDbContextFactory<FleanQueryDbContext>
+    // rather than IFleanQueryContextFactory because the body delegates to
+    // _userTaskFilter.GetFilteredBase(db, ...) which by contract takes the concrete
+    // FleanQueryDbContext (PostgresUserTaskFilterStrategy needs DbSet<T> for FromSqlInterpolated).
     private readonly IDbContextFactory<FleanQueryDbContext> _dbContextFactory;
     private readonly ISieveProcessor _sieveProcessor;
     private readonly IUserTaskFilterStrategy _userTaskFilter;


### PR DESCRIPTION
## Summary

- Enforces the CQRS read-side contract at compile time via a new `IFleanQueryContext` interface (`IQueryable<T>`-only, extends `IAsyncDisposable`) plus an `IFleanQueryContextFactory` wrapping the EF Core `IDbContextFactory<FleanQueryDbContext>`.
- Migrates `EfCoreProcessDefinitionRepository` to depend on the new factory (all 4 read methods use `IQueryable<T>` extensions only — body-change-free).
- Two deliberate carve-outs stay on the concrete `FleanQueryDbContext`, with inline rationale comments referencing #661:
  - `WorkflowQueryService` — delegates to `IUserTaskFilterStrategy` whose contract takes `FleanQueryDbContext`.
  - `PostgresUserTaskFilterStrategy` — `FromSqlInterpolated` is an EF Core extension on `DbSet<TEntity>` only.

Closes #661.

## Plan trail

Round 1 → Round 2 → Round 3 → Round 4 (each round addressed substantive review findings — `FromSqlInterpolated` constraint, ctor-signature mismatch on Singleton consumers, reflection-test inheritance, test-class enumeration). See issue comments for the full audit trail.

## Test plan

- [x] `dotnet build` — 0 errors, 618 warnings (all pre-existing MSTest analyzer noise on unrelated test files).
- [x] `Fleans.Persistence.Tests` — 148 passed, 124 Postgres skipped (Docker not required on CI for this PR's surface).
- [x] `Fleans.Application.Tests` — 334 passed, 6 skipped, 0 failed (10m 46s).
- [x] `Fleans.Infrastructure.Tests` — 186 passed, 0 failed (12s).
- [x] New unit test `IFleanQueryContextTests.IFleanQueryContext_DoesNotExposeMutationMethods` — reflection-based regression guard with `DeclaringType` filter (excludes inherited `IAsyncDisposable.DisposeAsync`).

## Key design decisions

- **`IFleanQueryContext : IAsyncDisposable`** lets consumers use the existing `await using` pattern. `DbContext` already implements `IAsyncDisposable`, so `FleanQueryDbContext` satisfies the contract via base-class inheritance.
- **Explicit-interface implementation on `FleanQueryDbContext`** for the 10 properties — necessary because the concrete `DbSet<T>` accessors can't implicitly satisfy `IQueryable<T>` return types.
- **`IFleanQueryContextFactory` (Singleton) wrapping `IDbContextFactory<FleanQueryDbContext>`** — avoids the round-2 "Scoped-in-Singleton" lifetime trap that blocked an earlier design.
- **`FleanQueryContextFactory` made `public`** (not `internal`) so test DI graphs in `Fleans.Application.Tests` and `Fleans.Infrastructure.Tests` can reference it without broadening `InternalsVisibleTo`. The class is a thin wrapper with no risky surface.
- **Default-interface-member `QueryContextFactory`** on `IPersistenceTestFixture` — keeps the 15 ctor call sites in `EfCoreProcessDefinitionRepositoryTests` as 1-token diffs (`fixture.QueryFactory` → `fixture.QueryContextFactory`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
