### PR TITLE
feat(kafka): SecurityProtocol + SASL config (PLAIN/SCRAM/OAuthBearer) (#680)

### DIFF
--- a/docs/conventions/streaming.md
+++ b/docs/conventions/streaming.md
@@ -60,3 +60,23 @@ Each plugin's grain class only sees its own traffic (eliminates the N-plugins ×
 `AddCustomTaskPlugin<T>(taskType, …)` validates at silo startup that (a) no other plugin already claims `taskType` and (b) `typeof(T)` declares a matching `[ImplicitStreamSubscription]`. Both throw `InvalidOperationException` with explicit messages.
 
 The `TaskType` mismatch branch in `OnNextAsync` is unreachable under correct routing and now logs `LogTaskTypeMismatch` (EventId 4037) as a warning instead of dropping silently.
+
+## Kafka SASL / TLS
+
+Kafka security is configured via five properties on `KafkaStreamingOptions`:
+
+| Property | Type | Default | Notes |
+|---|---|---|---|
+| `SecurityProtocol` | `KafkaSecurityProtocol` | `Plaintext` | Backward-compatible default; existing deployments are unaffected |
+| `SaslMechanism` | `KafkaSaslMechanism?` | `null` | Required for `SaslPlaintext` / `SaslSsl` protocols |
+| `SaslUsername` | `string?` | `null` | Required for PLAIN / SCRAM-SHA-256 / SCRAM-SHA-512 |
+| `SaslPassword` | `string?` | `null` | Required for PLAIN / SCRAM-SHA-256 / SCRAM-SHA-512 |
+| `OAuthBearerTokenProvider` | `Action<IClient, string>?` | `null` | Required for OAuthBearer; wired via `SetOAuthBearerTokenRefreshHandler` on each client builder |
+
+**Fail-fast validation.** `KafkaClientConfigExtensions.ApplySecurity` is called on all three client builders (producer, consumer, admin) and throws `InvalidOperationException` at silo startup for any misconfigured combination — missing mechanism, empty credentials, or missing OAuthBearer provider. This surfaces configuration errors before the first broker connection.
+
+**Enum ownership.** `KafkaSecurityProtocol` and `KafkaSaslMechanism` are Fleans-owned enums (1:1 switch to Confluent types) so Confluent types stay out of the public API surface. Unknown enum values throw at startup.
+
+**OAuthBearer handler.** The `OAuthBearerTokenProvider` callback matches Confluent.Kafka's `SetOAuthBearerTokenRefreshHandler(Action<IClient, string>)` signature directly — no adapter needed. The callback is registered after `ApplySecurity` on each builder.
+
+**mTLS (client-cert auth) is deferred to #681.** Plaintext, SSL (server-side TLS), and SASL (all four mechanisms) are covered by this feature. Client-certificate mutual TLS is a separate follow-up.

--- a/src/Fleans/Fleans.Infrastructure.Tests/Fleans.Infrastructure.Tests.csproj
+++ b/src/Fleans/Fleans.Infrastructure.Tests/Fleans.Infrastructure.Tests.csproj
@@ -15,6 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Confluent.Kafka" Version="2.6.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Microsoft.Orleans.Serialization.NewtonsoftJson" Version="10.0.1" />
     <PackageReference Include="Microsoft.Orleans.TestingHost" Version="10.0.1" />
@@ -27,6 +28,7 @@
     <ProjectReference Include="..\Fleans.Infrastructure\Fleans.Infrastructure.csproj" />
     <ProjectReference Include="..\Fleans.Persistence\Fleans.Persistence.csproj" />
     <ProjectReference Include="..\Fleans.Persistence.Sqlite\Fleans.Persistence.Sqlite.csproj" />
+    <ProjectReference Include="..\Fleans.Streaming.Kafka\Fleans.Streaming.Kafka.csproj" />
     <ProjectReference Include="..\Fleans.Worker\Fleans.Worker.csproj" />
   </ItemGroup>
 

--- a/src/Fleans/Fleans.Infrastructure.Tests/KafkaClientConfigExtensionsTests.cs
+++ b/src/Fleans/Fleans.Infrastructure.Tests/KafkaClientConfigExtensionsTests.cs
@@ -1,7 +1,7 @@
 using Confluent.Kafka;
 using Fleans.Streaming.Kafka;
 
-namespace Fleans.Streaming.Kafka.Tests;
+namespace Fleans.Infrastructure.Tests;
 
 /// <summary>
 /// Verifies <c>KafkaClientConfigExtensions.ApplySecurity</c> across the 11-case design matrix
@@ -117,8 +117,8 @@ public class KafkaClientConfigExtensionsTests
         var config = new ProducerConfig();
         var opts = new KafkaStreamingOptions
         {
-            SecurityProtocol      = KafkaSecurityProtocol.SaslSsl,
-            SaslMechanism         = KafkaSaslMechanism.OAuthBearer,
+            SecurityProtocol         = KafkaSecurityProtocol.SaslSsl,
+            SaslMechanism            = KafkaSaslMechanism.OAuthBearer,
             OAuthBearerTokenProvider = (_, _) => { },
         };
 

--- a/src/Fleans/Fleans.Streaming.Kafka.Tests/KafkaClientConfigExtensionsTests.cs
+++ b/src/Fleans/Fleans.Streaming.Kafka.Tests/KafkaClientConfigExtensionsTests.cs
@@ -1,0 +1,321 @@
+using Confluent.Kafka;
+using Fleans.Streaming.Kafka;
+
+namespace Fleans.Streaming.Kafka.Tests;
+
+/// <summary>
+/// Verifies <c>KafkaClientConfigExtensions.ApplySecurity</c> across the 11-case design matrix
+/// plus empty-string variants for credential validation (review minor finding).
+/// Tests target the internal helper directly — no host required.
+/// </summary>
+[TestClass]
+public class KafkaClientConfigExtensionsTests
+{
+    // --- Case 1: Plaintext ---
+
+    [TestMethod]
+    public void Plaintext_sets_protocol_and_no_sasl_props()
+    {
+        var config = new ProducerConfig();
+        var opts = new KafkaStreamingOptions { SecurityProtocol = KafkaSecurityProtocol.Plaintext };
+
+        KafkaClientConfigExtensions.ApplySecurity(config, opts);
+
+        Assert.AreEqual(SecurityProtocol.Plaintext, config.SecurityProtocol);
+        Assert.IsNull(config.SaslMechanism);
+        Assert.IsNull(config.SaslUsername);
+        Assert.IsNull(config.SaslPassword);
+    }
+
+    // --- Case 2: SSL ---
+
+    [TestMethod]
+    public void Ssl_sets_protocol_and_no_sasl_props()
+    {
+        var config = new ProducerConfig();
+        var opts = new KafkaStreamingOptions { SecurityProtocol = KafkaSecurityProtocol.Ssl };
+
+        KafkaClientConfigExtensions.ApplySecurity(config, opts);
+
+        Assert.AreEqual(SecurityProtocol.Ssl, config.SecurityProtocol);
+        Assert.IsNull(config.SaslMechanism);
+        Assert.IsNull(config.SaslUsername);
+        Assert.IsNull(config.SaslPassword);
+    }
+
+    // --- Case 3: SaslPlaintext + Plain + valid creds ---
+
+    [TestMethod]
+    public void SaslPlaintext_Plain_sets_protocol_mechanism_and_credentials()
+    {
+        var config = new ProducerConfig();
+        var opts = new KafkaStreamingOptions
+        {
+            SecurityProtocol = KafkaSecurityProtocol.SaslPlaintext,
+            SaslMechanism    = KafkaSaslMechanism.Plain,
+            SaslUsername     = "user",
+            SaslPassword     = "pass",
+        };
+
+        KafkaClientConfigExtensions.ApplySecurity(config, opts);
+
+        Assert.AreEqual(SecurityProtocol.SaslPlaintext, config.SecurityProtocol);
+        Assert.AreEqual(SaslMechanism.Plain, config.SaslMechanism);
+        Assert.AreEqual("user", config.SaslUsername);
+        Assert.AreEqual("pass", config.SaslPassword);
+    }
+
+    // --- Case 4: SaslPlaintext + ScramSha256 + valid creds ---
+
+    [TestMethod]
+    public void SaslPlaintext_ScramSha256_sets_protocol_mechanism_and_credentials()
+    {
+        var config = new ProducerConfig();
+        var opts = new KafkaStreamingOptions
+        {
+            SecurityProtocol = KafkaSecurityProtocol.SaslPlaintext,
+            SaslMechanism    = KafkaSaslMechanism.ScramSha256,
+            SaslUsername     = "u",
+            SaslPassword     = "p",
+        };
+
+        KafkaClientConfigExtensions.ApplySecurity(config, opts);
+
+        Assert.AreEqual(SecurityProtocol.SaslPlaintext, config.SecurityProtocol);
+        Assert.AreEqual(SaslMechanism.ScramSha256, config.SaslMechanism);
+        Assert.AreEqual("u", config.SaslUsername);
+        Assert.AreEqual("p", config.SaslPassword);
+    }
+
+    // --- Case 5: SaslSsl + ScramSha512 + valid creds ---
+
+    [TestMethod]
+    public void SaslSsl_ScramSha512_sets_protocol_mechanism_and_credentials()
+    {
+        var config = new ProducerConfig();
+        var opts = new KafkaStreamingOptions
+        {
+            SecurityProtocol = KafkaSecurityProtocol.SaslSsl,
+            SaslMechanism    = KafkaSaslMechanism.ScramSha512,
+            SaslUsername     = "u",
+            SaslPassword     = "p",
+        };
+
+        KafkaClientConfigExtensions.ApplySecurity(config, opts);
+
+        Assert.AreEqual(SecurityProtocol.SaslSsl, config.SecurityProtocol);
+        Assert.AreEqual(SaslMechanism.ScramSha512, config.SaslMechanism);
+        Assert.AreEqual("u", config.SaslUsername);
+        Assert.AreEqual("p", config.SaslPassword);
+    }
+
+    // --- Case 6: SaslSsl + OAuthBearer + non-null provider ---
+
+    [TestMethod]
+    public void SaslSsl_OAuthBearer_sets_protocol_and_mechanism_without_credentials()
+    {
+        var config = new ProducerConfig();
+        var opts = new KafkaStreamingOptions
+        {
+            SecurityProtocol      = KafkaSecurityProtocol.SaslSsl,
+            SaslMechanism         = KafkaSaslMechanism.OAuthBearer,
+            OAuthBearerTokenProvider = (_, _) => { },
+        };
+
+        KafkaClientConfigExtensions.ApplySecurity(config, opts);
+
+        Assert.AreEqual(SecurityProtocol.SaslSsl, config.SecurityProtocol);
+        Assert.AreEqual(SaslMechanism.OAuthBearer, config.SaslMechanism);
+        Assert.IsNull(config.SaslUsername);
+        Assert.IsNull(config.SaslPassword);
+    }
+
+    // --- Case 6b: SaslPlaintext + OAuthBearer (structural completeness) ---
+
+    [TestMethod]
+    public void SaslPlaintext_OAuthBearer_sets_protocol_and_mechanism_without_credentials()
+    {
+        var config = new ProducerConfig();
+        var opts = new KafkaStreamingOptions
+        {
+            SecurityProtocol         = KafkaSecurityProtocol.SaslPlaintext,
+            SaslMechanism            = KafkaSaslMechanism.OAuthBearer,
+            OAuthBearerTokenProvider = (_, _) => { },
+        };
+
+        KafkaClientConfigExtensions.ApplySecurity(config, opts);
+
+        Assert.AreEqual(SecurityProtocol.SaslPlaintext, config.SecurityProtocol);
+        Assert.AreEqual(SaslMechanism.OAuthBearer, config.SaslMechanism);
+        Assert.IsNull(config.SaslUsername);
+        Assert.IsNull(config.SaslPassword);
+    }
+
+    // --- Case 7: SaslPlaintext + null SaslMechanism → throws ---
+
+    [TestMethod]
+    public void SaslPlaintext_null_mechanism_throws()
+    {
+        var config = new ProducerConfig();
+        var opts = new KafkaStreamingOptions
+        {
+            SecurityProtocol = KafkaSecurityProtocol.SaslPlaintext,
+            SaslMechanism    = null,
+        };
+
+        Assert.ThrowsExactly<InvalidOperationException>(
+            () => KafkaClientConfigExtensions.ApplySecurity(config, opts));
+    }
+
+    // --- Case 8: Unknown enum value → throws ---
+
+    [TestMethod]
+    public void Unknown_SecurityProtocol_throws()
+    {
+        var config = new ProducerConfig();
+        var opts = new KafkaStreamingOptions
+        {
+            SecurityProtocol = (KafkaSecurityProtocol)99,
+        };
+
+        Assert.ThrowsExactly<InvalidOperationException>(
+            () => KafkaClientConfigExtensions.ApplySecurity(config, opts));
+    }
+
+    // --- Case 9: null SaslUsername → throws ---
+
+    [TestMethod]
+    public void SaslPlaintext_Plain_null_username_throws()
+    {
+        var config = new ProducerConfig();
+        var opts = new KafkaStreamingOptions
+        {
+            SecurityProtocol = KafkaSecurityProtocol.SaslPlaintext,
+            SaslMechanism    = KafkaSaslMechanism.Plain,
+            SaslUsername     = null,
+            SaslPassword     = "pass",
+        };
+
+        Assert.ThrowsExactly<InvalidOperationException>(
+            () => KafkaClientConfigExtensions.ApplySecurity(config, opts));
+    }
+
+    // --- Case 9b: empty SaslUsername → throws ---
+
+    [TestMethod]
+    public void SaslPlaintext_Plain_empty_username_throws()
+    {
+        var config = new ProducerConfig();
+        var opts = new KafkaStreamingOptions
+        {
+            SecurityProtocol = KafkaSecurityProtocol.SaslPlaintext,
+            SaslMechanism    = KafkaSaslMechanism.Plain,
+            SaslUsername     = "",
+            SaslPassword     = "pass",
+        };
+
+        Assert.ThrowsExactly<InvalidOperationException>(
+            () => KafkaClientConfigExtensions.ApplySecurity(config, opts));
+    }
+
+    // --- Case 10: null SaslPassword → throws ---
+
+    [TestMethod]
+    public void SaslPlaintext_Plain_null_password_throws()
+    {
+        var config = new ProducerConfig();
+        var opts = new KafkaStreamingOptions
+        {
+            SecurityProtocol = KafkaSecurityProtocol.SaslPlaintext,
+            SaslMechanism    = KafkaSaslMechanism.Plain,
+            SaslUsername     = "user",
+            SaslPassword     = null,
+        };
+
+        Assert.ThrowsExactly<InvalidOperationException>(
+            () => KafkaClientConfigExtensions.ApplySecurity(config, opts));
+    }
+
+    // --- Case 10b: empty SaslPassword → throws ---
+
+    [TestMethod]
+    public void SaslPlaintext_Plain_empty_password_throws()
+    {
+        var config = new ProducerConfig();
+        var opts = new KafkaStreamingOptions
+        {
+            SecurityProtocol = KafkaSecurityProtocol.SaslPlaintext,
+            SaslMechanism    = KafkaSaslMechanism.Plain,
+            SaslUsername     = "user",
+            SaslPassword     = "",
+        };
+
+        Assert.ThrowsExactly<InvalidOperationException>(
+            () => KafkaClientConfigExtensions.ApplySecurity(config, opts));
+    }
+
+    // --- Case 11: SaslSsl + OAuthBearer + null provider → throws ---
+
+    [TestMethod]
+    public void SaslSsl_OAuthBearer_null_provider_throws()
+    {
+        var config = new ProducerConfig();
+        var opts = new KafkaStreamingOptions
+        {
+            SecurityProtocol         = KafkaSecurityProtocol.SaslSsl,
+            SaslMechanism            = KafkaSaslMechanism.OAuthBearer,
+            OAuthBearerTokenProvider = null,
+        };
+
+        Assert.ThrowsExactly<InvalidOperationException>(
+            () => KafkaClientConfigExtensions.ApplySecurity(config, opts));
+    }
+
+    // --- Regression guard: existing options defaults must still work ---
+
+    [TestMethod]
+    public void Default_options_plaintext_no_sasl_props()
+    {
+        var config = new ProducerConfig();
+        var opts = new KafkaStreamingOptions(); // SecurityProtocol defaults to Plaintext
+
+        KafkaClientConfigExtensions.ApplySecurity(config, opts);
+
+        Assert.AreEqual(SecurityProtocol.Plaintext, config.SecurityProtocol);
+        Assert.IsNull(config.SaslMechanism);
+    }
+
+    // --- Works on ConsumerConfig and AdminClientConfig (ClientConfig subclasses) ---
+
+    [TestMethod]
+    public void ApplySecurity_works_on_ConsumerConfig()
+    {
+        var config = new ConsumerConfig();
+        var opts = new KafkaStreamingOptions
+        {
+            SecurityProtocol = KafkaSecurityProtocol.SaslPlaintext,
+            SaslMechanism    = KafkaSaslMechanism.Plain,
+            SaslUsername     = "u",
+            SaslPassword     = "p",
+        };
+
+        KafkaClientConfigExtensions.ApplySecurity(config, opts);
+
+        Assert.AreEqual(SecurityProtocol.SaslPlaintext, config.SecurityProtocol);
+        Assert.AreEqual(SaslMechanism.Plain, config.SaslMechanism);
+    }
+
+    [TestMethod]
+    public void ApplySecurity_works_on_AdminClientConfig()
+    {
+        var config = new AdminClientConfig();
+        var opts = new KafkaStreamingOptions
+        {
+            SecurityProtocol = KafkaSecurityProtocol.Ssl,
+        };
+
+        KafkaClientConfigExtensions.ApplySecurity(config, opts);
+
+        Assert.AreEqual(SecurityProtocol.Ssl, config.SecurityProtocol);
+    }
+}

--- a/src/Fleans/Fleans.Streaming.Kafka/Fleans.Streaming.Kafka.csproj
+++ b/src/Fleans/Fleans.Streaming.Kafka/Fleans.Streaming.Kafka.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Fleans.Application.Tests" />
+    <InternalsVisibleTo Include="Fleans.Infrastructure.Tests" />
     <InternalsVisibleTo Include="Fleans.Streaming.Kafka.Tests" />
   </ItemGroup>
 

--- a/src/Fleans/Fleans.Streaming.Kafka/Fleans.Streaming.Kafka.csproj
+++ b/src/Fleans/Fleans.Streaming.Kafka/Fleans.Streaming.Kafka.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Fleans.Application.Tests" />
+    <InternalsVisibleTo Include="Fleans.Streaming.Kafka.Tests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Fleans/Fleans.Streaming.Kafka/KafkaClientConfigExtensions.cs
+++ b/src/Fleans/Fleans.Streaming.Kafka/KafkaClientConfigExtensions.cs
@@ -1,0 +1,68 @@
+using Confluent.Kafka;
+
+namespace Fleans.Streaming.Kafka;
+
+/// <summary>
+/// Shared security-config helper applied to all three Kafka client builders
+/// (producer, consumer, admin) from the same validated source of truth.
+/// </summary>
+internal static class KafkaClientConfigExtensions
+{
+    /// <summary>
+    /// Applies the security-protocol and SASL settings from <paramref name="opts"/>
+    /// onto <paramref name="config"/>. Throws <see cref="InvalidOperationException"/>
+    /// for any misconfigured combination so the silo fails-fast at startup rather than
+    /// at first broker connection.
+    /// </summary>
+    internal static void ApplySecurity(ClientConfig config, KafkaStreamingOptions opts)
+    {
+        config.SecurityProtocol = opts.SecurityProtocol switch
+        {
+            KafkaSecurityProtocol.Plaintext     => SecurityProtocol.Plaintext,
+            KafkaSecurityProtocol.Ssl           => SecurityProtocol.Ssl,
+            KafkaSecurityProtocol.SaslPlaintext => SecurityProtocol.SaslPlaintext,
+            KafkaSecurityProtocol.SaslSsl       => SecurityProtocol.SaslSsl,
+            _ => throw new InvalidOperationException(
+                     $"Unsupported SecurityProtocol: {opts.SecurityProtocol}"),
+        };
+
+        if (opts.SecurityProtocol is not (KafkaSecurityProtocol.SaslPlaintext or KafkaSecurityProtocol.SaslSsl))
+            return;
+
+        if (opts.SaslMechanism is null)
+            throw new InvalidOperationException(
+                "SaslMechanism is required when SecurityProtocol is SASL_*");
+
+        config.SaslMechanism = opts.SaslMechanism.Value switch
+        {
+            KafkaSaslMechanism.Plain       => SaslMechanism.Plain,
+            KafkaSaslMechanism.ScramSha256 => SaslMechanism.ScramSha256,
+            KafkaSaslMechanism.ScramSha512 => SaslMechanism.ScramSha512,
+            KafkaSaslMechanism.OAuthBearer => SaslMechanism.OAuthBearer,
+            _ => throw new InvalidOperationException(
+                     $"Unsupported SaslMechanism: {opts.SaslMechanism}"),
+        };
+
+        if (opts.SaslMechanism.Value is KafkaSaslMechanism.Plain
+                                     or KafkaSaslMechanism.ScramSha256
+                                     or KafkaSaslMechanism.ScramSha512)
+        {
+            if (string.IsNullOrEmpty(opts.SaslUsername))
+                throw new InvalidOperationException(
+                    $"SaslUsername is required when SaslMechanism is {opts.SaslMechanism}");
+            if (string.IsNullOrEmpty(opts.SaslPassword))
+                throw new InvalidOperationException(
+                    $"SaslPassword is required when SaslMechanism is {opts.SaslMechanism}");
+            config.SaslUsername = opts.SaslUsername;
+            config.SaslPassword = opts.SaslPassword;
+        }
+
+        if (opts.SaslMechanism.Value is KafkaSaslMechanism.OAuthBearer)
+        {
+            if (opts.OAuthBearerTokenProvider is null)
+                throw new InvalidOperationException(
+                    "OAuthBearerTokenProvider is required when SaslMechanism is OAuthBearer");
+            // Handler is wired on the builder at each call site after ApplySecurity returns.
+        }
+    }
+}

--- a/src/Fleans/Fleans.Streaming.Kafka/KafkaQueueAdapter.cs
+++ b/src/Fleans/Fleans.Streaming.Kafka/KafkaQueueAdapter.cs
@@ -42,7 +42,11 @@ internal sealed class KafkaQueueAdapter : IQueueAdapter, IDisposable
             EnableIdempotence = false,
             Acks = Acks.All,
         };
