### PR TITLE
fix(#703): disable EndpointOptions.GatewayPort on plugin host silos

### DIFF
--- a/src/Fleans/Fleans.Application.Tests/Placement/PluginHostPlacementTests.cs
+++ b/src/Fleans/Fleans.Application.Tests/Placement/PluginHostPlacementTests.cs
@@ -81,6 +81,30 @@ public class PluginHostPlacementTests
     }
 
     [TestMethod]
+    public void AddFleansPluginHost_DisablesGatewayPort()
+    {
+        // #703 regression guard. Plugin host silos must NOT advertise as Orleans client
+        // gateways: their assembly load context intentionally lacks Fleans.Application /
+        // Fleans.Domain / Fleans.Persistence. An engine grain call (e.g. IWorkflowInstanceGrain)
+        // forwarded *through* a plugin gateway throws "Unable to load type" at the gateway.
+        // Removing the EndpointOptions.GatewayPort = 0 line from AddFleansPluginHost MUST
+        // make this test fail.
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["Fleans:Role"] = "Plugin" })
+            .Build();
+
+        var builder = new FakeSiloBuilder(configuration);
+        builder.AddFleansPluginHost(configuration);
+
+        using var provider = builder.Services.BuildServiceProvider();
+        var endpoints = provider.GetRequiredService<Microsoft.Extensions.Options.IOptions<Orleans.Configuration.EndpointOptions>>().Value;
+
+        Assert.AreEqual(0, endpoints.GatewayPort,
+            "AddFleansPluginHost must set EndpointOptions.GatewayPort = 0 — plugin silos lack " +
+            "Fleans.Application and cannot serve as Orleans client gateways for engine grains (#703).");
+    }
+
+    [TestMethod]
     public void AddFleansPluginHost_RegistersBothPlacementDirectors()
     {
         // #627 regression guard. Removing either AddPlacementDirector<> line from

--- a/src/Fleans/Fleans.Worker/Hosting/PluginHostExtensions.cs
+++ b/src/Fleans/Fleans.Worker/Hosting/PluginHostExtensions.cs
@@ -16,6 +16,11 @@ public static class PluginHostExtensions
         var siloName = BuildSiloName(role, Environment.MachineName, Guid.NewGuid());
 
         siloBuilder.Configure<Orleans.Configuration.SiloOptions>(o => o.SiloName = siloName);
+        // Plugin hosts must not advertise as Orleans client gateways: their assembly load context
+        // intentionally lacks Fleans.Application / Fleans.Domain / Fleans.Persistence, so any
+        // engine grain call (e.g. IWorkflowInstanceGrain) forwarded *through* a plugin gateway
+        // throws "Unable to load type" at the gateway. See #703.
+        siloBuilder.Configure<Orleans.Configuration.EndpointOptions>(o => o.GatewayPort = 0);
         siloBuilder.AddPlacementDirector<CorePlacementStrategy, CorePlacementDirector>();
         siloBuilder.AddPlacementDirector<WorkerPlacementStrategy, WorkerPlacementDirector>();
         siloBuilder.AddFleansPlacementAssertion(configuration);


### PR DESCRIPTION
Closes #703.

## Summary

`AddFleansPluginHost` was leaving Orleans's gateway port at the default, so plugin host silos advertised themselves as **client gateways** when joining the cluster via Redis clustering. `Fleans.Web` is an Orleans client (`UseOrleansClient`) and round-robins among advertised gateways. When the client landed on a plugin gateway and forwarded an engine grain call through it, the gateway threw the exact error reported in #703:

> `Unable to load Fleans.Application.Grains.IWorkflowInstanceGrain, Fleans.Application from assembly Fleans.Application`

— because the plugin silo's assembly load context intentionally lacks `Fleans.Application` (the whole point of the leaf-package design).

The one-line fix sets `EndpointOptions.GatewayPort = 0` inside `AddFleansPluginHost`, telling Orleans the silo does NOT advertise as a client gateway. Silo-to-silo traffic (the `SiloPort`) is unaffected — the silo still joins the cluster, participates in placement, and serves custom-task stream subscriptions for the plugin grain types it hosts.

## End-to-end verified

I reproduced the bug locally against the v0.5.0 release bundle + `fleans-custom-worker-example`, then applied this fix as a runtime override (`Orleans__Endpoints__GatewayPort=0`) on the running stack:

- Without the override: intermittent "Unable to load type" errors when starting workflows via the management Web.
- With the override applied: 10/10 starts succeed; HelloWorld plugin still activates on the plugin silo as designed; workflow completion + return-variables round-trip cleanly.

Workaround stop-gap for users on pre-fix Fleans versions documented in a parallel PR against [`fleans-custom-worker-example`](https://github.com/nightBaker/fleans-custom-worker-example).

## Test plan

- [x] `dotnet test --filter "PluginHostPlacementTests"` — 6/6 pass (1 new regression guard + 5 existing).
- [x] Build clean (0 errors, 132 pre-existing warnings).
- [ ] Manual: cycle the running v0.5.0 + custom-worker stack with the engine-fix applied (remove the env override, rebuild custom-worker image with this branch's `Fleans.Worker` package). I left the env-var workaround on the local stack for now — happy to do this cycle once the PR is approved.

## Related

- #627 (`AddFleansPluginHost` missing `CorePlacementStrategy` — landed pre-v0.5.0). Same surface area as this fix; both were latent multi-silo-cluster bugs that only surface when a plugin host is in the cluster.
- #628 (`ExpandoObjectSurrogateConverter` moved to `Fleans.Domain.Abstractions` — landed pre-v0.5.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)