### PR TITLE
audit: refresh infra rules 2026-06-22

### DIFF
--- a/docs/audits/audit-infra-rules.md
+++ b/docs/audits/audit-infra-rules.md
@@ -23,10 +23,10 @@
 ## scalability/user-task-full-table-materialize
 - **dimension:** scalability
 - **severity:** minor
-- **signal:** `WorkflowQueryService.GetPendingUserTasks` (the paged overload) in `src/Fleans/Fleans.Persistence/WorkflowQueryService.cs` calls `sievedQuery.ToListAsync()` before the `ApplyUserTaskFilters` call — the assignee/candidateGroup WHERE clause is applied in memory after the full non-completed user-task table is loaded. Look for `ToListAsync()` followed by `ApplyUserTaskFilters(` with no intervening DB-level WHERE on assignee or candidateGroup.
-- **remediation:** Add provider-specific EF Core expressions for `CandidateUsers`/`CandidateGroups` JSON array containment (`@>` / `?` on PostgreSQL via Npgsql's `EF.Functions`) so the filter executes server-side on the Postgres provider. The SQLite path can retain the in-memory fallback. Follow the `RelationalModelCustomizer` subclass pattern in `Fleans.Persistence.Sqlite` and `Fleans.Persistence.PostgreSql`. See issue #415.
+- **signal:** `WorkflowQueryService.GetPendingUserTasks` (the non-paged overload) in `src/Fleans/Fleans.Persistence/WorkflowQueryService.cs` calls `.ToListAsync()` on `db.UserTasks.Where(t => t.TaskState != Completed)` then passes the result to `ApplyUserTaskFilters` — no assignee/candidateGroup predicate pushed to the DB. The paged overload now uses `_userTaskFilter.GetFilteredBase` (SQL-push on PG, in-memory on SQLite) but the non-paged path does not. Look for `ToListAsync()` followed by `ApplyUserTaskFilters(` in the non-paged overload of `GetPendingUserTasks`.
+- **remediation:** Thread `_userTaskFilter.GetFilteredBase` into the non-paged overload the same way the paged overload does, removing the unconditional full-table load. The non-paged path is used by the API's unfiltered task list endpoint; as task volume grows it becomes a silo heap pressure point. See issue #415 (closed; residual gap in non-paged overload).
 - **first seen:** 2026-04-28
-- **last matched:** 2026-04-28
+- **last matched:** 2026-06-22
 
 ## pluggability/role-env-aspire-chart-parity
 - **dimension:** pluggability
@@ -35,3 +35,19 @@
 - **remediation:** Add `WithEnvironment("Fleans__Role", builder.Configuration["FLEANS_ROLE"] ?? "Combined")` when wiring the `fleans-core` project in Aspire. Document the `FLEANS_ROLE` local-dev override in CLAUDE.md under the Core/Worker role split section. See issue #416.
 - **first seen:** 2026-04-28
 - **last matched:** 2026-04-28
+
+## pluggability/reminders-provider-chart-gap
+- **dimension:** pluggability
+- **severity:** important
+- **signal:** `charts/fleans/templates/_helpers.tpl` `fleans.commonEnv` does not inject `Fleans__Reminders__Provider`, and `charts/fleans/values.yaml` has no `reminders:` block — search for the absence of `Fleans__Reminders__Provider` in `_helpers.tpl` and `reminders:` in `values.yaml`.
+- **remediation:** (1) Add `reminders: provider: Redis` to `values.yaml` with a note that `Postgres` requires `persistence.provider: Postgres`. (2) Add a `fail` guard and `Fleans__Reminders__Provider` env entry to `fleans.commonEnv` in `_helpers.tpl`, mirroring the streaming-provider pattern. Ensures operators can switch the BPMN timer durability backend without undocumented `extraEnv` workarounds. See issue #676.
+- **first seen:** 2026-06-22
+- **last matched:** 2026-06-22
+
+## pluggability/persistence-helm-render-time-validation
+- **dimension:** pluggability
+- **severity:** minor
+- **signal:** `charts/fleans/templates/_helpers.tpl` `fleans.commonEnv` sets `Persistence__Provider` from `.Values.persistence.provider` without a Helm `fail` guard, while `Fleans__Streaming__Provider` has an explicit `{{- if not (has $provider ...) }}{{- fail ... }}` guard — search for absence of `fail` adjacent to the `Persistence__Provider` env entry in `_helpers.tpl`.
+- **remediation:** Add `{{- $persistenceProvider := lower .Values.persistence.provider }}{{- if not (has $persistenceProvider (list "sqlite" "postgres")) }}{{- fail (printf "Unsupported persistence.provider %q ..." .Values.persistence.provider) }}{{- end }}` immediately before the `Persistence__Provider` line, matching the streaming guard pattern. Catches typos at `helm template` time instead of silo startup. See issue #675.
+- **first seen:** 2026-06-22
+- **last matched:** 2026-06-22


### PR DESCRIPTION
Generated by `audit-infra` on 2026-06-22.

## Summary

- **rules added:** 2
- **rules refreshed:** 1
- **issues opened:** 0 (two existing open issues adopted with audit markers)
- **issues updated:** 2 (#676, #675)

## Rules changes

### New: `pluggability/reminders-provider-chart-gap` (important)
`Fleans:Reminders:Provider` controls BPMN timer durability (Redis vs Postgres) but has no `values.yaml` key and no `commonEnv` entry in the Helm chart. Operators who want Postgres reminders must use opaque `extraEnv`. Adopted existing open issue #676 with the audit idempotency marker.

### New: `pluggability/persistence-helm-render-time-validation` (minor)
`_helpers.tpl` injects `Persistence__Provider` without a `{{- fail }}` guard, while the streaming provider already has one. A typo in `persistence.provider` reaches silo startup before being caught. Adopted existing open issue #675.

### Refreshed: `scalability/user-task-full-table-materialize`
Signal updated to reflect the current state: the **paged** overload was fixed (PostgreSQL path now uses `_userTaskFilter.GetFilteredBase` with SQL pushdown), but the **non-paged** overload still materialises the full user-task table. `last matched` bumped to 2026-06-22. Issue #415 is CLOSED — left alone per policy.

## Rules that no longer fire (resolved since last audit)

| Rule | Issue | Status |
|---|---|---|
| `pluggability/persistence-unknown-provider-silent-fallback` | #413 | Closed — explicit `else if`/`throw` added |
| `scalability/event-store-unbounded-read` | #414 | Closed — `MaxEventsPerLoad` guard + `Take()` added |
| `pluggability/role-env-aspire-chart-parity` | #416 | Closed — `Fleans__Role` injected in Aspire |

---
_Generated by [Claude Code](https://claude.ai/code/session_017YdiDHSGkZTNLeRNXqj9se)_