### PR TITLE
fix(20-complex-gateway): use child element for activationCondition

### DIFF
--- a/src/Fleans/Fleans.E2E.Tests/Specs/ComplexGatewayTests.cs
+++ b/src/Fleans/Fleans.E2E.Tests/Specs/ComplexGatewayTests.cs
@@ -1,0 +1,28 @@
+using Fleans.E2E.Tests.ApiClient;
+using Fleans.E2E.Tests.Infrastructure;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Fleans.E2E.Tests.Specs;
+
+// Ports tests/manual/20-complex-gateway/test-plan.md (scenario 20b)
+[TestClass]
+[TestCategory("E2E")]
+public class ComplexGatewayTests : WorkflowE2ETestBase
+{
+    [TestMethod]
+    public async Task JoinWithActivationCondition_FiresOnFirstToken_DiscardsSecond()
+    {
+        var xml = BpmnFixtureLoader.Load("20-complex-gateway", "join-activation-condition.bpmn");
+        var deployed = await ApiClient.DeployAsync(xml);
+        var started = await ApiClient.StartAsync(deployed.ProcessDefinitionKey);
+
+        var state = await ApiClient.WaitForCompletionAsync(started.WorkflowInstanceId);
+
+        // Both branches run before reaching the join; the join's activationCondition
+        // (_context._nroftoken >= 1) fires on the first token and the second is discarded.
+        state.AssertCompletedActivities(
+            "start", "fork", "fastTask", "slowTask", "join", "afterJoin", "end");
+        state.AssertVariableEquals("joined", "True");
+        Assert.IsEmpty(state.ActiveActivityIds);
+    }
+}

--- a/tests/manual/20-complex-gateway/join-activation-condition.bpmn
+++ b/tests/manual/20-complex-gateway/join-activation-condition.bpmn
@@ -14,7 +14,9 @@
       <!-- Simulates a slow branch; in a real test this would be a timer or user task -->
       <script>_context.slow = true</script>
     </scriptTask>
-    <complexGateway id="join" activationCondition="_context._nroftoken &gt;= 1" />
+    <complexGateway id="join">
+      <activationCondition>_context._nroftoken &gt;= 1</activationCondition>
+    </complexGateway>
     <scriptTask id="afterJoin" scriptFormat="csharp">
       <script>_context.joined = true</script>
     </scriptTask>


### PR DESCRIPTION
## Problem

Uploading `tests/manual/20-complex-gateway/join-activation-condition.bpmn` into the BPMN editor failed with:

```
Invalid BPMN: Cannot read properties of undefined (reading 'isGeneric')
TypeError ... at cr.parseContainments ... bpmn-modeler.production.min.js
```

The fixture declared `activationCondition` as an **attribute** on `<complexGateway>`. In BPMN 2.0 it is a **child element** of type `Expression`, so bpmn-js's moddle parser tried to resolve an element-type descriptor for it, got `undefined`, then read `.isGeneric` → crash.

## Fix

- Move `activationCondition` to the child-element form, matching the `conditionExpression` pattern already used in the sibling `fork-conditional.bpmn`:

  ```xml
  <complexGateway id="join">
    <activationCondition>_context._nroftoken &gt;= 1</activationCondition>
  </complexGateway>
  ```

- Parsed behavior is unchanged: `BpmnConverter` already reads **both** forms (attribute `??` child element, `BpmnConverter.cs:463`).
- Add `ComplexGatewayTests` E2E spec porting test-plan scenario 20b — the join fires on the first token, the second is discarded, both branches complete, `joined == True`, no stuck activities.

## Verification

- `dotnet build Fleans.E2E.Tests` — 0 errors.
- Full E2E suite (`TestCategory=E2E`): **48 passed, 0 failed, 30 skipped** — new test green, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)