### PR TITLE
security: reject CR/LF + invalid tokens in REST-caller headers; cap response body

### DIFF
--- a/src/Fleans/Fleans.Plugins.RestCaller.Tests/RestCallerHandlerTests.cs
+++ b/src/Fleans/Fleans.Plugins.RestCaller.Tests/RestCallerHandlerTests.cs
@@ -247,6 +247,79 @@ public class RestCallerHandlerTests
         Assert.AreEqual("400", ex.GetActivityErrorState().Code);
     }
 
+    // --- Header validation (CRLF + RFC 7230 token grammar) ---
+
+    [TestMethod]
+    public async Task HeaderValueContainingCrLf_FailsWith400()
+    {
+        var handler = MakeHandler(new HttpClientHandler());
+        var headers = new Dictionary<string, object?>
+        {
+            ["X-Test"] = "value\r\nHost: evil.example.com"
+        };
+        var ex = await Assert.ThrowsExactlyAsync<CustomTaskFailedActivityException>(() =>
+            handler.ExecuteForTest(
+                Inputs("http://example.com/", headers: headers), new ExpandoObject(), Ctx()));
+        var state = ex.GetActivityErrorState();
+        Assert.AreEqual("400", state.Code);
+        Assert.IsTrue(state.Message.Contains("CR or LF"),
+            $"Expected CR/LF rejection message, got: {state.Message}");
+    }
+
+    [TestMethod]
+    public async Task HeaderNameContainingCrLf_FailsWith400()
+    {
+        var handler = MakeHandler(new HttpClientHandler());
+        var headers = new Dictionary<string, object?>
+        {
+            ["X-Bad\r\nInjected"] = "value"
+        };
+        var ex = await Assert.ThrowsExactlyAsync<CustomTaskFailedActivityException>(() =>
+            handler.ExecuteForTest(
+                Inputs("http://example.com/", headers: headers), new ExpandoObject(), Ctx()));
+        Assert.AreEqual("400", ex.GetActivityErrorState().Code);
+    }
+
+    [TestMethod]
+    public async Task HeaderNameWithInvalidTokenChar_FailsWith400()
+    {
+        var handler = MakeHandler(new HttpClientHandler());
+        // Space and `:` and `=` and `<` are all outside RFC 7230 token grammar.
+        var headers = new Dictionary<string, object?>
+        {
+            ["X-Has Space"] = "v"
+        };
+        var ex = await Assert.ThrowsExactlyAsync<CustomTaskFailedActivityException>(() =>
+            handler.ExecuteForTest(
+                Inputs("http://example.com/", headers: headers), new ExpandoObject(), Ctx()));
+        var state = ex.GetActivityErrorState();
+        Assert.AreEqual("400", state.Code);
+        Assert.IsTrue(state.Message.Contains("invalid character"),
+            $"Expected token-grammar rejection, got: {state.Message}");
+    }
+
+    [TestMethod]
+    public async Task HeaderNameWithValidTokenChars_Accepted()
+    {
+        // Sanity-check: legitimate header names with the full RFC 7230 token alphabet still work.
+        await using var mock = await MockServer.StartAsync(async ctx =>
+        {
+            ctx.Response.StatusCode = 200;
+            await ctx.Response.WriteAsync("ok");
+        });
+
+        var handler = MakeHandler(new HttpClientHandler());
+        var headers = new Dictionary<string, object?>
+        {
+            ["X-Custom-Header_42!"] = "v"
+        };
+        await handler.ExecuteForTest(
+            Inputs($"{mock.BaseUrl}/", headers: headers), new ExpandoObject(), Ctx());
+
+        var rec = mock.Requests.Single();
+        Assert.AreEqual("v", rec.Headers["X-Custom-Header_42!"]);
+    }
+
     // --- JSON content-type detection ---
 
     [TestMethod]

