### PR TITLE
fix(#610): expose streaming queue-count knobs in Helm chart

### DIFF
--- a/charts/fleans/templates/_helpers.tpl
+++ b/charts/fleans/templates/_helpers.tpl
@@ -116,11 +116,15 @@ ASPNETCORE_URLS is intentionally excluded — each workload sets its own port.
 {{- else if eq $provider "redis" }}
 - name: Fleans__Streaming__Provider
   value: "Redis"
+- name: Fleans__Streaming__Redis__TotalQueueCount
+  value: {{ .Values.streaming.redis.totalQueueCount | quote }}
 {{- else if eq $provider "kafka" }}
 - name: Fleans__Streaming__Provider
   value: "Kafka"
 - name: Fleans__Streaming__Kafka__Brokers
   value: {{ .Values.streaming.kafka.brokers | quote }}
+- name: Fleans__Streaming__Kafka__QueueCount
+  value: {{ .Values.streaming.kafka.queueCount | quote }}
 {{- else if eq $provider "azurequeue" }}
 - name: Fleans__Streaming__Provider
   value: "AzureQueue"

--- a/charts/fleans/values.yaml
+++ b/charts/fleans/values.yaml
@@ -208,9 +208,16 @@ streaming:
   # Memory | Redis | Kafka | AzureQueue (case-insensitive)
   # WARNING: Memory is single-silo debug-only — DO NOT use in multi-silo deployments.
   provider: Redis
+  redis:
+    # Orleans stream parallelism — pulling-agent count per cluster.
+    # Default 8 matches the engine default in FleanStreamingExtensions.ReadRedisTotalQueueCount.
+    totalQueueCount: 8
   kafka:
     # Comma-separated brokers list, e.g. "kafka.kafka.svc:9092"
     brokers: ""
+    # Orleans stream parallelism — pulling-agent count per cluster.
+    # Default 8 matches the engine default in KafkaStreamingOptions.QueueCount.
+    queueCount: 8
   azureQueue:
     # Azurite or Azure Storage account connection string.
     # Inline value here for simplicity; for production use the existingSecret

--- a/website/src/content/docs/guides/self-host-helm.md
+++ b/website/src/content/docs/guides/self-host-helm.md
@@ -134,7 +134,9 @@ on the install command line via `--set` or pass a `-f my-values.yaml` overlay.
 | `auth.clientSecretExistingSecret` | `""` | Reference a `Secret` with key `client-secret`. **Use this in production.** |
 | `auth.clientSecret` | `""` | Inline OIDC client secret. **Not recommended for production.** |
 | `streaming.provider` | `Memory` | `Memory` (in-process) or `Kafka` (durable). |
+| `streaming.redis.totalQueueCount` | `8` | Orleans pulling-agent count for Redis streaming. |
 | `streaming.kafka.brokers` | `""` | Comma-separated Kafka brokers, e.g. `kafka.kafka.svc:9092`. |
+| `streaming.kafka.queueCount` | `8` | Orleans pulling-agent count for Kafka streaming. |
 | `extraEnv` | `[]` | Extra env vars on every Fleans workload (`api`, `web`, `mcp`). Use for `ConnectionStrings__fleans` overrides. |
 
 To tune Orleans consumer parallelism (pulling-agent count per cluster) for higher throughput, set `Fleans__Streaming__Redis__TotalQueueCount` (Redis), `Fleans__Streaming__Kafka__QueueCount` (Kafka), or supply an explicit `Fleans__Streaming__AzureQueue__QueueNames__0..N` list — see [Tuning throughput](/fleans/reference/streaming/#tuning-throughput) for the sizing heuristic, rehash caveat, and Kafka-side `NumPartitions` tuning.


### PR DESCRIPTION
## Summary

Closes #610

Adds first-class chart inputs for Orleans pulling-agent count on both Redis and Kafka streaming providers (previously only tunable via `extraEnv`).

## Changes

| File | Change |
|------|--------|
| `charts/fleans/templates/_helpers.tpl` | Emit `Fleans__Streaming__Redis__TotalQueueCount` and `Fleans__Streaming__Kafka__QueueCount` under their respective branches |
| `charts/fleans/values.yaml` | Add `streaming.redis.totalQueueCount: 8` and `streaming.kafka.queueCount: 8` (defaults match engine defaults) |
| `website/src/content/docs/guides/self-host-helm.md` | Add 2 values-table rows |

## Verification

```
$ helm template . --set streaming.provider=Redis | grep "Fleans__Streaming__Redis"
- name: Fleans__Streaming__Redis__TotalQueueCount
  value: "8"

$ helm template . --set streaming.provider=Kafka | grep "Fleans__Streaming__Kafka"
- name: Fleans__Streaming__Kafka__Brokers
- name: Fleans__Streaming__Kafka__QueueCount
  value: "8"

$ helm template . --set streaming.provider=Memory | grep "Fleans__Streaming__\(Redis\|Kafka\)"
(no output — correct, neither set under Memory)
```

## Backward compatibility

Existing deployments using `extraEnv` to set these vars continue to work — Kubernetes env list resolution is last-wins, so user-supplied `extraEnv` values override the chart-emitted defaults.

## Test plan

- [x] Helm renders new env vars under Redis branch
- [x] Helm renders new env vars under Kafka branch
- [x] Memory path renders neither (no leak)
- [x] Docs values table updated