### PR TITLE
docs(#458): document nuget.org repository signing for published packages

### DIFF
--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -28,7 +28,13 @@ The release workflow runs setup → images → compose → helm-package → rele
 2. **All 4 images pullable, multi-arch** — `docker buildx imagetools inspect ghcr.io/nightbaker/fleans-{api,web,worker,mcp}:0.1.0-beta` should resolve `linux/amd64` + `linux/arm64`.
 3. **Release assets attached** — `gh release view v0.1.0-beta --json assets` should list `docker-compose-v0.1.0-beta.zip` + `fleans-0.1.0-beta.tgz`.
 4. **Notes look right** — auto-generated notes group commits per `.github/release.yml` categories.
-5. **NuGet publish triggered + green** — pushing the tag fires `nuget-publish.yml` in parallel with `release.yml`. It blocks on the GitHub Release existing (max 20 min wait) before pushing to nuget.org. Verify via `gh run list --workflow=nuget-publish.yml --limit 1`. Verify each of the 4 packages on nuget.org: `Fleans.Domain.Abstractions`, `Fleans.Application.Abstractions`, `Fleans.Worker`, `Fleans.Plugins.RestCaller`.
+5. **NuGet publish triggered + green** — pushing the tag fires `nuget-publish.yml` in parallel with `release.yml`. It blocks on the GitHub Release existing (max 20 min wait) before pushing to nuget.org. Verify via `gh run list --workflow=nuget-publish.yml --limit 1`. Verify each of the 4 packages on nuget.org: `Fleans.Domain.Abstractions`, `Fleans.Application.Abstractions`, `Fleans.Worker`, `Fleans.Plugins.RestCaller`. No project-managed signing certificate or secret is required — nuget.org **repository-signs** every accepted package server-side.
+   - **Repository-signature smoke (first real publish only).** Restore one published package and confirm nuget.org's repository signature is present and valid:
+     ```bash
+     dotnet add package Fleans.Worker --version 0.1.0-beta
+     dotnet nuget verify --all ~/.nuget/packages/fleans.worker/0.1.0-beta/fleans.worker.0.1.0-beta.nupkg
+     ```
+     This is a **post-publish** check — the `0.0.0-ci-test` dry-run skips `dotnet nuget push`, so the dry-run/local artifacts have no repository signature and `verify` would report `NU3004`. Publisher (author) signing is a separate planned follow-up.
 6. **Cosign verify smoke test** — pick one of the published images and verify the signature against Sigstore. The output should include a `Bundle` block with a `tlogEntries[0].logIndex` proving the signature was logged to the public Rekor transparency log.
 
    ```bash

--- a/tests/manual/41-nuget-publish/test-plan.md
+++ b/tests/manual/41-nuget-publish/test-plan.md
@@ -110,6 +110,27 @@ dotnet build
 
 Expect: `dotnet build` succeeds with `Build succeeded.` and zero errors.
 
+### 5b. Repository-signature verification (post-publish only)
+
+nuget.org repository-signs every accepted package **server-side**, so this signature
+exists only on a package restored from nuget.org — **not** on a dry-run or locally-packed
+`.nupkg`. Run this **only against a real published version** (skip it for the
+`0.0.0-ci-test` dry-run, where `verify` would report `NU3004` because nothing was pushed).
+
+From the same `nuget-consumer-smoke` restore:
+
+```bash
+dotnet nuget verify --all \
+  ~/.nuget/packages/fleans.worker/0.1.0-beta/fleans.worker.0.1.0-beta.nupkg
+```
+
+Expect: exit `0` with a valid **repository** signature reported (a `NU3004` here means
+the package is unsigned/tampered, not repo-signed). Then confirm the consumer docs match:
+the *Package integrity & signatures* section in
+`website/src/content/docs/reference/self-hosting.md` describes this `verify --all` check,
+the repo-vs-publisher-signature distinction, and the pre-1.0 trade-off — verify the text
+still matches observed behavior.
+
 ### 6. Symbols verification
 
 From the same `nuget-consumer-smoke` project (or any IDE configured to load
@@ -151,6 +172,7 @@ backed by `Deterministic=true` + `ContinuousIntegrationBuild=true` in
 - [ ] Each package page on nuget.org shows README, MIT license, and `nightBaker/fleans` repo URL.
 - [ ] Re-running the workflow on the same release is idempotent (`--skip-duplicate`).
 - [ ] A clean external project successfully `dotnet add package`s and builds against all three.
+- [ ] (Post-publish) `dotnet nuget verify --all` on a restored package reports a valid nuget.org **repository** signature; the `self-hosting.md` *Package integrity & signatures* section matches observed behavior.
 - [ ] `.snupkg` symbols are reachable on the nuget.org symbol server (HTTP 200 / IDE source-stepping).
 - [ ] Two consecutive `dotnet pack` runs at the same version produce bit-identical `.nupkg` files.
 

--- a/website/src/content/docs/reference/self-hosting.md
+++ b/website/src/content/docs/reference/self-hosting.md
@@ -256,6 +256,21 @@ When the silo joins the Orleans cluster, `<bpmn:serviceTask type="rest-call">` a
 
 The packages are published by [`.github/workflows/nuget-publish.yml`](https://github.com/nightBaker/fleans/blob/main/.github/workflows/nuget-publish.yml) on `release.published`. The workflow can also be invoked manually with `workflow_dispatch` and `version=0.0.0-ci-test` to dry-run pack + upload-artifact without touching nuget.org. Re-runs against an already-published version are no-ops via `dotnet nuget push --skip-duplicate`.
 
+### Package integrity & signatures
+
+Every Fleans plugin package you install from nuget.org carries nuget.org's **repository signature**. nuget.org applies this signature **server-side, when it accepts the upload** — it is not produced by the Fleans build, and it is present on the package you restore, not on a locally-packed `.nupkg`. The repository signature chains to a root that .NET trusts by default, so you can verify any restored Fleans package:
+
+```bash
+# Resolve the package, then verify the signature on the restored .nupkg in your global packages cache.
+dotnet add package Fleans.Worker
+dotnet nuget verify --all \
+  ~/.nuget/packages/fleans.worker/<version>/fleans.worker.<version>.nupkg
+```
+
+`verify --all` exits `0` and reports a valid **repository** signature; it fails (`NU3004`) if the package is unsigned or has been tampered with after nuget.org signed it.
+
+**What this guarantees, and what it does not.** The repository signature gives you **integrity** — the package is exactly what nuget.org accepted and has not been altered in transit or on the feed. It does **not** assert *publisher* identity: it proves nuget.org holds the package, not that the Fleans project specifically signed it. For a pre-1.0 project this is a deliberate trade-off — repository signing delivers the tamper-resistance most consumers need at zero setup, and **publisher (author) signing** is a planned follow-up ([#728](https://github.com/nightBaker/fleans/issues/728)) for when publisher-authenticated signatures become worth the certificate onboarding. Until then, no project-managed signing certificate or per-consumer trust step is required.
+
 ## Limitations
 
 - **SQLite is not supported in production.** SQLite is the default `persistence.provider` for local Aspire-based dev only. The chart accepts the override but you would have to wire a writable per-pod volume yourself, and Orleans clustering across silos against a per-pod SQLite file is not a supported configuration. Use Postgres for any multi-replica deployment.


### PR DESCRIPTION
## Summary

Closes #458. Implements the v6 design (maintainer decision: **rely on nuget.org's automatic repository signing** rather than author-signing, since self-signed certs are rejected by nuget.org at push time). Docs-only — no workflow/engine/test code.

## What changed

- **`website/.../reference/self-hosting.md`** — new **"Package integrity & signatures"** section (single consumer-facing location, per the docs scope-split rule): nuget.org repository-signs every accepted package server-side; consumers verify with `dotnet nuget verify --all`; the repository-vs-publisher-signature distinction and the deliberate pre-1.0 trade-off; pointer to the publisher-signing follow-up #728.
- **`docs/runbooks/release.md`** — post-tag verification gains a **repository-signature smoke** (first real publish only), with an explicit note that the `0.0.0-ci-test` dry-run skips `dotnet nuget push` so it has no signature (`verify` → `NU3004`); states no project-managed signing cert/secret is required.
- **`tests/manual/41-nuget-publish/test-plan.md`** — new step **5b** (post-publish repo-signature verification + docs-accuracy check) and a matching checklist item; deliberately scoped to a real published version, not the dry-run.

## Key decisions

- **Repository signing, not author signing.** nuget.org applies the repository signature server-side at push acceptance — it delivers integrity/tamper-resistance at zero setup. It does **not** assert publisher identity; that's the accepted pre-1.0 trade-off.
- **Verification is release-gated.** Confirming the signature can only be done against a package actually published to nuget.org (the dry-run/local paths have none) — documented as such, not asserted as a CI/PR gate (AC5' = first-real-publish runbook check).
- **Publisher signing preserved as a follow-up.** Filed #728 (SignPath/CA); the cert-source-agnostic author-signing implementation remains on the unmerged `feature/458-nuget-package-signing` branch, ready to resume.

## How to test

Docs render check + the manual-plan step 5b is run post-publish (it cannot run in CI/dry-run by design). See `tests/manual/41-nuget-publish/test-plan.md` step 5b.

## Note for the reviewer
The issue is titled "NuGet package signing" but under this decision we document nuget.org's repository signing rather than adding author signing — consider retitling on merge (e.g. "Document nuget.org repository signing for published packages").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
