### PR TITLE
fix(#487): replace MCP tcpSocket probes with httpGet /alive and /health

### DIFF
--- a/charts/fleans/templates/deployment-mcp.yaml
+++ b/charts/fleans/templates/deployment-mcp.yaml
@@ -41,12 +41,14 @@ spec:
               value: "http://+:5200"
             {{- include "fleans.commonEnv" . | nindent 12 }}
           livenessProbe:
-            tcpSocket:
+            httpGet:
+              path: /alive
               port: mcp
             initialDelaySeconds: 30
             periodSeconds: 30
           readinessProbe:
-            tcpSocket:
+            httpGet:
+              path: /health
               port: mcp
             initialDelaySeconds: 10
             periodSeconds: 10


### PR DESCRIPTION
## Summary

Closes #487
Closes #609 (duplicate finding from a later audit cycle)

Replaces `tcpSocket` health probes on the MCP deployment with `httpGet` probes targeting `/alive` (liveness) and `/health` (readiness), matching the pattern already used by peer deployments (core, worker).

## Change

`charts/fleans/templates/deployment-mcp.yaml` lines 43-52:
- livenessProbe: `tcpSocket {port: mcp}` → `httpGet {path: /alive, port: mcp}`
- readinessProbe: `tcpSocket {port: mcp}` → `httpGet {path: /health, port: mcp}`

Probe timings preserved (30s/30s liveness, 10s/10s readiness).

## Why httpGet is better

- `tcpSocket` only checks port connectivity — a stuck process with an open socket passes
- `httpGet /alive` and `/health` exercise the ASP.NET health check pipeline registered via `MapDefaultEndpoints` in `Fleans.ServiceDefaults`
- Matches the peer deployment pattern (`deployment-core.yaml:44-55`)

## Test plan

- [x] Verified endpoints registered: `Fleans.ServiceDefaults/Extensions.cs:110,113` (`/health`, `/alive`)
- [x] Verified MCP calls `AddServiceDefaults` + `MapDefaultEndpoints`: `Fleans.Mcp/Program.cs:9,35`
- [ ] `helm template . --set mcp.enabled=true | grep -A4 "livenessProbe\|readinessProbe"` shows httpGet blocks