### PR TITLE
chart+aspire: wire Authentication into fleans-mcp deployment (follow-up to #709)

### DIFF
--- a/charts/fleans/templates/deployment-mcp.yaml
+++ b/charts/fleans/templates/deployment-mcp.yaml
@@ -39,6 +39,14 @@ spec:
           env:
             - name: ASPNETCORE_URLS
               value: "http://+:5200"
+            - name: ASPNETCORE_ENVIRONMENT
+              value: {{ .Values.appEnvironment | default "Production" | quote }}
+            {{- if .Values.auth.authority }}
+            - name: Authentication__Authority
+              value: {{ .Values.auth.authority | quote }}
+            - name: Authentication__Audience
+              value: {{ .Values.auth.mcpAudience | default "fleans-mcp" | quote }}
+            {{- end }}
             {{- include "fleans.commonEnv" . | nindent 12 }}
           livenessProbe:
             httpGet:

--- a/charts/fleans/values.yaml
+++ b/charts/fleans/values.yaml
@@ -188,10 +188,11 @@ redis:
       memory: 256Mi
 
 # -----------------------------------------------------------------------------
-# Authentication (OIDC for the Web admin UI)
+# Authentication (OIDC for the Web admin UI, JWT bearer for Fleans.Mcp).
+# Fleans.Mcp refuses to start in Production with an empty `authority`
+# (since #709); set `appEnvironment` to "Staging" for a deliberate
+# unauthenticated deployment, or supply `authority`.
 # -----------------------------------------------------------------------------
-# Leave authority + clientId empty to disable auth (matches Fleans.Web's
-# auth-disabled fallback). Provide all three to enable.
 auth:
   authority: ""
   clientId: ""
@@ -199,6 +200,15 @@ auth:
   clientSecretExistingSecret: ""
   # Or inline (NOT recommended for production — use existingSecret).
   clientSecret: ""
+  # JWT audience claim for Fleans.Mcp tokens.
+  mcpAudience: "fleans-mcp"
+
+# -----------------------------------------------------------------------------
+# ASP.NET Core environment passed via ASPNETCORE_ENVIRONMENT. Default
+# "Production" — Fleans.Mcp refuses to start in Production without
+# `auth.authority`. Override to "Staging" for an unauthenticated install.
+# -----------------------------------------------------------------------------
+appEnvironment: "Production"
 
 # -----------------------------------------------------------------------------
 # Streaming (Orleans Streams; defaults to Redis to match the engine default and

--- a/src/Fleans/Fleans.Aspire/Program.cs
+++ b/src/Fleans/Fleans.Aspire/Program.cs
@@ -208,11 +208,18 @@ if (builder.ExecutionContext.IsPublishMode)
 WithPersistence(webProject, usePostgres, pg, sqliteConnectionString);
 
 // MCP = Orleans client (for Claude Code)
+// Authentication__Authority is propagated so that `aspire publish` emits a
+// docker-compose / kubernetes manifest with the same auth wiring as the Helm
+// chart. The downstream Fleans.Mcp/Program.cs fail-closed guard (#709) refuses
+// to start in Production with an empty Authority, so leaving this off would
+// produce a publish artifact that crashes out of the box.
 WithPersistence(
     builder.AddProject<Projects.Fleans_Mcp>("fleans-mcp")
         .WithReference(orleans.AsClient())
         .WaitFor(fleansSilo)
         .WithHttpEndpoint(port: 5200, name: "mcp")
+        .WithEnvironment("Authentication__Authority", authAuthority)
+        .WithEnvironment("Authentication__Audience", "fleans-mcp")
         .WithReplicas(1),
     usePostgres, pg, sqliteConnectionString);
 


### PR DESCRIPTION
## Summary

Follow-up to the merged #709. That PR added a Production fail-closed guard to `Fleans.Mcp/Program.cs` but the chart and Aspire AppHost on `main` don't pass `Authentication__Authority` or `ASPNETCORE_ENVIRONMENT` to the MCP pod. ASP.NET Core defaults `IHostEnvironment.EnvironmentName` to `Production`, so every existing `helm install` (default values) CrashLoopBackOps after the #709 merge.

This PR wires the missing env vars in both the Helm chart and the Aspire AppHost, so:

- `helm install fleans --set auth.authority=...` starts cleanly.
- `aspire publish -t docker-compose` / `-t kubernetes` emits bundles that carry the same env vars.
- `helm-drift` check in `release.yml` stays green.

## Problem

`fleans-mcp` pod after the #709 merge with default chart values:

```
$ kubectl logs fleans-mcp-...
Unhandled exception. System.InvalidOperationException: Fleans.Mcp refuses to start
in Production without authentication. Set 'Authentication:Authority' …
```

Same shape if an operator runs the `aspire publish` docker-compose bundle from the release artifacts — the MCP container immediately exits.

Root cause: three artifacts that should agree on the env-var contract were updated only on the code side:

1. `Fleans.Mcp/Program.cs` ← changed in #709
2. `charts/fleans/templates/deployment-mcp.yaml` ← unchanged
3. `Fleans.Aspire/Program.cs` (publish-mode env wiring) ← unchanged

## Change

**`charts/fleans/values.yaml`** — new keys:

```yaml
appEnvironment: "Production"
auth:
  mcpAudience: "fleans-mcp"
```

Plus a refreshed comment on the `auth` section describing the fail-closed posture and the Staging escape hatch.

**`charts/fleans/templates/deployment-mcp.yaml`** — emit `ASPNETCORE_ENVIRONMENT` unconditionally; emit `Authentication__Authority` + `Authentication__Audience` when `auth.authority` is set:

```yaml
- name: ASPNETCORE_ENVIRONMENT
  value: {{ .Values.appEnvironment | default "Production" | quote }}
{{- if .Values.auth.authority }}
- name: Authentication__Authority
  value: {{ .Values.auth.authority | quote }}
- name: Authentication__Audience
  value: {{ .Values.auth.mcpAudience | default "fleans-mcp" | quote }}
{{- end }}
```

**`src/Fleans/Fleans.Aspire/Program.cs`** — `WithEnvironment` for the MCP project so `aspire publish` carries Authority + Audience into both compose and k8s outputs:

```csharp
.WithEnvironment("Authentication__Authority", authAuthority)
.WithEnvironment("Authentication__Audience", "fleans-mcp")
```

## Posture matrix (after this PR)

| Scenario | fleans-mcp behaviour |
|---|---|
| `helm install fleans` (defaults) | ASPNETCORE_ENVIRONMENT=Production, no Authority → CrashLoop (intended fail-closed) |
| `helm install fleans --set auth.authority=https://idp/...` | starts with JWT auth, Audience=fleans-mcp |
| `helm install fleans --set appEnvironment=Staging` | starts unauthenticated (operator escape hatch) |
| `aspire publish -t docker-compose` + run from bundle | inherits whatever Authority the AppHost was given at publish-time |

## Test plan

Local (helm 3 + .NET 10.0.108 SDK):

- [x] `helm lint charts/fleans/` → clean.
- [x] `helm template fleans charts/fleans/` → MCP pod gets ASPNETCORE_ENVIRONMENT=Production, no Authority.
- [x] `helm template fleans charts/fleans/ --set auth.authority=https://idp.example.com` → MCP gets Authority + Audience=fleans-mcp.
- [x] `helm template fleans charts/fleans/ --set appEnvironment=Staging` → Staging env emitted; CrashLoop guard skipped.
- [x] `dotnet build src/Fleans/Fleans.Aspire/` → 0 errors.

Relying on CI:

- [ ] `helm-lint.yml` workflow on this PR → passes.
- [ ] `release.yml` helm-drift step on next tagged release → green (Helm and Aspire now both emit the env vars).

## Notes

- The companion `Fleans.Api` Production-guard PR (#707) was closed without merging to avoid the same chart breakage. If/when it is re-opened, the analogous `auth.apiAudience` + `deployment-core.yaml` + Aspire `apiProject.WithEnvironment(...)` wiring should land in the same PR.
- The `auth.mcpAudience` key is documented but optional — services that share an audience can leave the default `fleans-mcp` and configure their IdP accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)