### PR TITLE
fix(#611): replace unbounded GetAllProcessDefinitions in Editor with targeted max-version query

### DIFF
--- a/src/Fleans/Fleans.Application.Tests/ProcessDefinitionGrainTests.cs
+++ b/src/Fleans/Fleans.Application.Tests/ProcessDefinitionGrainTests.cs
@@ -167,7 +167,7 @@ namespace Fleans.Application.Tests
         private class StubWorkflowQueryService : IWorkflowQueryService
         {
             public Task<InstanceStateSnapshot?> GetStateSnapshot(Guid workflowInstanceId) => Task.FromResult<InstanceStateSnapshot?>(null);
-            public Task<IReadOnlyList<ProcessDefinitionSummary>> GetAllProcessDefinitions() => Task.FromResult<IReadOnlyList<ProcessDefinitionSummary>>([]);
+            public Task<int> GetMaxVersionByKeyAsync(string processDefinitionKey) => Task.FromResult(0);
             public Task<PagedResult<ProcessDefinitionSummary>> GetAllProcessDefinitions(PageRequest page) => Task.FromResult(new PagedResult<ProcessDefinitionSummary>([], 0, page.Page, page.PageSize));
             public Task<PagedResult<ProcessDefinitionGroup>> GetProcessDefinitionGroups(PageRequest page) => Task.FromResult(new PagedResult<ProcessDefinitionGroup>([], 0, page.Page, page.PageSize));
             public Task<PagedResult<WorkflowInstanceInfo>> GetInstancesByKey(string processDefinitionKey, PageRequest page) => Task.FromResult(new PagedResult<WorkflowInstanceInfo>([], 0, page.Page, page.PageSize));

--- a/src/Fleans/Fleans.Application/IWorkflowQueryService.cs
+++ b/src/Fleans/Fleans.Application/IWorkflowQueryService.cs
@@ -7,7 +7,7 @@ namespace Fleans.Application;
 public interface IWorkflowQueryService
 {
     Task<InstanceStateSnapshot?> GetStateSnapshot(Guid workflowInstanceId);
-    Task<IReadOnlyList<ProcessDefinitionSummary>> GetAllProcessDefinitions();
+    Task<int> GetMaxVersionByKeyAsync(string processDefinitionKey);
     Task<PagedResult<ProcessDefinitionSummary>> GetAllProcessDefinitions(PageRequest page);
     Task<PagedResult<ProcessDefinitionGroup>> GetProcessDefinitionGroups(PageRequest page);
     Task<PagedResult<WorkflowInstanceInfo>> GetInstancesByKey(string processDefinitionKey, PageRequest page);

--- a/src/Fleans/Fleans.Persistence.Tests/WorkflowQueryServiceTests.cs
+++ b/src/Fleans/Fleans.Persistence.Tests/WorkflowQueryServiceTests.cs
@@ -254,7 +254,7 @@ public class WorkflowQueryServiceTests : PersistenceTestBase
     [DataTestMethod]
     [DataRow(PersistenceProvider.Sqlite)]
     [DataRow(PersistenceProvider.Postgres)]
-    public async Task GetAllProcessDefinitions_ReturnsAll_OrderedByKeyThenVersion(PersistenceProvider provider)
+    public async Task GetAllProcessDefinitions_Paged_ReturnsAll_OrderedByKeyThenVersion(PersistenceProvider provider)
     {
         await using var fixture = await TestFixtureFactory.CreateAsync(provider);
         var (service, commandFactory) = BuildService(fixture, provider);
@@ -266,30 +266,101 @@ public class WorkflowQueryServiceTests : PersistenceTestBase
         await SeedProcessDefinition(db, "beta:1:ts", "beta", 1);
         await SeedProcessDefinition(db, "alpha:2:ts", "alpha", 2);
 
-        var results = await service.GetAllProcessDefinitions();
+        var paged = await service.GetAllProcessDefinitions(
+            new PageRequest(PageSize: int.MaxValue, Sorts: "processDefinitionKey,version"));
 
-        Assert.AreEqual(4, results.Count);
-        Assert.AreEqual("alpha", results[0].ProcessDefinitionKey);
-        Assert.AreEqual(1, results[0].Version);
-        Assert.AreEqual("alpha", results[1].ProcessDefinitionKey);
-        Assert.AreEqual(2, results[1].Version);
-        Assert.AreEqual("beta", results[2].ProcessDefinitionKey);
-        Assert.AreEqual(1, results[2].Version);
-        Assert.AreEqual("beta", results[3].ProcessDefinitionKey);
-        Assert.AreEqual(2, results[3].Version);
+        Assert.AreEqual(4, paged.TotalCount);
+        Assert.AreEqual(4, paged.Items.Count);
+        Assert.AreEqual("alpha", paged.Items[0].ProcessDefinitionKey);
+        Assert.AreEqual(1, paged.Items[0].Version);
+        Assert.AreEqual("alpha", paged.Items[1].ProcessDefinitionKey);
+        Assert.AreEqual(2, paged.Items[1].Version);
+        Assert.AreEqual("beta", paged.Items[2].ProcessDefinitionKey);
+        Assert.AreEqual(1, paged.Items[2].Version);
+        Assert.AreEqual("beta", paged.Items[3].ProcessDefinitionKey);
+        Assert.AreEqual(2, paged.Items[3].Version);
     }
 
     [DataTestMethod]
     [DataRow(PersistenceProvider.Sqlite)]
     [DataRow(PersistenceProvider.Postgres)]
-    public async Task GetAllProcessDefinitions_ReturnsEmpty_WhenNoneExist(PersistenceProvider provider)
+    public async Task GetAllProcessDefinitions_Paged_ReturnsEmpty_WhenNoneExist(PersistenceProvider provider)
     {
         await using var fixture = await TestFixtureFactory.CreateAsync(provider);
         var (service, commandFactory) = BuildService(fixture, provider);
 
-        var results = await service.GetAllProcessDefinitions();
+        var paged = await service.GetAllProcessDefinitions(new PageRequest(PageSize: int.MaxValue));
 
-        Assert.AreEqual(0, results.Count);
+        Assert.AreEqual(0, paged.TotalCount);
+        Assert.AreEqual(0, paged.Items.Count);
+    }
+
+    // ─────────────────────────────────────────────────
+    // GetMaxVersionByKeyAsync
+    // ─────────────────────────────────────────────────
+
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetMaxVersionByKeyAsync_ReturnsZero_WhenEmpty(PersistenceProvider provider)
+    {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, _) = BuildService(fixture, provider);
+
+        var max = await service.GetMaxVersionByKeyAsync("never-deployed");
+
+        Assert.AreEqual(0, max);
+    }
+
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetMaxVersionByKeyAsync_ReturnsVersion_WhenSingleDeployment(PersistenceProvider provider)
+    {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture, provider);
+
+        using var db = commandFactory.CreateDbContext();
+        await SeedProcessDefinition(db, "x:1:ts", "x", 1);
+
+        var max = await service.GetMaxVersionByKeyAsync("x");
+
+        Assert.AreEqual(1, max);
+    }
+
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetMaxVersionByKeyAsync_ReturnsHighestVersion_WhenMultipleDeployments(PersistenceProvider provider)
+    {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture, provider);
+
+        using var db = commandFactory.CreateDbContext();
+        await SeedProcessDefinition(db, "x:1:ts", "x", 1);
+        await SeedProcessDefinition(db, "x:2:ts", "x", 2);
+        await SeedProcessDefinition(db, "x:3:ts", "x", 3);
+        await SeedProcessDefinition(db, "y:1:ts", "y", 1);
+
+        var max = await service.GetMaxVersionByKeyAsync("x");
+
+        Assert.AreEqual(3, max);
+    }
+
+    [DataTestMethod]
+    [DataRow(PersistenceProvider.Sqlite)]
+    [DataRow(PersistenceProvider.Postgres)]
+    public async Task GetMaxVersionByKeyAsync_ReturnsZero_WhenUnknownKey(PersistenceProvider provider)
+    {
+        await using var fixture = await TestFixtureFactory.CreateAsync(provider);
+        var (service, commandFactory) = BuildService(fixture, provider);
+
+        using var db = commandFactory.CreateDbContext();
+        await SeedProcessDefinition(db, "x:1:ts", "x", 1);
+
+        var max = await service.GetMaxVersionByKeyAsync("y");
+
+        Assert.AreEqual(0, max);
     }
 
     // ─────────────────────────────────────────────────

