### PR TITLE
audit: refresh infra rules 2026-06-15

### DIFF
--- a/docs/audits/audit-infra-rules.md
+++ b/docs/audits/audit-infra-rules.md
@@ -23,10 +23,10 @@
 ## scalability/user-task-full-table-materialize
 - **dimension:** scalability
 - **severity:** minor
-- **signal:** `WorkflowQueryService.GetPendingUserTasks` (the paged overload) in `src/Fleans/Fleans.Persistence/WorkflowQueryService.cs` calls `sievedQuery.ToListAsync()` before the `ApplyUserTaskFilters` call — the assignee/candidateGroup WHERE clause is applied in memory after the full non-completed user-task table is loaded. Look for `ToListAsync()` followed by `ApplyUserTaskFilters(` with no intervening DB-level WHERE on assignee or candidateGroup.
-- **remediation:** Add provider-specific EF Core expressions for `CandidateUsers`/`CandidateGroups` JSON array containment (`@>` / `?` on PostgreSQL via Npgsql's `EF.Functions`) so the filter executes server-side on the Postgres provider. The SQLite path can retain the in-memory fallback. Follow the `RelationalModelCustomizer` subclass pattern in `Fleans.Persistence.Sqlite` and `Fleans.Persistence.PostgreSql`. See issue #415.
+- **signal:** `WorkflowQueryService.GetPendingUserTasks` (paged overload) in `src/Fleans/Fleans.Persistence/WorkflowQueryService.cs` — look for the ABSENCE of a `_userTaskFilter.PushesToSql` guard that separates a server-side Postgres path (CountAsync + paginated ToListAsync) from the SQLite in-memory fallback. If both providers share the same `sievedQuery.ToListAsync()` before `ApplyUserTaskFilters(`, the Postgres pushdown is missing. Note: the SQLite in-memory path (inside the `else` branch when `PushesToSql` is false) is an accepted design limitation and should not re-trigger this rule on its own.
+- **remediation:** Confirmed partially resolved (#415, closed 2026-05-11): Postgres path now uses `_userTaskFilter.PushesToSql` → `CountAsync` + paginated `ToListAsync`; SQLite path retains in-memory fallback by design. Rule fires again only if the `PushesToSql` guard is removed or the Postgres branch regresses.
 - **first seen:** 2026-04-28
-- **last matched:** 2026-04-28
+- **last matched:** 2026-06-15
 
 ## pluggability/role-env-aspire-chart-parity
 - **dimension:** pluggability
@@ -35,3 +35,27 @@
 - **remediation:** Add `WithEnvironment("Fleans__Role", builder.Configuration["FLEANS_ROLE"] ?? "Combined")` when wiring the `fleans-core` project in Aspire. Document the `FLEANS_ROLE` local-dev override in CLAUDE.md under the Core/Worker role split section. See issue #416.
 - **first seen:** 2026-04-28
 - **last matched:** 2026-04-28
+
+## pluggability/persistence-provider-no-chart-fail-guard
+- **dimension:** pluggability
+- **severity:** minor
+- **signal:** `charts/fleans/templates/_helpers.tpl` inside `fleans.commonEnv` — look for the absence of a `{{- fail ... }}` guard on `persistence.provider` immediately before the `Persistence__Provider` env entry. The streaming provider has an equivalent guard (search for `fail (printf "Unsupported streaming.provider"`); persistence should too.
+- **remediation:** Add `{{- $persistenceProvider := lower .Values.persistence.provider }}` + `{{- if not (has $persistenceProvider (list "sqlite" "postgres")) }}` + `{{- fail ... }}` + `{{- end }}` before the `Persistence__Provider` env entry, mirroring lines 109-112 of the streaming block. See issue #675.
+- **first seen:** 2026-06-15
+- **last matched:** 2026-06-15
+
+## pluggability/reminders-provider-no-chart-input
+- **dimension:** pluggability
+- **severity:** important
+- **signal:** `charts/fleans/templates/_helpers.tpl` `fleans.commonEnv` — look for the absence of a `Fleans__Reminders__Provider` env entry and a corresponding `values.yaml` key `reminders.provider`. The silo reads `Fleans:Reminders:Provider` via `FleansRemindersExtensions.ResolveRemindersConfiguration` (`src/Fleans/Fleans.ServiceDefaults/Reminders/FleansRemindersExtensions.cs`); if no chart input exists, operators cannot switch to Postgres reminders without `extraEnv`.
+- **remediation:** Add `reminders.provider: Redis` to `values.yaml`; add a `fail` guard and `Fleans__Reminders__Provider` env entry to `_helpers.tpl` `fleans.commonEnv`, matching the streaming and persistence provider patterns. See issue #676.
+- **first seen:** 2026-06-15
+- **last matched:** 2026-06-15
+
+## reliability/logger-message-convention-violation
+- **dimension:** reliability
+- **severity:** minor
+- **signal:** Search `src/Fleans/Fleans.Streaming.Kafka/` and `src/Fleans/Fleans.Application/Effects/EffectDispatcher.cs` for `_logger\.Log(Error|Warning|Information|Debug)` calls. Any match that is NOT inside a `[LoggerMessage]`-generated partial method violates the convention. Currently: `KafkaQueueAdapter.cs:85`, `KafkaQueueAdapterFactory.cs:77,99,108`, `KafkaQueueAdapterReceiver.cs:44,70,88,108,125`, `EffectDispatcher.cs:40`.
+- **remediation:** Make each class `partial`; replace `_logger.Log*()` calls with `[LoggerMessage]`-attributed `private partial void Log...()` methods; allocate EventId ranges in `docs/conventions/observability-eventids.md`. Canonical pattern: `src/Fleans/Fleans.Application/Grains/WorkflowInstance.Logging.cs`. See issue #714.
+- **first seen:** 2026-06-15
+- **last matched:** 2026-06-15


### PR DESCRIPTION
Generated by `audit-infra` on 2026-06-15.

## Summary

- rules refreshed: 1 (signal updated on `scalability/user-task-full-table-materialize`)
- rules added: 3
- issues updated (marker retrofitted): #675, #676, #714
- issues opened: 0 (existing un-marked issues adopted rather than duplicated)

## Rules pass — what changed vs. last run

| Rule | Status |
|---|---|
| `pluggability/persistence-unknown-provider-silent-fallback` | ✅ Fixed — explicit `else if` + throw added; issue #413 closed |
| `scalability/event-store-unbounded-read` | ✅ Fixed — `Take(limit)` guard added; issue #414 closed |
| `scalability/user-task-full-table-materialize` | ⚠️ Partially resolved — Postgres path now pushes filter to SQL; SQLite in-memory fallback is accepted design. Signal updated to reflect. Issue #415 closed. |
| `pluggability/role-env-aspire-chart-parity` | ✅ Fixed — `Fleans__Role` now stamped via `WithEnvironment` in Aspire; issue #416 closed |

## New rules added (rubric pass)

**`pluggability/persistence-provider-no-chart-fail-guard`** (minor, issue #675)
`charts/fleans/templates/_helpers.tpl` passes `Persistence__Provider` through without a `{{- fail ... }}` guard, unlike `streaming.provider` which has one. An operator typo gets a runtime startup `ArgumentException` instead of a `helm template` error.

**`pluggability/reminders-provider-no-chart-input`** (important, issue #676)
`Fleans:Reminders:Provider` is a two-implementation pluggable seam (Redis/Postgres) but has no `values.yaml` key, no `commonEnv` stamp, and no chart-level validation guard. CLAUDE.md requires every silo-read config flag to be settable via both Aspire env stamping and `values.yaml`.

**`reliability/logger-message-convention-violation`** (minor, issue #714)
`KafkaQueueAdapter`, `KafkaQueueAdapterFactory`, `KafkaQueueAdapterReceiver`, and `EffectDispatcher` use `_logger.Log*()` extension calls instead of `[LoggerMessage]` source generators, violating CLAUDE.md's logging convention and breaking EventId discipline.

## Note on marker adoption

Issues #675, #676, and #714 were opened by a previous audit run without the `<!-- audit-id: ... -->` marker. Rather than creating duplicate issues, this run retrofitted the markers into the existing issue bodies so future runs can find and refresh them idempotently.

https://claude.ai/code/session_01Cdihk7q5WT22562rX2tJoc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cdihk7q5WT22562rX2tJoc)_