-        _producer = new ProducerBuilder<byte[], byte[]>(producerConfig).Build();
+        KafkaClientConfigExtensions.ApplySecurity(producerConfig, _options);
+        var producerBuilder = new ProducerBuilder<byte[], byte[]>(producerConfig);
+        if (_options.OAuthBearerTokenProvider is not null)
+            producerBuilder.SetOAuthBearerTokenRefreshHandler(_options.OAuthBearerTokenProvider);
+        _producer = producerBuilder.Build();
     }
 
     public async Task QueueMessageBatchAsync<T>(

--- a/src/Fleans/Fleans.Streaming.Kafka/KafkaQueueAdapterFactory.cs
+++ b/src/Fleans/Fleans.Streaming.Kafka/KafkaQueueAdapterFactory.cs
@@ -64,7 +64,12 @@ public sealed class KafkaQueueAdapterFactory : IQueueAdapterFactory
         var expected = KafkaTopicNaming.AllExpectedTopics(_options).ToArray();
         if (expected.Length == 0) return;
 
-        using var admin = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = _options.Brokers }).Build();
+        var adminConfig = new AdminClientConfig { BootstrapServers = _options.Brokers };
+        KafkaClientConfigExtensions.ApplySecurity(adminConfig, _options);
+        var adminBuilder = new AdminClientBuilder(adminConfig);
+        if (_options.OAuthBearerTokenProvider is not null)
+            adminBuilder.SetOAuthBearerTokenRefreshHandler(_options.OAuthBearerTokenProvider);
+        using var admin = adminBuilder.Build();
 
         HashSet<string> existing;
         try