--- a/src/Fleans/Fleans.Persistence/WorkflowQueryService.cs
+++ b/src/Fleans/Fleans.Persistence/WorkflowQueryService.cs
@@ -93,16 +93,14 @@ public class WorkflowQueryService : IWorkflowQueryService
             state.CreatedAt, state.ExecutionStartedAt, state.CompletedAt);
     }
 
-    public async Task<IReadOnlyList<ProcessDefinitionSummary>> GetAllProcessDefinitions()
+    public async Task<int> GetMaxVersionByKeyAsync(string processDefinitionKey)
     {
         await using var db = await _dbContextFactory.CreateDbContextAsync();
 
-        var definitions = await db.ProcessDefinitions
-            .OrderBy(d => d.ProcessDefinitionKey)
-            .ThenBy(d => d.Version)
-            .ToListAsync();
-
-        return definitions.Select(ProjectToSummary).ToList();
+        return await db.ProcessDefinitions
+            .Where(d => d.ProcessDefinitionKey == processDefinitionKey)
+            .Select(d => (int?)d.Version)
+            .MaxAsync() ?? 0;
     }
 
     public async Task<PagedResult<ProcessDefinitionSummary>> GetAllProcessDefinitions(PageRequest page)

--- a/src/Fleans/Fleans.Web/Components/Pages/Editor.razor
+++ b/src/Fleans/Fleans.Web/Components/Pages/Editor.razor
@@ -432,13 +432,8 @@
             pendingWorkflow = workflow;
             deployProcessKey = workflow.WorkflowId;
 
