### PR TITLE
security: do not map Orleans Dashboard when auth is disabled

### DIFF
--- a/src/Fleans/Fleans.Web/Program.cs
+++ b/src/Fleans/Fleans.Web/Program.cs
@@ -194,10 +194,26 @@ if (authEnabled)
             }
             await next();
         }));
+
+    // Orleans Dashboard at /dashboard — mapped only when the explicit auth gate
+    // above is installed. With auth off, MapOrleansDashboard would expose silo
+    // membership, grain counts, and live call graphs to anyone reachable.
+    app.MapOrleansDashboard(routePrefix: "/dashboard");
+}
+else if (app.Environment.IsDevelopment())
+{
+    // Development convenience: keep the dashboard available for local debugging
+    // (Aspire dev loop, Combined silo). Log a loud warning so an operator who
+    // accidentally points a Development build at a multi-tenant cluster notices
+    // what they just shipped. Staging/Production with auth disabled get no
+    // dashboard at all — the only way to expose it is to enable auth.
+    app.Logger.LogWarning(
+        "Orleans Dashboard is mounted at /dashboard WITHOUT authentication " +
+        "(Development environment, auth disabled). Do not expose this listener " +
+        "to untrusted networks.");
+    app.MapOrleansDashboard(routePrefix: "/dashboard");
 }
 
-// Orleans Dashboard at /dashboard
-app.MapOrleansDashboard(routePrefix: "/dashboard");
 app.MapDefaultEndpoints();
 
 app.Run();


### PR DESCRIPTION
## Summary

The Orleans Dashboard at `/dashboard` is currently mounted unconditionally on `Fleans.Web`, while the auth middleware that should be guarding it is mounted only when authentication is enabled. With `Authentication:Authority` empty (the documented default), the dashboard is reachable anonymously — exposing silo membership, grain types and counts, live call graphs, error rates, and the dashboard's own interactive controls.

This PR moves `MapOrleansDashboard` **inside** the existing `if (authEnabled)` block, with a narrow `else if (app.Environment.IsDevelopment())` escape hatch so the Aspire dev loop keeps working. Staging/Production with auth off get no dashboard at all.

## Problem

Today's `Fleans.Web/Program.cs` (around line 185-200) is split:

```csharp
if (authEnabled)
{
    // D4 — Orleans Dashboard does not honour [Authorize]; gate it explicitly
    app.UseWhen(
        ctx => ctx.Request.Path.StartsWithSegments(\"/dashboard\"),
        branch => branch.Use(async (ctx, next) =>
        {
            if (ctx.User.Identity?.IsAuthenticated != true)
            {
                await ctx.ChallengeAsync(OpenIdConnectDefaults.AuthenticationScheme);
                return;
            }
            await next();
        }));
}

// Orleans Dashboard at /dashboard          ← outside the gate
app.MapOrleansDashboard(routePrefix: \"/dashboard\");
```

The comment on `D4` already names the load-bearing fact: Orleans Dashboard's `Microsoft.Orleans.Dashboard` NuGet does not respect ASP.NET Core authorization attributes — the middleware gate is the only protection. But that gate is itself gated on `authEnabled`. When authentication is disabled (default Helm install, `appsettings.json` without an Authority, local Aspire run), the gate is never installed; the `MapOrleansDashboard` call below it stays in. Anonymous `GET /dashboard` then returns the full UI.

In a typical Helm install the Web Service is exposed to the cluster network; depending on the operator's Ingress / NetworkPolicy posture this can reach the open internet or every workload in the cluster.

## Industry comparison

**Camunda / Cockpit** ships authentication that's switched on by default (`demo:demo` for the local distribution, configurable for production). Cockpit was historically misconfigured in the wild — there's a documented history of `Cockpit` instances reachable on the open internet with default credentials — but the *intent* of the project is auth-on. Fleans's default-off-auth posture is more permissive than Camunda's.

**Temporal** doesn't ship a comparable \"cluster-introspection UI\" with a separate auth surface. Temporal Web UI calls the frontend gRPC API; the frontend's `Authorizer` plugin is the single auth surface, and `temporal server start-dev` exposes everything but only on localhost. Temporal Cloud requires mTLS for every call regardless. Fleans here is closer to Cockpit's split-surface model, which is why we need explicit guarding.

Either way: a community admin UI plugin (which is what `Microsoft.Orleans.Dashboard` is) should not be the perimeter — the host has to gate it.

## Change

One file (`Fleans.Web/Program.cs`), one structural move:

- `MapOrleansDashboard(\"/dashboard\")` moves **inside** the `if (authEnabled)` block, right after the existing gate middleware.
- A new `else if (app.Environment.IsDevelopment())` branch keeps the dashboard mapped for the local dev loop, with `ILogger.LogWarning` shouting that it's running without auth. Staging and Production with auth off get no dashboard at all.

```csharp
if (authEnabled)
{
    app.UseWhen(/* dashboard auth gate */ …);
    app.MapOrleansDashboard(routePrefix: \"/dashboard\");
}
else if (app.Environment.IsDevelopment())
{
    app.Logger.LogWarning(\"Orleans Dashboard is mounted at /dashboard WITHOUT authentication …\");
    app.MapOrleansDashboard(routePrefix: \"/dashboard\");
}
```

No new packages, no new abstractions, no behaviour change when auth is enabled.

## Why a Development escape hatch

The Aspire dev loop (`dotnet run --project Fleans.Aspire`) sets `ASPNETCORE_ENVIRONMENT=Development` and runs without an IdP. The dashboard is genuinely useful there for grain debugging. Removing it from Development would be a UX regression for the inner-loop workflow described in `README.md`. The trade-off here:

| Env | Auth on | Auth off |
|---|---|---|
| Development | dashboard mounted, gated | dashboard mounted, **logged warning** |
| Staging | dashboard mounted, gated | dashboard **not** mounted |
| Production | dashboard mounted, gated | dashboard **not** mounted |

If a future PR closes the \"Production with auth off\" path entirely (fail-closed on startup), the Staging/Production rows simplify, but this PR is independently valuable today.

## Test plan

Locally verified (.NET 10.0.108 SDK):

- [x] `dotnet build src/Fleans/Fleans.Web/Fleans.Web.csproj` — 0 errors, 18 pre-existing warnings.
- [x] `dotnet test src/Fleans/Fleans.Domain.Tests` — 447 passed.

Could not validate locally (the Web project's Orleans client requires a live Redis/cluster, which my sandbox doesn't have):

- [ ] CI build + existing E2E pass — relying on the PR pipeline.
- [ ] `ASPNETCORE_ENVIRONMENT=Development`, no auth → `GET /dashboard` returns the UI, log line warns about the missing gate.
- [ ] `ASPNETCORE_ENVIRONMENT=Staging`, no auth → `GET /dashboard` returns 404.
- [ ] `ASPNETCORE_ENVIRONMENT=Production`, auth enabled → unchanged from main.

## Related

- Follow-up to the broader \"Fleans ships an open admin plane by default\" thread. Other independent PRs are stacked on this:
  - `Fleans.Mcp` has no auth wiring at all — separate fix.
  - REST API controllers have no `[Authorize]` attributes — separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)