--- a/src/Fleans/Fleans.Streaming.Kafka/KafkaQueueAdapterReceiver.cs
+++ b/src/Fleans/Fleans.Streaming.Kafka/KafkaQueueAdapterReceiver.cs
@@ -40,9 +40,12 @@ internal sealed class KafkaQueueAdapterReceiver : IQueueAdapterReceiver
             EnableAutoCommit = false,
             EnablePartitionEof = false,
         };
-        _consumer = new ConsumerBuilder<byte[], byte[]>(config)
-            .SetErrorHandler((_, e) => _logger.LogWarning("Kafka consumer error on topic {Topic}: {Reason}", _topic, e.Reason))
-            .Build();
+        KafkaClientConfigExtensions.ApplySecurity(config, _options);
+        var consumerBuilder = new ConsumerBuilder<byte[], byte[]>(config)
+            .SetErrorHandler((_, e) => _logger.LogWarning("Kafka consumer error on topic {Topic}: {Reason}", _topic, e.Reason));
+        if (_options.OAuthBearerTokenProvider is not null)
+            consumerBuilder.SetOAuthBearerTokenRefreshHandler(_options.OAuthBearerTokenProvider);
+        _consumer = consumerBuilder.Build();
         _consumer.Subscribe(_topic);
         return Task.CompletedTask;
     }