-            var definitions = await QueryService.GetAllProcessDefinitions();
-            var existing = definitions
-                .Where(d => d.ProcessDefinitionKey == deployProcessKey)
-                .OrderByDescending(d => d.Version)
-                .FirstOrDefault();
-            var nextVersion = existing != null ? existing.Version + 1 : 1;
-            deployNextVersion = $"v{nextVersion}";
+            var maxVersion = await QueryService.GetMaxVersionByKeyAsync(deployProcessKey);
+            deployNextVersion = $"v{maxVersion + 1}";
 
             showDeployDialog = true;
         }


### PR DESCRIPTION
## Summary

Closes #611. The deploy dialog in `Editor.razor` was calling the no-arg `GetAllProcessDefinitions()` and materialising every row (including `BpmnXml`, several hundred KB each) just to compute `max(version) + 1` for a single `processDefinitionKey`. Replaces that with a new `GetMaxVersionByKeyAsync(string)` projection — single round-trip, no `BpmnXml` materialisation.

Implements **Option C** from the approved Design & Plan v3 (https://github.com/nightBaker/fleans/issues/611#issuecomment-4556606901 + v3 reviewer approval).

## Changes

- **`IWorkflowQueryService`**: add `GetMaxVersionByKeyAsync(string)`, remove the no-arg `GetAllProcessDefinitions()`. The paged overload remains.
- **`WorkflowQueryService`**: implement via `Where(...).Select(d => (int?)d.Version).MaxAsync() ?? 0` — projection pushdown skips the `BpmnXml` column entirely.
- **`Editor.razor`**: collapse the 7-line `GetAll → Where → OrderByDescending → FirstOrDefault → +1` chain to a single `GetMaxVersionByKeyAsync` call + `deployNextVersion = $"v{maxVersion + 1}"`.
- **`StubWorkflowQueryService`** (test mock): drop the no-arg stub, add the new method's stub.
- **`WorkflowQueryServiceTests`**: rewrite the two tests that called the removed overload as `GetAllProcessDefinitions_Paged_…` variants using the paged overload with an explicit `Sorts: "processDefinitionKey,version"` to preserve ordering coverage. Add 4 new tests on `GetMaxVersionByKeyAsync` (empty / single / multi / unknown-key).

## Why the test rewrite needs explicit `Sorts`

The paged overload uses Sieve, which does not sort by default. Without `Sorts`, the rewrite read the rows in insertion order and the ordering assertion failed. Added `Sorts: "processDefinitionKey,version"` to make the paged test verify the same ordering shape the removed no-arg method guaranteed.

## API-break note

`IWorkflowQueryService.GetAllProcessDefinitions()` (no-arg) is removed. It is **not** in the published NuGet stack — the interface lives in `Fleans.Application` (solution-internal). Per the issue's maintainer answer, the only production callsite was `Editor.razor:435` (now migrated) and the only test callsites were the 3 sites updated in this PR. `grep -rn "GetAllProcessDefinitions()" src/` returns zero hits after this change.

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `dotnet test Fleans.Persistence.Tests/...` — 154 passed (SQLite), 128 skipped (Postgres, no container), 0 failed
- [x] `dotnet test Fleans.Application.Tests/... --filter "FullyQualifiedName~ProcessDefinitionGrain"` — 4/4 passed
- [ ] Manual smoke matrix (per Design & Plan v3 step 8) — run after deploy:
  - Never-deployed key → expect `deployNextVersion = "v1"`
  - 3 existing deployments of key X → expect `deployNextVersion = "v4"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)