### PR TITLE
docs(#624): split concepts/custom-tasks.md, extract plugin hosting into new concept page

### DIFF
--- a/tools/website-pin-allowlist.txt
+++ b/tools/website-pin-allowlist.txt
@@ -1,4 +1,4 @@
-website/src/content/docs/concepts/activities/tasks.mdx:129:Source: `BpmnConverter.cs:333`.
+website/src/content/docs/concepts/activities/tasks.mdx:141:Source: `BpmnConverter.cs:333`.
 website/src/content/docs/concepts/activities/tasks.mdx:35:Plain Tasks auto-complete — they never block the workflow. Source: `BpmnConverter.cs:303`.
 website/src/content/docs/concepts/activities/tasks.mdx:65:back after completion. Source: `BpmnConverter.cs:354`.
 website/src/content/docs/concepts/activities/tasks.mdx:94:task is completed via `POST /Workflow/{id}/complete-activity`. Source: `BpmnConverter.cs:313`.

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -32,6 +32,7 @@ export default defineConfig({
             { label: 'What is BPMN?', slug: 'concepts/bpmn-overview' },
             { label: 'BPMN Support', slug: 'concepts/bpmn-support' },
             { label: 'Custom Tasks', slug: 'concepts/custom-tasks' },
+            { label: 'Hosting plugins externally', slug: 'concepts/plugin-hosting' },
           ],
         },
         {

--- a/website/src/content/docs/concepts/activities/tasks.mdx
+++ b/website/src/content/docs/concepts/activities/tasks.mdx
@@ -98,9 +98,10 @@ task is completed via `POST /Workflow/{id}/complete-activity`. Source: `BpmnConv
 
 ## Service Task (Custom Task)
 
-A **Service Task** (`<bpmn:serviceTask type="…">`) delegates execution to a plugin grain
-identified by the `type` attribute. Plugins live on a Worker silo and implement
-`CustomTaskHandlerBase`. Output variables are mapped back via `<fleans:output>` bindings.
+A **Service Task** (`<bpmn:serviceTask type="…">`) delegates execution to a custom-task plugin
+identified by the `type` attribute. The plugin runs on a Worker silo — either bundled with the
+engine image or in a dedicated [external plugin host](/fleans/concepts/plugin-hosting/) — and
+publishes results back through `<fleans:output>` bindings.
 
 **BPMN:**
 ```xml
@@ -123,11 +124,21 @@ identified by the `type` attribute. Plugins live on a Worker silo and implement
        class="bpmn-activity-img-dark"  alt="Service Task BPMN diagram" />
 </div>
 
-:::note
-The `type` value must match a registered plugin's `TaskType`. See
-[Writing Custom-Task Plugins](/fleans/guides/writing-custom-tasks) for the full authoring guide.
-Source: `BpmnConverter.cs:333`.
+The `type` value must match a registered plugin's `TaskType`. To learn more:
+
+- [Custom Tasks](/fleans/concepts/custom-tasks/) — architecture, event flow, parameter mapping, and the REST Caller bundled plugin.
+- [Hosting plugins externally](/fleans/concepts/plugin-hosting/) — run plugins in a dedicated Worker silo isolated from the engine image.
+- [Writing Custom-Task Plugins](/fleans/guides/writing-custom-tasks/) — step-by-step authoring guide.
+
+:::note[Camunda back-compat]
+Files exported from Camunda Zeebe (e.g. `<extensionElements><zeebe:taskDefinition type="..."/></extensionElements>`)
+are accepted as-is — the BPMN converter understands both `<fleans:taskDefinition>` and the
+legacy `<zeebe:taskDefinition>` shape. New Fleans-authored files should use the `<fleans:...>`
+namespace; see [BPMN extension namespaces](/fleans/reference/bpmn-extension-namespaces/) for
+the convention.
 :::
+
+Source: `BpmnConverter.cs:333`.
 
 ---
 

--- a/website/src/content/docs/concepts/custom-tasks.md
+++ b/website/src/content/docs/concepts/custom-tasks.md
@@ -166,127 +166,15 @@ The publisher routes `ExecuteCustomTaskEvent` to `events.ExecuteCustomTaskEvent.
 
 Plugin authors hosting from the [`fleans-custom-worker-example`](https://github.com/nightBaker/fleans-custom-worker-example) template need to update their handlers: each concrete `CustomTaskHandlerBase` subclass must carry `[ImplicitStreamSubscription("events.ExecuteCustomTaskEvent.<task-type>")]` with a literal string matching its `TaskType`. The Worker host's `AddCustomTaskPlugin<T>(taskType, …)` call now throws `InvalidOperationException` at startup if the attribute is missing or drifted, or if two plugins claim the same `TaskType` — diagnose against the exception message.
 
-## Hosting plugins outside the engine repo
-
-If you want to run your custom-task plugins in their own deployable (separate from the engine
-image) — see the [Hosting Plugins (Custom Worker Host)](/fleans/guides/custom-worker-host/) guide.
-The [`fleans-custom-worker-example`](https://github.com/nightBaker/fleans-custom-worker-example)
-GitHub template is the supported starting point; it references **only** `Fleans.Worker`
-(via NuGet) + plugin assemblies, with no `Fleans.Application` / `Fleans.Domain` in the
-dependency closure.
-
 ## Hosting plugins externally
 
-The recommended deployment pattern for non-trivial plugin estates is to run plugins in their
-own silo process, separate from the engine's `Fleans.Api` / `Fleans.Web` / `Fleans.WorkerHost`.
+For production plugin estates, run your plugins in a dedicated Worker silo separate from
+the engine's `Fleans.Api` / `Fleans.Web` / `Fleans.WorkerHost` images. This is the recommended
+deployment pattern for non-trivial plugin estates.
 
-### When to host externally
-
-- **Operational isolation.** A misbehaving plugin (memory leak, runaway HTTP call) only kills
-  its own silo, never the engine workers that run Script / Condition grains.
-- **Independent deploy cadence.** Ship a new version of an `email` or `slack` plugin without
-  rebuilding or restarting the engine.
-- **Per-team ownership.** Different teams can each ship their own plugin host image; only
-  `Fleans.Worker` (from nuget.org) is shared across them — no engine source dependency.
-
-### The `Plugin` role
-
-`Fleans:Role` accepts three values cluster-wide. The third — `Plugin` — was added for
-external plugin hosts:
-
-| Role | Silo prefix | Purpose |
-|---|---|---|
-| `Core` | `core-` | Engine API / Web / Mcp silos. Hosts `[CorePlacement]` grains. |
-| `Worker` / `Combined` | `worker-` / `combined-` | Engine workers (and `Combined` dev silos). Hosts `[WorkerPlacement]` grains. |
-| `Plugin` | `plugin-` | **External** plugin hosts. Hosts **only** plugin grains registered via `AddCustomTaskPlugin<T>()`. |
-
-Engine binaries (`Fleans.Api`, `Fleans.WorkerHost`) **reject** `Fleans:Role=Plugin` at startup
-with an explicit message — the `Plugin` role is reserved for hosts using the
-`AddFleansPluginHost` helper.
-
-### The one-liner
-
-External hosts call a single extension method to wire up role validation, silo naming, and
-default placement:
-
-```csharp
-using Fleans.Worker.Hosting;
-using Fleans.Plugins.MyThing;
-using StackExchange.Redis;
-
-var builder = WebApplication.CreateBuilder(args);
-builder.AddServiceDefaults();
-builder.AddKeyedRedisClient("orleans-redis");
-
-var orleansRedis = builder.Configuration.GetConnectionString("orleans-redis");
-
-builder.UseOrleans(siloBuilder =>
-{
-    siloBuilder.AddFleansPluginHost(builder.Configuration); // role + silo name + placement director
-
-    if (!string.IsNullOrEmpty(orleansRedis))
-    {
-        siloBuilder.UseRedisClustering(orleansRedis);
-        siloBuilder.AddRedisGrainStorage("PubSubStore",
-            opt => opt.ConfigurationOptions = ConfigurationOptions.Parse(orleansRedis));
-        siloBuilder.UseInMemoryReminderService();
-    }
-
-    siloBuilder.AddFleanStreaming(builder.Configuration);   // matches engine stream provider
-});
-
-builder.Services.AddMyThingPlugin();
-var app = builder.Build();
-app.Run();
-```
-
-`AddFleansPluginHost`:
-
-- Validates `Fleans:Role` is `Plugin` (recommended) or `Combined`. Rejects `Core` / `Worker`
-  with `InvalidOperationException`.
-- Stamps the silo name as `plugin-<machine>-<guid>` so other silos see the prefix via Orleans
-  membership.
-- Registers `WorkerPlacementDirector` so the plugin silo participates correctly in cluster-wide
-  placement decisions for `[WorkerPlacement]` grains it doesn't host.
-
-Everything else — Redis clustering, `PubSubStore`, stream provider, `Fleans.ServiceDefaults` —
-is wired separately. The minimal `Program.cs` above (`AddKeyedRedisClient`, `UseRedisClustering`,
-`AddFleanStreaming`) is the complete operator-facing setup. Match the engine's Redis connection
-string so plugin grains share the same Orleans cluster.
-
-### The isolation guarantee
-
-A plugin host runs **only** the plugin grain classes compiled into its assembly load context.
-The isolation falls out of two Orleans mechanisms:
-
-1. **Grain class discovery.** Orleans' `IPlacementContext.GetCompatibleSilos` automatically
-   excludes silos that don't have the concrete grain type loaded. A `plugin-*` host that
-   doesn't reference `Fleans.Plugins.RestCaller` is not a candidate for `RestCallerHandler`
-   activations — Orleans never even considers it.
-2. **`WorkerPlacementDirector` rejects `plugin-` prefix.** Engine-internal grains marked with
-   `[WorkerPlacement]` (`ScriptExecutorGrain`, `ConditionExpressionEvaluatorGrain`) route only
-   to silos whose name starts with `worker-` or `combined-`. The `plugin-` prefix is
-   explicitly excluded.
-
-The net effect: a `plugin-*` silo carrying only an `EmailHandler` plugin grain will host
-exactly that, nothing else. Engine workers continue to host Script / Condition grains plus
-any engine-bundled plugins (e.g. `Fleans.Plugins.RestCaller` shipped with `Fleans.WorkerHost`).
-
-:::note
-`CustomTaskHandlerBase` subclasses **do not** carry `[WorkerPlacement]`. They use Orleans
-default placement, which relies on `GetCompatibleSilos` to pick a silo that has the concrete
-handler assembly loaded. Per-plugin isolation falls out of grain-class discovery; you should
-not add a custom placement attribute to a plugin handler.
-:::
-
-### Scaffolding a plugin host
-
-The [`fleans-custom-worker-example`](https://github.com/nightBaker/fleans-custom-worker-example)
-repository is marked as a GitHub template. Click **Use this template** to scaffold a new
-plugin-host project pre-wired with `AddFleansPluginHost`, Redis client, and a `Program.cs`
-shaped for your own plugin packages. Reference your plugin NuGet packages, call their
-`AddXxxPlugin()` extensions in `Program.cs`, and build the container image — the resulting
-image deploys alongside the engine's `fleans-{api,web,worker,mcp}` containers.
+See [Hosting plugins externally](/fleans/concepts/plugin-hosting/) for the architecture,
+the `Plugin` role, isolation guarantees, the `AddFleansPluginHost` one-liner, and the
+scaffolding template.
 
 ## Reference
 

--- a/website/src/content/docs/concepts/plugin-hosting.md
+++ b/website/src/content/docs/concepts/plugin-hosting.md
@@ -1,0 +1,126 @@
+---
+title: Hosting plugins externally
+description: Run custom-task plugins in a dedicated Worker silo isolated from the engine image. Architecture, isolation guarantees, and scaffolding from the supported template.
+---
+
+## Start with the template
+
+If you want to run your custom-task plugins in their own deployable (separate from the engine
+image) — see the [Hosting Plugins (Custom Worker Host)](/fleans/guides/custom-worker-host/) guide.
+The [`fleans-custom-worker-example`](https://github.com/nightBaker/fleans-custom-worker-example)
+GitHub template is the supported starting point; it references **only** `Fleans.Worker`
+(via NuGet) + plugin assemblies, with no `Fleans.Application` / `Fleans.Domain` in the
+dependency closure.
+
+## Overview
+
+The recommended deployment pattern for non-trivial plugin estates is to run plugins in their
+own silo process, separate from the engine's `Fleans.Api` / `Fleans.Web` / `Fleans.WorkerHost`.
+
+## When to host externally
+
+- **Operational isolation.** A misbehaving plugin (memory leak, runaway HTTP call) only kills
+  its own silo, never the engine workers that run Script / Condition grains.
+- **Independent deploy cadence.** Ship a new version of an `email` or `slack` plugin without
+  rebuilding or restarting the engine.
+- **Per-team ownership.** Different teams can each ship their own plugin host image; only
+  `Fleans.Worker` (from nuget.org) is shared across them — no engine source dependency.
+
+## The `Plugin` role
+
+`Fleans:Role` accepts three values cluster-wide. The third — `Plugin` — was added for
+external plugin hosts:
+
+| Role | Silo prefix | Purpose |
+|---|---|---|
+| `Core` | `core-` | Engine API / Web / Mcp silos. Hosts `[CorePlacement]` grains. |
+| `Worker` / `Combined` | `worker-` / `combined-` | Engine workers (and `Combined` dev silos). Hosts `[WorkerPlacement]` grains. |
+| `Plugin` | `plugin-` | **External** plugin hosts. Hosts **only** plugin grains registered via `AddCustomTaskPlugin<T>()`. |
+
+Engine binaries (`Fleans.Api`, `Fleans.WorkerHost`) **reject** `Fleans:Role=Plugin` at startup
+with an explicit message — the `Plugin` role is reserved for hosts using the
+`AddFleansPluginHost` helper.
+
+## The one-liner
+
+External hosts call a single extension method to wire up role validation, silo naming, and
+default placement:
+
+```csharp
+using Fleans.Worker.Hosting;
+using Fleans.Plugins.MyThing;
+using StackExchange.Redis;
+
+var builder = WebApplication.CreateBuilder(args);
+builder.AddServiceDefaults();
+builder.AddKeyedRedisClient("orleans-redis");
+
+var orleansRedis = builder.Configuration.GetConnectionString("orleans-redis");
+
+builder.UseOrleans(siloBuilder =>
+{
+    siloBuilder.AddFleansPluginHost(builder.Configuration); // role + silo name + placement director
+
+    if (!string.IsNullOrEmpty(orleansRedis))
+    {
+        siloBuilder.UseRedisClustering(orleansRedis);
+        siloBuilder.AddRedisGrainStorage("PubSubStore",
+            opt => opt.ConfigurationOptions = ConfigurationOptions.Parse(orleansRedis));
+        siloBuilder.UseInMemoryReminderService();
+    }
+
+    siloBuilder.AddFleanStreaming(builder.Configuration);   // matches engine stream provider
+});
+
+builder.Services.AddMyThingPlugin();
+var app = builder.Build();
+app.Run();
+```
+
+`AddFleansPluginHost`:
+
+- Validates `Fleans:Role` is `Plugin` (recommended) or `Combined`. Rejects `Core` / `Worker`
+  with `InvalidOperationException`.
+- Stamps the silo name as `plugin-<machine>-<guid>` so other silos see the prefix via Orleans
+  membership.
+- Registers `WorkerPlacementDirector` so the plugin silo participates correctly in cluster-wide
+  placement decisions for `[WorkerPlacement]` grains it doesn't host.
+
+Everything else — Redis clustering, `PubSubStore`, stream provider, `Fleans.ServiceDefaults` —
+is wired separately. The minimal `Program.cs` above (`AddKeyedRedisClient`, `UseRedisClustering`,
+`AddFleanStreaming`) is the complete operator-facing setup. Match the engine's Redis connection
+string so plugin grains share the same Orleans cluster.
+
+## The isolation guarantee
+
+A plugin host runs **only** the plugin grain classes compiled into its assembly load context.
+The isolation falls out of two Orleans mechanisms:
+
+1. **Grain class discovery.** Orleans' `IPlacementContext.GetCompatibleSilos` automatically
+   excludes silos that don't have the concrete grain type loaded. A `plugin-*` host that
+   doesn't reference `Fleans.Plugins.RestCaller` is not a candidate for `RestCallerHandler`
+   activations — Orleans never even considers it.
+2. **`WorkerPlacementDirector` rejects `plugin-` prefix.** Engine-internal grains marked with
+   `[WorkerPlacement]` (`ScriptExecutorGrain`, `ConditionExpressionEvaluatorGrain`) route only
+   to silos whose name starts with `worker-` or `combined-`. The `plugin-` prefix is
+   explicitly excluded.
+
+The net effect: a `plugin-*` silo carrying only an `EmailHandler` plugin grain will host
+exactly that, nothing else. Engine workers continue to host Script / Condition grains plus
+any engine-bundled plugins (e.g. `Fleans.Plugins.RestCaller` shipped with `Fleans.WorkerHost`).
+
+:::note
+`CustomTaskHandlerBase` subclasses **do not** carry `[WorkerPlacement]`. They use Orleans
+default placement, which relies on `GetCompatibleSilos` to pick a silo that has the concrete
+handler assembly loaded. Per-plugin isolation falls out of grain-class discovery; you should
+not add a custom placement attribute to a plugin handler.
+:::
+
+## Scaffolding a plugin host
+
+The [`fleans-custom-worker-example`](https://github.com/nightBaker/fleans-custom-worker-example)
+repository is marked as a GitHub template. Click **Use this template** to scaffold a new
+plugin-host project pre-wired with `AddFleansPluginHost`, Redis client, and a `Program.cs`
+shaped for your own plugin packages. Reference your plugin NuGet packages, call their
+`AddXxxPlugin()` extensions in `Program.cs`, and build the container image — the resulting
+image deploys alongside the engine's `fleans-{api,web,worker,mcp}` containers.


### PR DESCRIPTION
## Summary

Closes #624

Splits `concepts/custom-tasks.md` into two concept pages, addressing the round-1 finding that the Service Task entry on `tasks.mdx` set the wrong mental model by conflating engine `[WorkerPlacement]` grains with the external plugin-host process.

## Changes

| File | Change |
|------|--------|
| `concepts/plugin-hosting.md` (new) | Extract L178-290 content from `custom-tasks.md` + fold L169-177 as "Start with the template" first H2. Frontmatter `title` + `description`; body starts at H2 (no double-title). |
| `concepts/custom-tasks.md` | Delete L169-290; replace with 2-paragraph signpost pointing at `/concepts/plugin-hosting/`. |
| `concepts/activities/tasks.mdx` | Rewrite Service Task subsection: 3 cross-links (custom-tasks, plugin-hosting, writing-custom-tasks), `:::note[Camunda back-compat]` for legacy `<zeebe:taskDefinition>` files. |
| `astro.config.mjs` | Register `Hosting plugins externally` in the Concepts sidebar group. |

## Verification

- ✅ Website builds clean: 35 pages (was 34 + 1 new), no broken-link warnings
- ✅ Cross-link sweep 1: `grep "custom-tasks.md\|/custom-tasks)" website/src/content/docs/` → 0 hits to update
- ✅ Cross-link sweep 2: `grep "#when-to-host-externally\|#the-plugin-role\|#the-one-liner\|#the-isolation-guarantee\|#scaffolding-a-plugin-host"` → 0 hits (no in-tree links to moved anchors)
- ✅ Frontmatter convention: new page mirrors `custom-tasks.md` (Starlight `title:` + `description:`, body starts at H2)

## Acknowledgments

- Pre-1.0 anchor breakage acceptable per round 3 review (no widely-shared bookmarks)
- `<fleans:...>` syntax used directly (no `<zeebe:...>` fallback) — #623 is closed