### PR TITLE
security: fail-closed when running Production without authentication

### DIFF
--- a/src/Fleans/Fleans.Api/Program.cs
+++ b/src/Fleans/Fleans.Api/Program.cs
@@ -30,6 +30,22 @@ builder.AddServiceDefaults();
 // Authentication — opt-in: only enabled when Authentication:Authority is configured
 var authAuthority = builder.Configuration["Authentication:Authority"];
 var authEnabled = !string.IsNullOrEmpty(authAuthority);
+
+// Fail-closed in Production: an empty Authentication:Authority in non-Development
+// environments would leave every controller anonymous (none of them carry [Authorize]
+// individually — the fallback policy is the only protection, and that is only
+// registered inside `if (authEnabled)` below). Refuse to start instead of silently
+// shipping an open admin surface. Operators who knowingly want an unauthenticated
+// deployment must opt in by setting ASPNETCORE_ENVIRONMENT=Development or Staging.
+if (!authEnabled && builder.Environment.IsProduction())
+{
+    throw new InvalidOperationException(
+        "Fleans.Api refuses to start in Production without authentication. " +
+        "Set 'Authentication:Authority' (OIDC issuer URL) and 'Authentication:Audience'. " +
+        "To run unauthenticated for local/dev use, set ASPNETCORE_ENVIRONMENT to " +
+        "Development or Staging.");
+}
+
 if (authEnabled)
 {
     builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)

--- a/src/Fleans/Fleans.Web/Program.cs
+++ b/src/Fleans/Fleans.Web/Program.cs
@@ -56,6 +56,21 @@ var authAuthority = builder.Configuration["Authentication:Authority"];
 var authClientId = builder.Configuration["Authentication:ClientId"];
 var authEnabled = !string.IsNullOrEmpty(authAuthority) && !string.IsNullOrEmpty(authClientId);
 
+// Fail-closed in Production: with auth off, the fallback policy is never registered
+// (see `if (authEnabled)` block below) AND the Orleans Dashboard mapping at the bottom
+// of this file is unconditional, so an empty Authentication section in Production
+// would publish an open admin UI + cluster dashboard. Refuse to start instead.
+// Operators who knowingly want an unauthenticated deployment must opt in by setting
+// ASPNETCORE_ENVIRONMENT=Development or Staging.
+if (!authEnabled && builder.Environment.IsProduction())
+{
+    throw new InvalidOperationException(
+        "Fleans.Web refuses to start in Production without authentication. " +
+        "Set 'Authentication:Authority' (OIDC issuer URL) and 'Authentication:ClientId'. " +
+        "To run unauthenticated for local/dev use, set ASPNETCORE_ENVIRONMENT to " +
+        "Development or Staging.");
+}
+
 builder.Services.AddSingleton(new AuthOptions(authEnabled, authAuthority ?? "", authClientId ?? ""));
 
 if (authEnabled)


### PR DESCRIPTION
## Summary

Refuse to start `Fleans.Api` and `Fleans.Web` in Production if the `Authentication` section is empty. Today both processes silently fall into anonymous mode — every controller and every Blazor page becomes public, and the Orleans Dashboard joins them. This PR makes that misconfiguration loud at process start rather than a quiet hole at runtime.

No dev-loop change: `dotnet run --project Fleans.Aspire` (which sets `ASPNETCORE_ENVIRONMENT=Development`) keeps working exactly as before. Operators who deliberately want an unauthenticated install in Production must set `ASPNETCORE_ENVIRONMENT=Staging` (or supply credentials).

## Problem

Both `Fleans.Api/Program.cs` and `Fleans.Web/Program.cs` wrap their entire auth pipeline in `if (authEnabled)`:

- `AddJwtBearer` / `AddOpenIdConnect` registration
- `SetFallbackPolicy(RequireAuthenticatedUser())`
- `UseAuthentication` / `UseAuthorization` middleware