--- a/src/Fleans/Fleans.Plugins.RestCaller/RestCallerHandler.cs
+++ b/src/Fleans/Fleans.Plugins.RestCaller/RestCallerHandler.cs
@@ -110,6 +110,7 @@ public sealed partial class RestCallerHandler : CustomTaskHandlerBase
         {
             if (string.Equals(name, "Content-Type", StringComparison.OrdinalIgnoreCase))
                 continue;  // already handled via StringContent
+            ValidateHeader(name, value);
             if (!request.Headers.TryAddWithoutValidation(name, value))
                 request.Content?.Headers.TryAddWithoutValidation(name, value);
         }
@@ -212,6 +213,51 @@ public sealed partial class RestCallerHandler : CustomTaskHandlerBase
     }
 
     // --- helpers for resolvedInputs coercion ---
+
+    /// <summary>
+    /// Rejects header names/values that contain CR or LF. Modern .NET handlers strip
+    /// these at send time and raise HttpRequestException, but rejecting here makes
+    /// the failure deterministic and produces a 400 CustomTaskFailedActivityException
+    /// instead of a 502 network error wrapper. Header names additionally must conform
+    /// to RFC 7230 token grammar — `TryAddWithoutValidation` lets through bytes that
+    /// silently break the upstream parser; reject up-front so workflow authors get a
+    /// clear error.
+    /// </summary>
+    private static void ValidateHeader(string name, string value)
+    {
+        if (string.IsNullOrEmpty(name))
+            throw new CustomTaskFailedActivityException("400", "header name cannot be empty");
+
+        if (ContainsCrOrLf(name))
+            throw new CustomTaskFailedActivityException("400",
+                $"header name '{name}' contains CR or LF");
+
+        foreach (var c in name)
+        {
+            // RFC 7230 token: !#$%&'*+-.^_`|~ and DIGIT / ALPHA. Excludes control chars,
+            // whitespace, separators (:,;()<>@\"/[]?={}). Conservative on purpose —
+            // headers that don't fit this grammar would be rejected by the SocketsHttpHandler
+            // anyway; failing early avoids ambiguous 502 wrappers.
+            var ok = c is (>= 'a' and <= 'z') or (>= 'A' and <= 'Z') or (>= '0' and <= '9')
+                  || c is '!' or '#' or '$' or '%' or '&' or '\'' or '*' or '+' or '-'
+                       or '.' or '^' or '_' or '`' or '|' or '~';
+            if (!ok)
+                throw new CustomTaskFailedActivityException("400",
+                    $"header name '{name}' contains invalid character '{c}' " +
+                    "(RFC 7230 token grammar required)");
+        }
+
+        if (ContainsCrOrLf(value))
+            throw new CustomTaskFailedActivityException("400",
+                $"header '{name}' value contains CR or LF");
+    }
+
+    private static bool ContainsCrOrLf(string s)
+    {
+        for (var i = 0; i < s.Length; i++)
+            if (s[i] is '\r' or '\n') return true;
+        return false;
+    }
 
     private static string? ReadString(IDictionary<string, object?> inputs, string key)
         => inputs.TryGetValue(key, out var v) ? v?.ToString() : null;

