### PR TITLE
audit: refresh infra rules 2026-05-25

### DIFF
--- a/docs/audits/audit-infra-rules.md
+++ b/docs/audits/audit-infra-rules.md
@@ -26,7 +26,7 @@
 - **signal:** `WorkflowQueryService.GetPendingUserTasks` (the paged overload) in `src/Fleans/Fleans.Persistence/WorkflowQueryService.cs` calls `sievedQuery.ToListAsync()` before the `ApplyUserTaskFilters` call — the assignee/candidateGroup WHERE clause is applied in memory after the full non-completed user-task table is loaded. Look for `ToListAsync()` followed by `ApplyUserTaskFilters(` with no intervening DB-level WHERE on assignee or candidateGroup.
 - **remediation:** Add provider-specific EF Core expressions for `CandidateUsers`/`CandidateGroups` JSON array containment (`@>` / `?` on PostgreSQL via Npgsql's `EF.Functions`) so the filter executes server-side on the Postgres provider. The SQLite path can retain the in-memory fallback. Follow the `RelationalModelCustomizer` subclass pattern in `Fleans.Persistence.Sqlite` and `Fleans.Persistence.PostgreSql`. See issue #415.
 - **first seen:** 2026-04-28
-- **last matched:** 2026-04-28
+- **last matched:** 2026-05-25
 
 ## pluggability/role-env-aspire-chart-parity
 - **dimension:** pluggability
@@ -35,3 +35,27 @@
 - **remediation:** Add `WithEnvironment("Fleans__Role", builder.Configuration["FLEANS_ROLE"] ?? "Combined")` when wiring the `fleans-core` project in Aspire. Document the `FLEANS_ROLE` local-dev override in CLAUDE.md under the Core/Worker role split section. See issue #416.
 - **first seen:** 2026-04-28
 - **last matched:** 2026-04-28
+
+## reliability/mcp-tcp-probe-not-http
+- **dimension:** reliability
+- **severity:** important
+- **signal:** `charts/fleans/templates/deployment-mcp.yaml` uses `tcpSocket` for both `livenessProbe` and `readinessProbe` — look for `tcpSocket:` under either probe block in that file. All other Fleans deployments (core, worker, web, custom-worker) use `httpGet` with `/alive` (liveness) and `/health` (readiness).
+- **remediation:** Replace both `tcpSocket` blocks in `deployment-mcp.yaml` with `httpGet` probes matching `deployment-core.yaml:44-52`. No application changes needed — `Fleans.Mcp/Program.cs` calls `app.MapDefaultEndpoints()` which registers `/alive` and `/health` via `Fleans.ServiceDefaults/Extensions.cs:110-113`. See issue #609.
+- **first seen:** 2026-05-25
+- **last matched:** 2026-05-25
+
+## pluggability/chart-persistence-provider-no-fail-guard
+- **dimension:** pluggability
+- **severity:** minor
+- **signal:** `charts/fleans/templates/_helpers.tpl` has a `{{- fail ... }}` guard for unknown `streaming.provider` values but no equivalent guard for `persistence.provider` — search for `fail` adjacent to `persistence.provider` in `_helpers.tpl`. An unknown value passes `helm template` silently and only fails at silo startup.
+- **remediation:** Add a Helm `fail` guard immediately before the `Persistence__Provider` env var entry in `_helpers.tpl`, mirroring the streaming guard at line 110-112: `{{- if not (has (lower .Values.persistence.provider) (list "sqlite" "postgres")) }}{{- fail (printf "Unsupported persistence.provider %q. Valid: Sqlite, Postgres." .Values.persistence.provider) }}{{- end }}`. See issue #675.
+- **first seen:** 2026-05-25
+- **last matched:** 2026-05-25
+
+## pluggability/reminders-provider-chart-gap
+- **dimension:** pluggability
+- **severity:** minor
+- **signal:** `charts/fleans/templates/_helpers.tpl` `fleans.commonEnv` template does not set `Fleans__Reminders__Provider` and `charts/fleans/values.yaml` has no `reminders.provider` key — search for `Reminders` in both files. `FleansRemindersExtensions.ResolveRemindersConfiguration` supports `Redis` and `Postgres` providers and throws on unknowns, but only `extraEnv` can configure this in a Helm install.
+- **remediation:** Add `reminders.provider: Redis` to `values.yaml` and a corresponding `fail`-guarded `Fleans__Reminders__Provider` env var entry in `fleans.commonEnv` in `_helpers.tpl`, matching the streaming provider pattern. See issue #676.
+- **first seen:** 2026-05-25
+- **last matched:** 2026-05-25


### PR DESCRIPTION
Generated by `audit-infra` on 2026-05-25.

## What changed

- **rules added: 3**
  - `reliability/mcp-tcp-probe-not-http` — MCP deployment uses `tcpSocket` probes; `/alive` + `/health` endpoints exist but aren't used (#609)
  - `pluggability/chart-persistence-provider-no-fail-guard` — streaming provider has a Helm `fail` guard; persistence provider doesn't (#675)
  - `pluggability/reminders-provider-chart-gap` — `Fleans:Reminders:Provider` is code-supported (Redis/Postgres) but has no `values.yaml` key or `commonEnv` entry (#676)

- **rules refreshed: 1**
  - `scalability/user-task-full-table-materialize` — `last matched` bumped to 2026-05-25; the non-paged overload and SQLite paged path still materialise the full table (#415 closed, pattern persists for SQLite path)

## Already resolved since last audit (no action needed)

| Rule | Issue | Status |
|---|---|---|
| `pluggability/persistence-unknown-provider-silent-fallback` | #413 | Closed — explicit `else if (Sqlite)` + throw added |
| `scalability/event-store-unbounded-read` | #414 | Closed — `Take(limit)` + `_maxEventsPerLoad` guard in place |
| `pluggability/role-env-aspire-chart-parity` | #416 | Closed — `Fleans__Role` stamped via `WithEnvironment` in Aspire |

## Issues touched

- #609 updated (marker added, `last-matched` refreshed)
- #675 opened
- #676 opened

---
_Generated by [Claude Code](https://claude.ai/code/session_013TcNgJ7q1BvkvS2Lh64Nus)_