### PR TITLE
docs(#483): add Common Issues troubleshooting page

### DIFF
--- a/website/src/content/docs/reference/troubleshooting-common-issues.md
+++ b/website/src/content/docs/reference/troubleshooting-common-issues.md
@@ -1,0 +1,41 @@
+---
+title: Common Issues
+description: Known issues, workarounds, and behavior gaps in the current Fleans release.
+---
+
+This page documents known bugs and behavior gaps. For the full element-level coverage status, see [BPMN Support](/fleans/concepts/bpmn-support/).
+
+## Boundary events on intermediate-catch don't fire
+
+**Affects:** intermediate timer, message, and signal catch events with a boundary event attached.
+
+**Symptom:** the boundary event never fires. The host activity blocks until something else (cancel, completion, or timeout from a higher scope) interrupts it.
+
+**Root cause:** boundary subscriptions are not registered when the host is an `IntermediateCatchEvent`. Boundaries on Tasks, Subprocesses, and Call Activities are unaffected.
+
+**Workaround:** wrap the intermediate-catch in a single-activity subprocess and attach the boundary event to the subprocess instead.
+
+**Fixtures reproducing this issue:**
+
+- [`tests/manual/08-timer-events`](https://github.com/nightBaker/fleans/tree/main/tests/manual/08-timer-events)
+- [`tests/manual/09-message-events`](https://github.com/nightBaker/fleans/tree/main/tests/manual/09-message-events)
+- [`tests/manual/10-signal-events`](https://github.com/nightBaker/fleans/tree/main/tests/manual/10-signal-events)
+
+## Child-process errors don't propagate to parent error boundary on CallActivity
+
+**Affects:** call activities with an error boundary event, where the called child process throws an unhandled error.
+
+**Symptom:** the CallActivity stays in `Running` state indefinitely. The error boundary event on the parent does not fire.
+
+**Root cause:** error events emitted from the child workflow don't trigger the parent's CallActivity error-boundary subscription.
+
+**Workaround:** handle the error inside the child process and signal the parent via a normal end event with a discriminator variable. The parent reads the variable and gateway-routes accordingly.
+
+**Fixtures reproducing this issue:**
+
+- [`tests/manual/11-error-boundary`](https://github.com/nightBaker/fleans/tree/main/tests/manual/11-error-boundary)
+
+## Related
+
+- [BPMN Support](/fleans/concepts/bpmn-support/) — full element-level status table.
+- [Error Handling](/fleans/patterns/error-handling/) — supported error handling patterns.

--- a/website/src/content/docs/reference/troubleshooting-common-issues.md
+++ b/website/src/content/docs/reference/troubleshooting-common-issues.md
@@ -38,4 +38,4 @@ This page documents known bugs and behavior gaps. For the full element-level cov
 ## Related
 
 - [BPMN Support](/fleans/concepts/bpmn-support/) — full element-level status table.
-- [Error Handling](/fleans/patterns/error-handling/) — supported error handling patterns.
+- [Error Handling](/fleans/guides/error-handling/) — supported error handling patterns.


### PR DESCRIPTION
## Summary

Closes #483

Adds `website/src/content/docs/reference/troubleshooting-common-issues.md` documenting 2 known bugs with structured Affects/Symptom/Root cause/Workaround/Fixture sections:

1. **Boundary events on intermediate-catch don't fire** — boundaries not registered on `IntermediateCatchEvent` hosts (fixtures: manual plans 08, 09, 10)
2. **Child-process errors don't propagate to parent error boundary** — CallActivity stays Running (fixture: manual plan 11)

## Scope decisions (per maintainer answers)

- **Placement:** `/reference/` (lookup page, not tutorial)
- **Resolved bugs (#231, #470):** omitted — page covers current-release issues only
- **Sidebar group:** deferred — ships as navigable URL only; sidebar Troubleshooting group PR follows after #484 + #485 merge

## Test plan

- [x] `cd website && npm run build` — 32 pages green (31 + 1 new), no broken links
- [x] Cross-links use GitHub blob URLs per CLAUDE.md website scope split
- [ ] Verify page renders correctly at `/fleans/reference/troubleshooting-common-issues/`