--- a/src/Fleans/Fleans.Plugins.RestCaller/RestCallerServiceCollectionExtensions.cs
+++ b/src/Fleans/Fleans.Plugins.RestCaller/RestCallerServiceCollectionExtensions.cs
@@ -11,13 +11,27 @@ namespace Fleans.Plugins.RestCaller;
 /// </summary>
 public static class RestCallerServiceCollectionExtensions
 {
+    /// <summary>
+    /// Default cap on the response body the REST-call plugin will buffer into
+    /// workflow state. 8 MiB is large enough for typical REST envelopes while
+    /// keeping a single misbehaving upstream from filling the silo heap with a
+    /// multi-GB response (the BCL default is 2 GiB). Operators with legitimate
+    /// large-payload use cases can replace the typed-client registration with
+    /// their own <c>AddHttpClient&lt;RestCallerHandler&gt;</c> call before
+    /// <see cref="AddRestCallerPlugin"/>.
+    /// </summary>
+    public const long DefaultMaxResponseContentBufferSize = 8L * 1024 * 1024;
+
     public static IServiceCollection AddRestCallerPlugin(this IServiceCollection services)
     {
         // Typed-client; HttpClient.Timeout = InfiniteTimeSpan because per-call timeout is
         // enforced by the handler via CancellationTokenSource.CancelAfter(timeoutSec).
+        // MaxResponseContentBufferSize caps ReadAsStringAsync / ReadAsByteArrayAsync so
+        // a hostile or compromised upstream cannot stream gigabytes into the silo heap.
         services.AddHttpClient<RestCallerHandler>(client =>
         {
             client.Timeout = Timeout.InfiniteTimeSpan;
+            client.MaxResponseContentBufferSize = DefaultMaxResponseContentBufferSize;
         });
 
         services.AddCustomTaskPlugin<RestCallerHandler>(


### PR DESCRIPTION
## Summary

Two related hardening changes on the built-in `rest-call` custom task plugin:

1. **Reject CR/LF and non-RFC-7230 characters in user-supplied header names/values** before they reach `TryAddWithoutValidation` — so workflow authors get a deterministic 400 with a clear message instead of relying on `SocketsHttpHandler` to defend at send time.
2. **Cap the buffered response body at 8 MiB** by setting `HttpClient.MaxResponseContentBufferSize`. Today the BCL default of 2 GiB applies, so a hostile or compromised upstream can stream gigabytes into `ReadAsStringAsync` and exhaust the silo heap.

Both changes are scoped to `Fleans.Plugins.RestCaller`; no behaviour change in other projects. 22 unit tests pass locally (18 pre-existing + 4 new).

## Problem

### 1. Header injection surface

`RestCallerHandler.ExecuteAsync` reads header names and values from the resolved workflow inputs and passes them straight through:

```csharp
foreach (var (name, value) in headers)
{
    if (string.Equals(name, \"Content-Type\", StringComparison.OrdinalIgnoreCase))
        continue;
    if (!request.Headers.TryAddWithoutValidation(name, value))   // ← no checks
        request.Content?.Headers.TryAddWithoutValidation(name, value);
}
```

\"TryAddWithoutValidation\" deliberately bypasses .NET's built-in HTTP header parsing. Modern `SocketsHttpHandler` validates header bytes again at send time and raises `HttpRequestException` on CR/LF — but that fallback is implicit, version-dependent, and produces a generic 502 wrapper that hides the actual cause from the workflow author.

Two failure modes today:

- **Header value `\"Bearer x\\r\\nHost: evil\\r\\n\\r\\n\"`** — workflow author or upstream variable carries CR/LF; today's behaviour is \"either the BCL strips it or the request gets corrupted in a transport-dependent way.\" Tomorrow if anyone replaces the handler (custom `IHttpMessageHandlerFactory`, mock for tests, exotic proxy), the validation may not fire and we're back to response-splitting against permissive backends.
- **Header name `\"X-Bad: Name\"`** (space, colon) — `TryAddWithoutValidation` lets it through. The upstream parser may interpret bytes after the space as a new header or reject the whole request with an opaque error.

### 2. Unbounded response body

`RestCallerServiceCollectionExtensions` configures the typed client with `Timeout = Timeout.InfiniteTimeSpan` (per-call timeout is enforced via CancellationToken — that's fine) but never sets `MaxResponseContentBufferSize`, so the BCL default of 2 GiB applies. Then `RestCallerHandler.BuildResponseAsync` does:

```csharp
var rawBody = await response.Content.ReadAsStringAsync();
```

A compromised or hostile upstream that streams `Content-Length: 2147483647` (or omits it and just keeps sending bytes) can drive the silo into GC pressure or OOM. The per-call timeout (default ≤ 300 s) is long enough to leak a *lot* of bytes before it fires.

## Industry comparison

**Camunda** (Connectors / HTTP-JSON connector) validates header names against RFC 7230 token grammar before invoking its HTTP client; values are passed through but the connector documentation calls out that values are bounded by the broker's payload size limit (configurable, default 4 MiB). Response-body limits ship as a connector property `connectionTimeoutInSeconds` + an implicit broker max-payload guard — the workflow author cannot fetch arbitrary-sized blobs into a variable. Fleans pre-PR was more permissive on both axes.

**Temporal** has no first-party HTTP activity; user-written activities handle their own HTTP. The Temporal SDK's default `DataConverter` enforces a per-payload size limit (2 MiB default, configurable). Activities that exceed it raise `DataConverterException` rather than silently growing workflow state. Fleans pre-PR had no equivalent guard — `__response.body` could grow without bound, which then also bloats the event-sourced workflow history.

This PR matches Camunda's posture: validate header names up front, cap response body to a reasonable size.

## Change

**File 1 — `RestCallerHandler.cs`:**

```csharp
foreach (var (name, value) in headers)
{
    if (string.Equals(name, \"Content-Type\", StringComparison.OrdinalIgnoreCase))
        continue;
    ValidateHeader(name, value);                                  // ← new
    if (!request.Headers.TryAddWithoutValidation(name, value))
        request.Content?.Headers.TryAddWithoutValidation(name, value);
}

// new helper:
private static void ValidateHeader(string name, string value)
{
    // empty / CR / LF / non-RFC-7230-token chars → CustomTaskFailedActivityException(\"400\", …)
}
```

`ValidateHeader` rejects:

- Empty name.
- CR or LF anywhere in name or value.
- Any character in the name outside the RFC 7230 token alphabet (`!#$%&'*+-.^_\`|~`, `DIGIT`, `ALPHA`).

The token alphabet whitelist is conservative on purpose — anything `TryAddWithoutValidation` would let through that the upstream parser then rejects is now caught at our boundary with a clear 400 + activity-failure message naming the bad character.

**File 2 — `RestCallerServiceCollectionExtensions.cs`:**

```csharp
public const long DefaultMaxResponseContentBufferSize = 8L * 1024 * 1024;

services.AddHttpClient<RestCallerHandler>(client =>
{
    client.Timeout = Timeout.InfiniteTimeSpan;
    client.MaxResponseContentBufferSize = DefaultMaxResponseContentBufferSize;   // ← new
});
```

8 MiB picked as a round number that covers typical REST envelopes (most JSON APIs ship < 1 MiB per response) without leaving the silo open to multi-GB blob fetches. The default is a `public const` so operators with legitimate large-payload use cases can register their own `AddHttpClient<RestCallerHandler>` with a different value before `AddRestCallerPlugin`. When the limit is hit, the BCL raises `HttpRequestException` which the existing `catch (HttpRequestException)` arm in `ExecuteAsync` maps to `CustomTaskFailedActivityException(\"502\", ...)`.

**File 3 — `RestCallerHandlerTests.cs`:** four new tests:

- `HeaderValueContainingCrLf_FailsWith400` — covers the response-splitting vector.
- `HeaderNameContainingCrLf_FailsWith400` — covers split-key injection.
- `HeaderNameWithInvalidTokenChar_FailsWith400` — covers non-token bytes (space).
- `HeaderNameWithValidTokenChars_Accepted` — regression: a header named `X-Custom-Header_42!` (covers a broad slice of the token grammar) still flows through.

## Test plan

Locally verified (.NET 10.0.108 SDK):

- [x] `dotnet build src/Fleans/Fleans.Plugins.RestCaller` — 0 errors.
- [x] `dotnet test src/Fleans/Fleans.Plugins.RestCaller.Tests` — 22 passed (18 pre-existing + 4 new), 0 failed.

Could not validate locally:

- [ ] CI build + E2E pass.
- [ ] End-to-end: deploy a BPMN with a `rest-call` task whose header value contains `\\r\\n`; instance fails with `__error.code = \"400\"`, message names CR/LF.
- [ ] End-to-end: upstream returning > 8 MiB response → activity fails with `__error.code = \"502\"`, no silo OOM.

## What this PR deliberately does **not** do

- **Block private-IP / loopback URLs** (the SSRF half of the REST-caller hardening). That's a separate, larger PR adding a configurable outbound allowlist and DNS pinning.
- **Make the buffer size operator-configurable via `IConfiguration`.** A `const` keeps this PR scoped. Follow-up can wire a `RestCallerOptions` if real operator demand shows up.
- **Add per-tool rate limiting on the REST plugin.** Existing infra is at the API layer; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)