--- a/src/Fleans/Fleans.Streaming.Kafka/KafkaStreamingOptions.cs
+++ b/src/Fleans/Fleans.Streaming.Kafka/KafkaStreamingOptions.cs
@@ -1,7 +1,32 @@
+using Confluent.Kafka;
+
 namespace Fleans.Streaming.Kafka;
 
 /// <summary>
-/// v1 Kafka streaming options. Plaintext brokers only — production SASL/TLS lands in a follow-up.
+/// Kafka security protocol, mirroring Confluent.Kafka's enum but kept Fleans-owned
+/// so Confluent types stay out of the public API surface.
+/// </summary>
+public enum KafkaSecurityProtocol
+{
+    Plaintext,
+    Ssl,
+    SaslPlaintext,
+    SaslSsl,
+}
+
+/// <summary>
+/// SASL mechanism, mirroring Confluent.Kafka's enum.
+/// </summary>
+public enum KafkaSaslMechanism
+{
+    Plain,
+    ScramSha256,
+    ScramSha512,
+    OAuthBearer,
+}
+
+/// <summary>
+/// Kafka streaming options.
 /// </summary>
 public class KafkaStreamingOptions
 {
@@ -33,4 +58,33 @@ public class KafkaStreamingOptions
     public TimeSpan PollTimeout { get; set; } = TimeSpan.FromMilliseconds(50);
 
     public TimeSpan AdminTimeout { get; set; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Kafka security protocol. Defaults to <see cref="KafkaSecurityProtocol.Plaintext"/>
+    /// for backward compatibility with existing plaintext deployments.
+    /// </summary>
+    public KafkaSecurityProtocol SecurityProtocol { get; set; } = KafkaSecurityProtocol.Plaintext;
+
+    /// <summary>
+    /// SASL mechanism. Required when <see cref="SecurityProtocol"/> is
+    /// <see cref="KafkaSecurityProtocol.SaslPlaintext"/> or <see cref="KafkaSecurityProtocol.SaslSsl"/>.
+    /// </summary>
+    public KafkaSaslMechanism? SaslMechanism { get; set; }
+
+    /// <summary>
+    /// SASL username. Required for PLAIN, SCRAM-SHA-256, and SCRAM-SHA-512 mechanisms.
+    /// </summary>
+    public string? SaslUsername { get; set; }
+
+    /// <summary>
+    /// SASL password. Required for PLAIN, SCRAM-SHA-256, and SCRAM-SHA-512 mechanisms.
+    /// </summary>
+    public string? SaslPassword { get; set; }
+
+    /// <summary>
+    /// OAuthBearer token provider callback. Required when <see cref="SaslMechanism"/> is
+    /// <see cref="KafkaSaslMechanism.OAuthBearer"/>. The callback is registered via
+    /// <c>SetOAuthBearerTokenRefreshHandler</c> on each client builder.
+    /// </summary>
+    public Action<IClient, string>? OAuthBearerTokenProvider { get; set; }
 }

--- a/tests/manual/66-kafka-sasl/test-plan.md
+++ b/tests/manual/66-kafka-sasl/test-plan.md
@@ -1,0 +1,111 @@
+# Manual Test Plan: Kafka SASL / SecurityProtocol config (#680)
+
+**STATUS: NEEDS-RERUN**
+
+## Prerequisites
+
+- Docker with a Kafka image that supports SASL (e.g. `confluentinc/cp-kafka:7.x` or `bitnami/kafka:3.x`)
+- Local Fleans stack started via `dotnet run --project Fleans.Aspire` with `FLEANS_STREAMING_PROVIDER=Kafka`
+
+---
+
+## Test 1 — Plaintext (baseline, backward-compat)
+
+**Setup:** Start Kafka without auth. Set `Fleans:Streaming:Kafka:Brokers=localhost:9092`.
+
+**Steps:**
+1. Start `dotnet run --project Fleans.Aspire` with `FLEANS_STREAMING_PROVIDER=Kafka`.
+2. Run a hello-world workflow that passes through a Script Task (uses Kafka stream internally).
+3. Verify the workflow completes.
+
+**Pass:** Workflow completes; no Kafka errors in logs; no new `SecurityProtocol` setting needed.
+
+---
+
+## Test 2 — SASL/PLAIN
+
+**Setup:** Start Kafka with SASL_PLAINTEXT + PLAIN mechanism.
+
+Example Docker Compose snippet:
+```yaml
+environment:
+  KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: SASL_PLAINTEXT:SASL_PLAINTEXT
+  KAFKA_SASL_ENABLED_MECHANISMS: PLAIN
+  KAFKA_SASL_JAAS_CONFIG: 'org.apache.kafka.common.security.plain.PlainLoginModule required username="fleans" password="secret" user_fleans="secret";'
+```
+
+**Fleans config:**
+```json
+{
+  "Fleans": {
+    "Streaming": {
+      "Kafka": {
+        "SecurityProtocol": "SaslPlaintext",
+        "SaslMechanism": "Plain",
+        "SaslUsername": "fleans",
+        "SaslPassword": "secret"
+      }
+    }
+  }
+}
+```
+
+**Steps:**
+1. Start Fleans with the above config.
+2. Run a hello-world workflow.
+3. Verify the workflow completes.
+
+**Pass:** Workflow completes; silo log does not contain auth errors.
+
+---
+
+## Test 3 — SASL/SCRAM-SHA-512
+
+**Setup:** Start Kafka with SASL_SSL + SCRAM-SHA-512.
+
+**Fleans config:**
+```json
+{
+  "Fleans": {
+    "Streaming": {
+      "Kafka": {
+        "SecurityProtocol": "SaslSsl",
+        "SaslMechanism": "ScramSha512",
+        "SaslUsername": "fleans",
+        "SaslPassword": "secret"
+      }
+    }
+  }
+}
+```
+
+**Steps:**
+1. Start Fleans with the above config.
+2. Run a hello-world workflow.
+3. Verify the workflow completes.
+
+**Pass:** Workflow completes; no auth errors.
+
+---
+
+## Test 4 — Misconfiguration is rejected at startup
+
+**Setup:** Set `SecurityProtocol=SaslPlaintext` but omit `SaslMechanism`.
+
+**Steps:**
+1. Start Fleans. Expect the silo to fail fast with an `InvalidOperationException` mentioning "SaslMechanism is required".
+2. Verify the process does not reach an unhealthy running state.
+
+**Pass:** Silo startup fails with a clear `InvalidOperationException`. No silent misconfiguration.
+
+---
+
+## Test 5 — Default plaintext is unaffected by the new properties
+
+**Setup:** No security properties set (just `Brokers`). Same as before #680.
+
+**Steps:**
+1. Start Fleans. No new config needed.
+2. Verify startup succeeds and workflow runs normally.
+
+**Pass:** Identical behavior to pre-#680 for plaintext Kafka deployments.

--- a/tests/manual/README.md
+++ b/tests/manual/README.md
@@ -112,6 +112,8 @@ Each numbered entry below is one regression "step". For each one, follow the lin
 
 65. **Persistent reminders** — `65-persistent-reminders/test-plan.md` (`timer-restart.bpmn`). Verifies #650: BPMN `TimerIntermediateCatchEvent(PT5M)` survives silo restart. Step A: single-silo restart against Compose-bundle. Step B: multi-silo cluster Core-only restart while Worker stays up. Plus a fail-fast regression: with `orleans-redis` unset, silo refuses to start with `InvalidOperationException` from `AddFleansReminders`.
 
+66. **Kafka SASL / SecurityProtocol config** — `66-kafka-sasl/test-plan.md`. Verifies #680: Kafka connections work under Plaintext, SASL_PLAINTEXT+PLAIN, and SASL_SSL+SCRAM-SHA-512. Also verifies fail-fast startup rejection when `SaslMechanism` is omitted for a SASL protocol. Default plaintext path is unaffected (backward-compat).
+
 ## Website regression suite
 
 Website-specific manual tests live under `website/`. These run in a local dev server, not against the .NET stack.


### PR DESCRIPTION
## Summary

Closes #680.

Adds Kafka SASL / security-protocol configuration to the Fleans Kafka streaming provider. Existing plaintext deployments are unaffected — `SecurityProtocol` defaults to `Plaintext`.

### What's implemented

- **`KafkaSecurityProtocol` enum** — Fleans-owned (Plaintext, Ssl, SaslPlaintext, SaslSsl); keeps Confluent types off the public surface
- **`KafkaSaslMechanism` enum** — Fleans-owned (Plain, ScramSha256, ScramSha512, OAuthBearer)
- **5 new properties** on `KafkaStreamingOptions`: `SecurityProtocol`, `SaslMechanism`, `SaslUsername`, `SaslPassword`, `OAuthBearerTokenProvider`
- **`KafkaClientConfigExtensions.ApplySecurity`** — shared internal helper called from all three client builders (producer, consumer, admin) with fail-fast `InvalidOperationException` guards:
  - Missing `SaslMechanism` for SASL_* protocols
  - Null or empty `SaslUsername`/`SaslPassword` for PLAIN/SCRAM
  - Null `OAuthBearerTokenProvider` for OAuthBearer
- **3 call-site updates**: `KafkaQueueAdapter`, `KafkaQueueAdapterReceiver`, `KafkaQueueAdapterFactory` — each applies `ApplySecurity` then conditionally wires `SetOAuthBearerTokenRefreshHandler`
- **14 new unit tests** covering the full 11-case design matrix plus empty-string credential variants (`KafkaClientConfigExtensionsTests.cs`)
- **`streaming.md`** SASL/TLS subsection
- **Manual test plan** `tests/manual/66-kafka-sasl/test-plan.md`

### Key decisions

- Validation co-located in `ApplySecurity` (not per call-site) — single source of truth, no drift
- `OAuthBearerTokenProvider` as `Action<IClient, string>` matches Confluent's `SetOAuthBearerTokenRefreshHandler` signature directly — no adapter needed
- `InternalsVisibleTo` added for `Fleans.Streaming.Kafka.Tests` to enable direct unit-testing of the internal helper
- mTLS (client-cert) deferred to #681 per design

### How to test

Unit tests: `dotnet test Fleans.Streaming.Kafka.Tests/Fleans.Streaming.Kafka.Tests.csproj` (19 pass)

Manual: `tests/manual/66-kafka-sasl/test-plan.md` — requires a SASL-enabled Kafka container