### PR TITLE
feat(#459): swap WorkerHost RestCaller ProjectReference to PackageReference

### DIFF
--- a/docs/conventions/plugin-stack.md
+++ b/docs/conventions/plugin-stack.md
@@ -52,3 +52,13 @@ Code that scans `typeof(IDomainEvent).Assembly.GetTypes()` (or any other anchor 
 ## Plugin NuGet versioning
 
 Plugin NuGet packages (`Fleans.Domain.Abstractions`, `Fleans.Application.Abstractions`, `Fleans.Worker`, `Fleans.Plugins.RestCaller`) share the engine's `<VersionPrefix>` track (from `src/Fleans/Directory.Build.props`) — every release bumps every plugin even if its source is bit-identical.
+
+## Iterating on plugin source against engine consumers (WorkerHost / CustomWorkerHost)
+
+`Fleans.WorkerHost` consumes `Fleans.Plugins.RestCaller` from nuget.org via `<PackageReference>`. Local edits to `src/Fleans/Fleans.Plugins.RestCaller/` source are **not visible** to WorkerHost via a plain `dotnet build`. This is intentional — the swap proves the published plugin SDK works end-to-end from a consumer's perspective.
+
+To test local RestCaller source changes against WorkerHost during development:
+
+- **Option (a) — `<ProjectReference>` override (temporary).** Edit `Fleans.WorkerHost.csproj` locally to swap the `<PackageReference>` back to the `<ProjectReference>` form. Do not commit. Revert before opening a PR.
+- **Option (b) — local NuGet feed.** Bump `src/Fleans/Fleans.Plugins.RestCaller/Fleans.Plugins.RestCaller.csproj`'s `<Version>` (e.g. `0.4.1-local`), `dotnet pack`, then `dotnet nuget push` to a local source. Update WorkerHost's `<PackageReference Version>` to match.
+- **Option (c) — release a new tag.** For substantive RestCaller changes, follow the standard release runbook (`docs/runbooks/release.md`) to cut a new tag; WorkerHost's pinned version updates in a follow-up PR.

--- a/src/Fleans/Fleans.WorkerHost/Fleans.WorkerHost.csproj
+++ b/src/Fleans/Fleans.WorkerHost/Fleans.WorkerHost.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.StackExchange.Redis" Version="13.1.1" />
+    <PackageReference Include="Fleans.Plugins.RestCaller" Version="0.4.1" />
     <PackageReference Include="Microsoft.Orleans.Clustering.Redis" Version="10.0.1" />
     <PackageReference Include="Microsoft.Orleans.Dashboard" Version="10.0.1" />
     <PackageReference Include="Microsoft.Orleans.GrainDirectory.Redis" Version="10.0.1" />
@@ -24,7 +25,6 @@
     <ProjectReference Include="..\Fleans.Persistence\Fleans.Persistence.csproj" />
     <ProjectReference Include="..\Fleans.Persistence.Sqlite\Fleans.Persistence.Sqlite.csproj" />
     <ProjectReference Include="..\Fleans.Persistence.PostgreSql\Fleans.Persistence.PostgreSql.csproj" />
-    <ProjectReference Include="..\Fleans.Plugins.RestCaller\Fleans.Plugins.RestCaller.csproj" />
     <ProjectReference Include="..\Fleans.ServiceDefaults\Fleans.ServiceDefaults.csproj" />
     <ProjectReference Include="..\Fleans.Worker\Fleans.Worker.csproj" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

Closes #459 (AC1 only — per maintainer scope decision Q1=a, AC2 for `Fleans.CustomWorkerHost.csproj` moves to a sister issue in `fleans-custom-worker-example`).

- **Replaced** `<ProjectReference>` to `Fleans.Plugins.RestCaller` with `<PackageReference Version="0.4.1">` in `Fleans.WorkerHost.csproj`
- **Verified** transitive resolution: `Fleans.Worker`, `Fleans.Application.Abstractions`, `Fleans.Domain.Abstractions` all resolve via existing `ProjectReference` entries — no dual Project/Package collision. `dotnet list package --include-transitive` shows only `Fleans.Plugins.RestCaller 0.4.1` as a Fleans package; no `<PrivateAssets>all</PrivateAssets>` contingency needed.
- **Added** dev-workflow documentation to `docs/conventions/plugin-stack.md` covering local iteration options

## Dev workflow note

After this PR, `Fleans.WorkerHost` consumes `Fleans.Plugins.RestCaller` from nuget.org at version `0.4.1`. Local edits to `src/Fleans/Fleans.Plugins.RestCaller/` source are **not visible** to WorkerHost via a plain `dotnet build`. This is intentional — the swap proves the published plugin SDK works end-to-end from a consumer's perspective.

To test local RestCaller source changes against WorkerHost during development, see `docs/conventions/plugin-stack.md` § "Iterating on plugin source against engine consumers".

## Transitive resolution check

```
> Fleans.Plugins.RestCaller   0.4.1   0.4.1
```
No other `Fleans.*` packages in transitive list — all shared abstractions resolve via ProjectReferences.

## Test plan

- [x] `dotnet build Fleans.WorkerHost` — 0 errors
- [x] `dotnet list package --include-transitive` — no Fleans dual resolution
- [x] `dotnet test` — full suite passes
- [ ] Smoke test: `dotnet run --project Fleans.Aspire` → WorkerHost boots, rest-call service task executes