With `Authentication:Authority` empty (the default in `appsettings.json` and in the Helm chart's `values.yaml`), none of these run. Controllers under `Fleans.Api/Controllers/` carry **no `[Authorize]` attributes** (verified via grep), so anonymous callers can reach:

- `POST /Definitions/deploy` — load arbitrary BPMN, including `<scriptTask scriptFormat="csharp">` which `DynamicExpresso` will execute in-process on the worker silo
- `POST /Execution/start`, `POST /Execution/message`, `POST /Execution/signal`
- `POST /UserTasks/{id}/claim` — combined with `BodyUserGroupResolver`, the body's `userGroups` is taken on trust
- `POST /Definitions/disable`, `enable`

The Web project is worse: per the design rule in `CLAUDE.md`, Blazor pages call Orleans grains **directly** instead of going through the API, so "fix it at the API perimeter" doesn't help. And `app.MapOrleansDashboard("/dashboard")` (line 200 of `Fleans.Web/Program.cs`) sits **outside** the `if (authEnabled)` block — the explicit gate above it (lines 186-196) is itself conditional on `authEnabled`, so when auth is off the gate isn't installed.

Cumulative effect: a stock `helm install fleans` with no `auth.authority` value lands a public BPMN-deploy endpoint plus a public Orleans Dashboard plus a public Blazor admin UI on whatever network the cluster is on.

## Industry comparison

**Camunda 7 / Zeebe** ship the same fail-open posture by default (REST API without authentication when no Identity provider is configured). This has produced a documented history of "Camunda exposed on the internet" advisories. Camunda 8 SaaS hardened by requiring API tokens for every request; self-hosted Camunda still requires the operator to opt in to auth. Fleans inherits this BPMN-engine family trait.

**Temporal** has a similar "self-hosted dev mode is open" trait (`temporal server start-dev` listens without auth), but with two differences: (a) its server never executes user-supplied workflow code, so the worst case is data exfiltration rather than RCE; (b) the production Temporal Helm charts and Temporal Cloud both default to mTLS-required. Fleans here moves one step toward the Temporal posture: dev mode stays easy, Production fails closed.

## Change

Two new pre-`builder.Build()` checks, one in each `Program.cs`:

\`\`\`csharp
if (!authEnabled && builder.Environment.IsProduction())
{
    throw new InvalidOperationException(
        \"Fleans.<X> refuses to start in Production without authentication. \" +
        \"Set 'Authentication:Authority' …\");
}
\`\`\`

No new packages, no new abstractions, no behaviour change in Development/Staging.

## What this PR deliberately does **not** do

- **Add `[Authorize]` to every controller.** That's a follow-up PR and needs a regression pass on the E2E suite.
- **Touch `Fleans.Mcp`.** MCP has no auth wiring at all today; the right fix is a follow-up PR that adds an auth layer or restricts the listener to loopback. Adding only a Production guard there would leave the dev-mode surface wide open and provide false confidence.
- **Touch `Fleans.WorkerHost`.** It only maps `/health` and `/alive`; no business-facing HTTP routes.
- **Force-enable auth in Development.** A common dev loop is `dotnet run --project Fleans.Aspire` against local SQLite + Memory streams; requiring an IdP there would be hostile.

## Test plan

Locally verified (.NET 10.0.108 SDK, branch built clean, 447 unit tests pass):

- [x] `ASPNETCORE_ENVIRONMENT=Production`, no Authentication config → both processes throw \`InvalidOperationException\` at startup with a clear message pointing at the missing config key. Throw fires before Orleans / DB / Redis are touched.
- [x] `ASPNETCORE_ENVIRONMENT=Production`, `Authentication__Authority` set → check passes, process proceeds to normal startup (then fails on missing Redis in my local sandbox, which is expected).
- [x] `ASPNETCORE_ENVIRONMENT=Development` (default in launchSettings.json) → no behaviour change.

What I could not validate locally (no infra):

- [ ] CI build + existing E2E pass — relying on the PR pipeline.
- [ ] Helm install with empty `auth.authority` and `ASPNETCORE_ENVIRONMENT=Production` → pod CrashLoopBackOff with the new message in `kubectl logs`.

## Follow-ups (separate PRs)

- Move `MapOrleansDashboard` inside the `if (authEnabled)` block in \`Fleans.Web/Program.cs\` so even Development mode stops exposing the cluster dashboard anonymously.
- Wire authentication into `Fleans.Mcp`.
- Add `[Authorize]` baseline to controllers so a future regression in \`Program.cs\` can't reopen the hole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)